### PR TITLE
Use world lighting for market block entity

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/render/MarketBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/MarketBlockEntityRenderer.java
@@ -3,14 +3,18 @@ package net.jeremy.gardenkingmod.client.render;
 import net.jeremy.gardenkingmod.GardenKingMod;
 import net.jeremy.gardenkingmod.block.entity.MarketBlockEntity;
 import net.jeremy.gardenkingmod.client.model.MarketBlockModel;
+import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.RotationAxis;
+import net.minecraft.world.World;
 
 public class MarketBlockEntityRenderer implements BlockEntityRenderer<MarketBlockEntity> {
         private static final Identifier TEXTURE = new Identifier(GardenKingMod.MOD_ID,
@@ -29,8 +33,15 @@ public class MarketBlockEntityRenderer implements BlockEntityRenderer<MarketBloc
                 matrices.translate(0.5f, 1.5f, 0.5f);
                 matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
 
+                World world = entity.getWorld();
+                int combinedLight = LightmapTextureManager.MAX_LIGHT_COORDINATE;
+                if (world != null) {
+                        combinedLight = WorldRenderer.getLightmapCoordinates(world, entity.getPos());
+                }
+
                 VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));
-                this.model.render(matrices, vertexConsumer, light, overlay, 1.0f, 1.0f, 1.0f, 1.0f);
+                this.model.render(matrices, vertexConsumer, combinedLight, OverlayTexture.DEFAULT_UV, 1.0f, 1.0f, 1.0f,
+                                1.0f);
 
                 matrices.pop();
         }


### PR DESCRIPTION
## Summary
- compute the market block entity's light from the world when available
- fall back to the maximum light value and continue using the default overlay

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cb6c7acd188321a011ef75d69d01dc