### PR TITLE
Fix MarketBlock ItemScatterer import

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/MarketBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/MarketBlock.java
@@ -7,7 +7,7 @@ import net.minecraft.block.BlockWithEntity;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
-import net.minecraft.item.ItemScatterer;
+import net.minecraft.util.ItemScatterer;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;


### PR DESCRIPTION
## Summary
- update `MarketBlock` to import `ItemScatterer` from the `net.minecraft.util` package

## Testing
- `./gradlew build` *(fails: could not download required Minecraft jars after 3 attempts)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e617b994832184e42416f275bc97