### PR TITLE
Add Croptopia dependency

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,8 @@
 		"fabricloader": ">=0.17.2",
 		"minecraft": "~1.20.1",
 		"java": ">=17",
-		"fabric-api": "*"
+		"fabric-api": "*",
+		"croptopia": "*"
 	},
 	"suggests": {
 		"another-mod": "*"


### PR DESCRIPTION
## Summary
- add Croptopia as a dependency in `fabric.mod.json`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8664f14ac8321bde55b5995a675de