### PR TITLE
Add market block entity and UI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,13 +11,11 @@ base {
 }
 
 repositories {
-	// Add repositories to retrieve artifacts from in here.
-	// You should only use this when depending on other mods because
-	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
-	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
-	// for more information about repositories.
-
-    modImplementation "curse.maven:croptopia-415438:4997461"
+        // Add repositories to retrieve artifacts from in here.
+        // You should only use this when depending on other mods because
+        // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
+        // See https://docs.gradle.org/current/userguide/declaring_repositories.html
+        // for more information about repositories.
 }
 
 fabricApi {
@@ -32,9 +30,11 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	
+        // Fabric API. This is technically optional, but you probably want it anyway.
+        modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+        modImplementation "curse.maven:croptopia-415438:4997461"
+
 }
 
 processResources {

--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
@@ -13,6 +13,8 @@ public class GardenKingMod implements ModInitializer {
         public void onInitialize() {
                 ModItems.registerModItems();
                 ModBlocks.registerModBlocks();
+                ModBlockEntities.registerBlockEntities();
+                ModScreenHandlers.registerScreenHandlers();
                 ModScoreboards.registerScoreboards();
 
                 LOGGER.info("Garden King Mod initialized");

--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -1,10 +1,13 @@
 package net.jeremy.gardenkingmod;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.minecraft.client.gui.screen.ingame.HandledScreens;
+
+import net.jeremy.gardenkingmod.screen.MarketScreen;
 
 public class GardenKingModClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
-
+        HandledScreens.register(ModScreenHandlers.MARKET_SCREEN_HANDLER, MarketScreen::new);
     }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/ModBlockEntities.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModBlockEntities.java
@@ -1,0 +1,21 @@
+package net.jeremy.gardenkingmod;
+
+import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
+import net.jeremy.gardenkingmod.block.entity.MarketBlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+
+public final class ModBlockEntities {
+        public static final BlockEntityType<MarketBlockEntity> MARKET_BLOCK_ENTITY = Registry.register(
+                        Registries.BLOCK_ENTITY_TYPE, new Identifier(GardenKingMod.MOD_ID, "market_block"),
+                        FabricBlockEntityTypeBuilder.create(MarketBlockEntity::new, ModBlocks.MARKET_BLOCK).build());
+
+        private ModBlockEntities() {
+        }
+
+        public static void registerBlockEntities() {
+                GardenKingMod.LOGGER.info("Registering block entities for {}", GardenKingMod.MOD_ID);
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/ModScreenHandlers.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModScreenHandlers.java
@@ -1,0 +1,21 @@
+package net.jeremy.gardenkingmod;
+
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
+import net.jeremy.gardenkingmod.screen.MarketScreenHandler;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.util.Identifier;
+
+public final class ModScreenHandlers {
+        public static final ScreenHandlerType<MarketScreenHandler> MARKET_SCREEN_HANDLER = Registry.register(
+                        Registries.SCREEN_HANDLER, new Identifier(GardenKingMod.MOD_ID, "market"),
+                        new ExtendedScreenHandlerType<>(MarketScreenHandler::new));
+
+        private ModScreenHandlers() {
+        }
+
+        public static void registerScreenHandlers() {
+                GardenKingMod.LOGGER.info("Registering screen handlers for {}", GardenKingMod.MOD_ID);
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
@@ -1,0 +1,189 @@
+package net.jeremy.gardenkingmod.block.entity;
+
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
+import net.jeremy.gardenkingmod.ModBlockEntities;
+import net.jeremy.gardenkingmod.ModItems;
+import net.jeremy.gardenkingmod.ModScoreboards;
+import net.jeremy.gardenkingmod.screen.MarketScreenHandler;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.Inventories;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.registry.Registries;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.collection.DefaultedList;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class MarketBlockEntity extends BlockEntity implements ExtendedScreenHandlerFactory, Inventory {
+        public static final int INVENTORY_SIZE = 1;
+        public static final int INPUT_SLOT = 0;
+
+        private final DefaultedList<ItemStack> items = DefaultedList.ofSize(INVENTORY_SIZE, ItemStack.EMPTY);
+
+        public MarketBlockEntity(BlockPos pos, BlockState state) {
+                super(ModBlockEntities.MARKET_BLOCK_ENTITY, pos, state);
+        }
+
+        public static boolean isSellable(ItemStack stack) {
+                if (stack.isEmpty()) {
+                        return false;
+                }
+
+                Identifier identifier = Registries.ITEM.getId(stack.getItem());
+                return identifier != null && "croptopia".equals(identifier.getNamespace());
+        }
+
+        @Override
+        public void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf) {
+                buf.writeBlockPos(getPos());
+        }
+
+        @Override
+        public Text getDisplayName() {
+                return Text.translatable("container.gardenkingmod.market");
+        }
+
+        @Override
+        public ScreenHandler createMenu(int syncId, PlayerInventory playerInventory, PlayerEntity player) {
+                return new MarketScreenHandler(syncId, playerInventory, this);
+        }
+
+        @Override
+        public int size() {
+                return items.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+                for (ItemStack stack : items) {
+                        if (!stack.isEmpty()) {
+                                return false;
+                        }
+                }
+                return true;
+        }
+
+        @Override
+        public ItemStack getStack(int slot) {
+                return items.get(slot);
+        }
+
+        @Override
+        public ItemStack removeStack(int slot, int amount) {
+                ItemStack stack = Inventories.splitStack(items, slot, amount);
+                if (!stack.isEmpty()) {
+                        markDirty();
+                }
+                return stack;
+        }
+
+        @Override
+        public ItemStack removeStack(int slot) {
+                ItemStack stack = Inventories.removeStack(items, slot);
+                if (!stack.isEmpty()) {
+                        markDirty();
+                }
+                return stack;
+        }
+
+        @Override
+        public void setStack(int slot, ItemStack stack) {
+                items.set(slot, stack);
+                if (stack.getCount() > getMaxCountPerStack()) {
+                        stack.setCount(getMaxCountPerStack());
+                }
+                markDirty();
+        }
+
+        @Override
+        public boolean canPlayerUse(PlayerEntity player) {
+                if (world == null || world.getBlockEntity(pos) != this) {
+                        return false;
+                }
+
+                return player.squaredDistanceTo((double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D,
+                                (double) pos.getZ() + 0.5D) <= 64.0D;
+        }
+
+        @Override
+        public boolean isValid(int slot, ItemStack stack) {
+                return slot == INPUT_SLOT && (stack.isEmpty() || isSellable(stack));
+        }
+
+        @Override
+        public void clear() {
+                items.clear();
+        }
+
+        @Override
+        public void markDirty() {
+                super.markDirty();
+                World world = getWorld();
+                if (world != null) {
+                        world.updateListeners(pos, getCachedState(), getCachedState(), Block.NOTIFY_ALL);
+                        world.updateComparators(pos, getCachedState().getBlock());
+                }
+        }
+
+        @Override
+        protected void writeNbt(NbtCompound nbt) {
+                super.writeNbt(nbt);
+                Inventories.writeNbt(nbt, items);
+        }
+
+        @Override
+        public void readNbt(NbtCompound nbt) {
+                super.readNbt(nbt);
+                Inventories.readNbt(nbt, items);
+        }
+
+        public boolean sell(ServerPlayerEntity player) {
+                ItemStack stack = getStack(INPUT_SLOT);
+                if (stack.isEmpty()) {
+                        player.sendMessage(Text.translatable("message.gardenkingmod.market.empty"), true);
+                        return false;
+                }
+
+                if (!isSellable(stack)) {
+                        player.sendMessage(Text.translatable("message.gardenkingmod.market.invalid"), true);
+                        return false;
+                }
+
+                int soldCount = stack.getCount();
+                items.set(INPUT_SLOT, ItemStack.EMPTY);
+                markDirty();
+
+                ItemStack currencyStack = new ItemStack(ModItems.GARDEN_COIN, soldCount);
+                boolean fullyInserted = player.getInventory().insertStack(currencyStack);
+                if (!fullyInserted && !currencyStack.isEmpty()) {
+                        player.dropItem(currencyStack, false);
+                }
+
+                int lifetimeTotal = ModScoreboards.addCurrency(player, soldCount);
+                Text message = lifetimeTotal >= 0
+                                ? Text.translatable("message.gardenkingmod.market.sold.lifetime", soldCount, soldCount,
+                                                lifetimeTotal)
+                                : Text.translatable("message.gardenkingmod.market.sold", soldCount, soldCount);
+                player.sendMessage(message, true);
+
+                World world = getWorld();
+                if (world != null) {
+                        world.playSound(null, pos, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.BLOCKS, 0.75f,
+                                        1.0f);
+                }
+
+                return true;
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -1,0 +1,48 @@
+package net.jeremy.gardenkingmod.screen;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+public class MarketScreen extends HandledScreen<MarketScreenHandler> {
+        private static final Identifier TEXTURE = new Identifier(GardenKingMod.MOD_ID, "textures/gui/container/market.png");
+
+        private ButtonWidget sellButton;
+
+        public MarketScreen(MarketScreenHandler handler, PlayerInventory inventory, Text title) {
+                super(handler, inventory, title);
+                this.backgroundWidth = 176;
+                this.backgroundHeight = 166;
+                this.playerInventoryTitleY = this.backgroundHeight - 94;
+        }
+
+        @Override
+        protected void init() {
+                super.init();
+                sellButton = addDrawableChild(ButtonWidget.builder(Text.translatable("screen.gardenkingmod.market.sell"),
+                                button -> {
+                                        if (client != null && client.interactionManager != null) {
+                                                client.interactionManager.clickButton(handler.syncId, 0);
+                                        }
+                                }).dimensions(x + 62, y + 60, 52, 20).build());
+        }
+
+        @Override
+        protected void drawBackground(DrawContext context, float delta, int mouseX, int mouseY) {
+                context.drawTexture(TEXTURE, x, y, 0, 0, backgroundWidth, backgroundHeight);
+        }
+
+        @Override
+        public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+                renderBackground(context);
+                if (sellButton != null) {
+                        sellButton.active = handler.hasSellableItem();
+                }
+                super.render(context, mouseX, mouseY, delta);
+                drawMouseoverTooltip(context, mouseX, mouseY);
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
@@ -1,0 +1,127 @@
+package net.jeremy.gardenkingmod.screen;
+
+import net.jeremy.gardenkingmod.ModScreenHandlers;
+import net.jeremy.gardenkingmod.block.entity.MarketBlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.math.BlockPos;
+
+public class MarketScreenHandler extends ScreenHandler {
+        private final Inventory inventory;
+        private final MarketBlockEntity blockEntity;
+
+        public MarketScreenHandler(int syncId, PlayerInventory playerInventory, PacketByteBuf buf) {
+                this(syncId, playerInventory, getBlockEntity(playerInventory, buf.readBlockPos()));
+        }
+
+        public MarketScreenHandler(int syncId, PlayerInventory playerInventory, MarketBlockEntity blockEntity) {
+                super(ModScreenHandlers.MARKET_SCREEN_HANDLER, syncId);
+                this.blockEntity = blockEntity;
+                this.inventory = blockEntity != null ? blockEntity : new SimpleInventory(MarketBlockEntity.INVENTORY_SIZE);
+
+                checkSize(this.inventory, MarketBlockEntity.INVENTORY_SIZE);
+                this.inventory.onOpen(playerInventory.player);
+
+                this.addSlot(new Slot(this.inventory, MarketBlockEntity.INPUT_SLOT, 80, 35) {
+                        @Override
+                        public boolean canInsert(ItemStack stack) {
+                                return MarketBlockEntity.isSellable(stack);
+                        }
+                });
+
+                addPlayerInventory(playerInventory);
+                addPlayerHotbar(playerInventory);
+        }
+
+        private static MarketBlockEntity getBlockEntity(PlayerInventory playerInventory, BlockPos pos) {
+                if (playerInventory.player.getWorld().getBlockEntity(pos) instanceof MarketBlockEntity marketBlockEntity) {
+                        return marketBlockEntity;
+                }
+
+                return null;
+        }
+
+        @Override
+        public boolean canUse(PlayerEntity player) {
+                if (this.blockEntity != null) {
+                        return this.blockEntity.canPlayerUse(player);
+                }
+
+                return this.inventory.canPlayerUse(player);
+        }
+
+        @Override
+        public void onClosed(PlayerEntity player) {
+                super.onClosed(player);
+                if (this.blockEntity != null) {
+                        this.blockEntity.onClose(player);
+                } else {
+                        this.inventory.onClose(player);
+                }
+        }
+
+        @Override
+        public ItemStack quickMove(PlayerEntity player, int index) {
+                ItemStack newStack = ItemStack.EMPTY;
+                Slot slot = this.slots.get(index);
+                if (slot != null && slot.hasStack()) {
+                        ItemStack originalStack = slot.getStack();
+                        newStack = originalStack.copy();
+                        if (index == MarketBlockEntity.INPUT_SLOT) {
+                                if (!this.insertItem(originalStack, MarketBlockEntity.INVENTORY_SIZE, this.slots.size(), true)) {
+                                        return ItemStack.EMPTY;
+                                }
+                        } else if (!MarketBlockEntity.isSellable(originalStack)
+                                        || !this.insertItem(originalStack, MarketBlockEntity.INPUT_SLOT,
+                                                        MarketBlockEntity.INPUT_SLOT + 1, false)) {
+                                return ItemStack.EMPTY;
+                        }
+
+                        if (originalStack.isEmpty()) {
+                                slot.setStack(ItemStack.EMPTY);
+                        } else {
+                                slot.markDirty();
+                        }
+                }
+
+                return newStack;
+        }
+
+        @Override
+        public boolean onButtonClick(PlayerEntity player, int id) {
+                if (id == 0 && blockEntity != null && player instanceof ServerPlayerEntity serverPlayer) {
+                        if (blockEntity.sell(serverPlayer)) {
+                                sendContentUpdates();
+                        }
+                        return true;
+                }
+
+                return super.onButtonClick(player, id);
+        }
+
+        public boolean hasSellableItem() {
+                return MarketBlockEntity.isSellable(this.inventory.getStack(MarketBlockEntity.INPUT_SLOT));
+        }
+
+        private void addPlayerInventory(PlayerInventory playerInventory) {
+                for (int row = 0; row < 3; ++row) {
+                        for (int column = 0; column < 9; ++column) {
+                                this.addSlot(new Slot(playerInventory, column + row * 9 + 9, 8 + column * 18,
+                                                84 + row * 18));
+                        }
+                }
+        }
+
+        private void addPlayerHotbar(PlayerInventory playerInventory) {
+                for (int slot = 0; slot < 9; ++slot) {
+                        this.addSlot(new Slot(playerInventory, slot, 8 + slot * 18, 142));
+                }
+        }
+}

--- a/src/main/resources/assets/gardenkingmod/blockstates/market_block.json
+++ b/src/main/resources/assets/gardenkingmod/blockstates/market_block.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": { "model": "gardenkingmod:block/market_block" }
+  }
+}

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -1,6 +1,11 @@
 {
+"block.gardenkingmod.market_block": "Garden Market",
 "item.gardenkingmod.garden_coin": "Garden Coin",
+"container.gardenkingmod.market": "Garden Market",
+"screen.gardenkingmod.market.sell": "Sell",
 "message.gardenkingmod.market.sold": "Sold %1$s Croptopia crops for %2$s coins.",
 "message.gardenkingmod.market.sold.lifetime": "Sold %1$s Croptopia crops for %2$s coins. Lifetime earnings: %3$s coins.",
+"message.gardenkingmod.market.empty": "There are no crops to sell.",
+"message.gardenkingmod.market.invalid": "Only Croptopia crops can be sold here!",
 "scoreboard.gardenkingmod.garden_currency": "Garden Coins"
 }

--- a/src/main/resources/assets/gardenkingmod/models/block/market_block.json
+++ b/src/main/resources/assets/gardenkingmod/models/block/market_block.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "gardenkingmod:block/market_block"
+  }
+}

--- a/src/main/resources/assets/gardenkingmod/models/item/garden_coin.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/garden_coin.json
@@ -1,6 +1,6 @@
 {
-"parent": "minecraft:item/generated",
-"textures": {
-"layer0": "gardenkingmod:item/garden_coin"
-}
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "gardenkingmod:item/garden_coin"
+  }
 }

--- a/src/main/resources/assets/gardenkingmod/models/item/market_block.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/market_block.json
@@ -1,0 +1,3 @@
+{
+  "parent": "gardenkingmod:block/market_block"
+}


### PR DESCRIPTION
## Summary
- implement a Market block entity with inventory-driven selling logic plus a matching screen handler and client screen
- register the new block entity and screen handler, update the block to open the UI, and expose translations and block/item models
- move the Croptopia dependency into the dependencies block so Gradle can resolve it correctly
- remove market and coin texture PNGs so contributors can supply them locally without binary files

## Testing
- `./gradlew build` *(fails: unable to download curse.maven:croptopia-415438:4997461 because the remote returned HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c872e8589483219a00b5ee9dc26821