### PR TITLE
Register market block entity renderer

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -1,13 +1,15 @@
 package net.jeremy.gardenkingmod;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.minecraft.client.gui.screen.ingame.HandledScreens;
-
+import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
 import net.jeremy.gardenkingmod.screen.MarketScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreens;
+import net.minecraft.client.render.block.entity.BlockEntityRendererFactories;
 
 public class GardenKingModClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         HandledScreens.register(ModScreenHandlers.MARKET_SCREEN_HANDLER, MarketScreen::new);
+        BlockEntityRendererFactories.register(ModBlockEntities.MARKET_BLOCK_ENTITY, MarketBlockEntityRenderer::new);
     }
 }


### PR DESCRIPTION
## Summary
- import the market block entity renderer into the client initializer
- register the market block entity renderer alongside the market screen handler

## Testing
- ./gradlew build *(fails: dependency downloads blocked with HTTP 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2d593f6c8321b729098e0e206a2c