### PR TITLE
Add Cursemaven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ repositories {
         // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
         // See https://docs.gradle.org/current/userguide/declaring_repositories.html
         // for more information about repositories.
+        maven { url "https://cursemaven.com" }
         maven { url "https://maven.croptopia.com" }
 }
 


### PR DESCRIPTION
## Summary
- add Cursemaven repository to the Gradle buildscript so Curse Maven dependencies resolve
- retain the existing Croptopia repository entry

## Testing
- ./gradlew build *(fails: remote repository returns HTTP 403 for curse.maven:croptopia-415438:4997461)*

------
https://chatgpt.com/codex/tasks/task_e_68c88980f73083218ca834de7f07f9a1