### PR TITLE
Restore market block model layer constant

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/MarketBlockModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/MarketBlockModel.java
@@ -16,6 +16,11 @@ import net.minecraft.entity.Entity;
 import net.minecraft.util.Identifier;
 
 public class MarketBlockModel extends EntityModel<Entity> {
+    public static final EntityModelLayer LAYER_LOCATION = new EntityModelLayer(
+            new Identifier(GardenKingMod.MOD_ID, "market_block"),
+            "main"
+    );
+
     private final ModelPart bone;
     private final ModelPart bb_main;
     public MarketBlockModel(ModelPart root) {


### PR DESCRIPTION
## Summary
- reintroduce the public LAYER_LOCATION constant on MarketBlockModel so other classes can access the model layer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb98834aa48321a8222b30e14ab80b