### PR TITLE
Add market block to functional item group

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/ModBlocks.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModBlocks.java
@@ -1,12 +1,14 @@
 package net.jeremy.gardenkingmod;
 
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.jeremy.gardenkingmod.block.MarketBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroups;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
@@ -28,5 +30,6 @@ public final class ModBlocks {
 
         public static void registerModBlocks() {
                 GardenKingMod.LOGGER.info("Registering mod blocks for {}", GardenKingMod.MOD_ID);
+                ItemGroupEvents.modifyEntriesEvent(ItemGroups.FUNCTIONAL).register(entries -> entries.add(MARKET_BLOCK));
         }
 }


### PR DESCRIPTION
## Summary
- add the market block to the Functional Blocks creative tab via ItemGroupEvents

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cb6ab36334832194c15f3718abce4c