### PR TITLE
Add Croptopia Maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ repositories {
         // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
         // See https://docs.gradle.org/current/userguide/declaring_repositories.html
         // for more information about repositories.
+        maven { url "https://maven.croptopia.com" }
 }
 
 fabricApi {


### PR DESCRIPTION
## Summary
- add the Croptopia Maven repository to the root buildscript so the Croptopia mod can resolve from its official maven

## Testing
- ./gradlew build *(fails: 403 Forbidden while downloading curse.maven:croptopia-415438:4997461 from maven.croptopia.com)*

------
https://chatgpt.com/codex/tasks/task_e_68c884021be48321be9bea2ae885df6b