### PR TITLE
Add Garden Coin currency with lifetime tracking

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/ModItems.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModItems.java
@@ -1,7 +1,9 @@
 package net.jeremy.gardenkingmod;
 
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroups;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
@@ -18,5 +20,6 @@ public final class ModItems {
 
         public static void registerModItems() {
                 GardenKingMod.LOGGER.info("Registering mod items for {}", GardenKingMod.MOD_ID);
+                ItemGroupEvents.modifyEntriesEvent(ItemGroups.INGREDIENTS).register(entries -> entries.add(GARDEN_COIN));
         }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/ModScoreboards.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModScoreboards.java
@@ -1,6 +1,8 @@
 package net.jeremy.gardenkingmod;
 
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.jeremy.gardenkingmod.currency.GardenCurrencyHolder;
 import net.minecraft.scoreboard.Scoreboard;
 import net.minecraft.scoreboard.ScoreboardCriterion;
 import net.minecraft.scoreboard.ScoreboardObjective;
@@ -17,13 +19,35 @@ public final class ModScoreboards {
 
         public static void registerScoreboards() {
                 ServerLifecycleEvents.SERVER_STARTED.register(server -> ensureObjective(server.getScoreboard()));
+                ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> syncPlayerScore(handler.player));
         }
 
-        public static void addCurrency(ServerPlayerEntity player, int amount) {
+        public static int addCurrency(ServerPlayerEntity player, int amount) {
                 if (amount <= 0) {
-                        return;
+                        return player instanceof GardenCurrencyHolder holder ? holder.gardenkingmod$getLifetimeCurrency() : -1;
                 }
 
+                MinecraftServer server = player.getServer();
+                if (server == null) {
+                        return -1;
+                }
+
+                Scoreboard scoreboard = server.getScoreboard();
+                ScoreboardObjective objective = ensureObjective(scoreboard);
+                ScoreboardPlayerScore score = scoreboard.getPlayerScore(player.getEntityName(), objective);
+
+                int updatedScore;
+                if (player instanceof GardenCurrencyHolder holder) {
+                        updatedScore = holder.gardenkingmod$addToLifetimeCurrency(amount);
+                } else {
+                        updatedScore = score.getScore() + amount;
+                }
+
+                score.setScore(updatedScore);
+                return updatedScore;
+        }
+
+        private static void syncPlayerScore(ServerPlayerEntity player) {
                 MinecraftServer server = player.getServer();
                 if (server == null) {
                         return;
@@ -31,18 +55,17 @@ public final class ModScoreboards {
 
                 Scoreboard scoreboard = server.getScoreboard();
                 ScoreboardObjective objective = ensureObjective(scoreboard);
-                if (objective == null) {
-                        return;
-                }
-
                 ScoreboardPlayerScore score = scoreboard.getPlayerScore(player.getEntityName(), objective);
-                score.setScore(score.getScore() + amount);            
+
+                if (player instanceof GardenCurrencyHolder holder) {
+                        score.setScore(holder.gardenkingmod$getLifetimeCurrency());
+                }
         }
 
         private static ScoreboardObjective ensureObjective(Scoreboard scoreboard) {
                 ScoreboardObjective objective = scoreboard.getObjective(CURRENCY_OBJECTIVE);
                 if (objective == null) {
-                        objective = scoreboard.addObjective(CURRENCY_OBJECTIVE, ScoreboardCriterion.DUMMY, Text.literal("Garden Coins"), ScoreboardCriterion.RenderType.INTEGER);
+                        objective = scoreboard.addObjective(CURRENCY_OBJECTIVE, ScoreboardCriterion.DUMMY, Text.translatable("scoreboard.gardenkingmod.garden_currency"), ScoreboardCriterion.RenderType.INTEGER);
                         GardenKingMod.LOGGER.info("Created scoreboard objective {}", CURRENCY_OBJECTIVE);
                 }
 

--- a/src/main/java/net/jeremy/gardenkingmod/block/MarketBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/MarketBlock.java
@@ -49,8 +49,11 @@ public class MarketBlock extends Block {
                 }
 
                 if (player instanceof ServerPlayerEntity serverPlayer) {
-                        ModScoreboards.addCurrency(serverPlayer, soldCount);
-                        serverPlayer.sendMessage(Text.literal("Sold " + soldCount + " Croptopia crops for " + soldCount + " coins."), true);
+                        int lifetimeTotal = ModScoreboards.addCurrency(serverPlayer, soldCount);
+                        Text message = lifetimeTotal >= 0
+                                        ? Text.translatable("message.gardenkingmod.market.sold.lifetime", soldCount, soldCount, lifetimeTotal)
+                                        : Text.translatable("message.gardenkingmod.market.sold", soldCount, soldCount);
+                        serverPlayer.sendMessage(message, true);
                 }
 
                 world.playSound(null, pos, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.BLOCKS, 0.75f, 1.0f);

--- a/src/main/java/net/jeremy/gardenkingmod/currency/GardenCurrencyHolder.java
+++ b/src/main/java/net/jeremy/gardenkingmod/currency/GardenCurrencyHolder.java
@@ -1,0 +1,26 @@
+package net.jeremy.gardenkingmod.currency;
+
+/**
+ * Simple capability-style interface injected into {@link net.minecraft.entity.player.PlayerEntity}
+ * to persist lifetime Garden Coin earnings across play sessions.
+ */
+public interface GardenCurrencyHolder {
+        String LIFETIME_CURRENCY_KEY = "GardenKingLifetimeCurrency";
+
+        int gardenkingmod$getLifetimeCurrency();
+
+        void gardenkingmod$setLifetimeCurrency(int amount);
+
+        default int gardenkingmod$addToLifetimeCurrency(int amount) {
+                if (amount == 0) {
+                        return gardenkingmod$getLifetimeCurrency();
+                }
+
+                int updated = gardenkingmod$getLifetimeCurrency() + amount;
+                if (updated < 0) {
+                        updated = 0;
+                }
+                gardenkingmod$setLifetimeCurrency(updated);
+                return updated;
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/mixin/PlayerEntityMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/PlayerEntityMixin.java
@@ -1,0 +1,43 @@
+package net.jeremy.gardenkingmod.mixin;
+
+import net.jeremy.gardenkingmod.currency.GardenCurrencyHolder;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PlayerEntity.class)
+public abstract class PlayerEntityMixin implements GardenCurrencyHolder {
+        @Unique
+        private int gardenkingmod$lifetimeCurrency;
+
+        @Override
+        public int gardenkingmod$getLifetimeCurrency() {
+                return this.gardenkingmod$lifetimeCurrency;
+        }
+
+        @Override
+        public void gardenkingmod$setLifetimeCurrency(int amount) {
+                this.gardenkingmod$lifetimeCurrency = Math.max(0, amount);
+        }
+
+        @Inject(method = "readCustomDataFromNbt", at = @At("RETURN"))
+        private void gardenkingmod$readLifetimeCurrency(NbtCompound nbt, CallbackInfo ci) {
+                if (nbt.contains(LIFETIME_CURRENCY_KEY, NbtElement.NUMBER_TYPE)) {
+                        gardenkingmod$setLifetimeCurrency(nbt.getInt(LIFETIME_CURRENCY_KEY));
+                }
+        }
+
+        @Inject(method = "writeCustomDataToNbt", at = @At("RETURN"))
+        private void gardenkingmod$writeLifetimeCurrency(NbtCompound nbt, CallbackInfo ci) {
+                if (gardenkingmod$getLifetimeCurrency() > 0) {
+                        nbt.putInt(LIFETIME_CURRENCY_KEY, gardenkingmod$getLifetimeCurrency());
+                } else {
+                        nbt.remove(LIFETIME_CURRENCY_KEY);
+                }
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/ServerPlayerEntityMixin.java
@@ -1,0 +1,18 @@
+package net.jeremy.gardenkingmod.mixin;
+
+import net.jeremy.gardenkingmod.currency.GardenCurrencyHolder;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerPlayerEntity.class)
+public abstract class ServerPlayerEntityMixin {
+        @Inject(method = "copyFrom", at = @At("TAIL"))
+        private void gardenkingmod$copyLifetimeCurrency(ServerPlayerEntity oldPlayer, boolean alive, CallbackInfo ci) {
+                GardenCurrencyHolder newHolder = (GardenCurrencyHolder) this;
+                GardenCurrencyHolder oldHolder = (GardenCurrencyHolder) oldPlayer;
+                newHolder.gardenkingmod$setLifetimeCurrency(oldHolder.gardenkingmod$getLifetimeCurrency());
+        }
+}

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -1,0 +1,6 @@
+{
+"item.gardenkingmod.garden_coin": "Garden Coin",
+"message.gardenkingmod.market.sold": "Sold %1$s Croptopia crops for %2$s coins.",
+"message.gardenkingmod.market.sold.lifetime": "Sold %1$s Croptopia crops for %2$s coins. Lifetime earnings: %3$s coins.",
+"scoreboard.gardenkingmod.garden_currency": "Garden Coins"
+}

--- a/src/main/resources/assets/gardenkingmod/models/item/garden_coin.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/garden_coin.json
@@ -1,0 +1,6 @@
+{
+"parent": "minecraft:item/generated",
+"textures": {
+"layer0": "gardenkingmod:item/garden_coin"
+}
+}

--- a/src/main/resources/gardenkingmod.mixins.json
+++ b/src/main/resources/gardenkingmod.mixins.json
@@ -2,9 +2,11 @@
 	"required": true,
 	"package": "net.jeremy.gardenkingmod.mixin",
 	"compatibilityLevel": "JAVA_17",
-	"mixins": [
-		"ExampleMixin"
-	],
+        "mixins": [
+                "ExampleMixin",
+                "PlayerEntityMixin",
+                "ServerPlayerEntityMixin"
+        ],
 	"injectors": {
 		"defaultRequire": 1
 	},


### PR DESCRIPTION
## Summary
- add a Garden Coin currency item and surface it in the creative inventory with supporting assets
- persist player earnings with a lifetime scoreboard that syncs from custom player data
- show lifetime totals when selling at the market block and translate the objective label
- remove the Garden Coin texture asset to keep the repository free of binaries

## Testing
- `./gradlew build` *(fails: Could not resolve LWJGL dependencies; received 403 Forbidden from Maven repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c867a3c78883219e7821ef7ab3fc0f