### PR TITLE
Adjust market renderer lighting sampling

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/render/MarketBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/MarketBlockEntityRenderer.java
@@ -13,6 +13,7 @@ import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RotationAxis;
 import net.minecraft.world.World;
 
@@ -36,7 +37,8 @@ public class MarketBlockEntityRenderer implements BlockEntityRenderer<MarketBloc
                 World world = entity.getWorld();
                 int combinedLight = LightmapTextureManager.MAX_LIGHT_COORDINATE;
                 if (world != null) {
-                        combinedLight = WorldRenderer.getLightmapCoordinates(world, entity.getPos());
+                        BlockPos exposedPos = entity.getPos().up();
+                        combinedLight = WorldRenderer.getLightmapCoordinates(world, exposedPos);
                 }
 
                 VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));


### PR DESCRIPTION
## Summary
- sample the market block entity lighting from the exposed block above instead of the occluded block center
- retain the LightmapTextureManager.MAX_LIGHT_COORDINATE fallback when the world reference is unavailable

## Testing
- ./gradlew build
- ./gradlew runClient *(fails: unable to download game assets in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb77ab26248321acbdd895782a6360