### PR TITLE
Fix market stall lighting

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/ModBlocks.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModBlocks.java
@@ -4,6 +4,7 @@ import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.jeremy.gardenkingmod.block.MarketBlock;
+import net.jeremy.gardenkingmod.block.MarketBlockPart;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.item.BlockItem;
@@ -14,7 +15,11 @@ import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
 
 public final class ModBlocks {
-        public static final Block MARKET_BLOCK = registerBlock("market_block", new MarketBlock(FabricBlockSettings.copyOf(Blocks.OAK_PLANKS).strength(2.5f)));
+        public static final Block MARKET_BLOCK = registerBlock("market_block",
+                        new MarketBlock(
+                                        FabricBlockSettings.copyOf(Blocks.OAK_PLANKS).strength(2.5f).nonOpaque()));
+        public static final Block MARKET_BLOCK_PART = registerBlockWithoutItem("market_block_part",
+                        new MarketBlockPart(FabricBlockSettings.copyOf(Blocks.OAK_PLANKS).dropsNothing().nonOpaque()));
 
         private ModBlocks() {
         }
@@ -26,6 +31,10 @@ public final class ModBlocks {
 
         private static Item registerBlockItem(String name, Block block) {
                 return Registry.register(Registries.ITEM, new Identifier(GardenKingMod.MOD_ID, name), new BlockItem(block, new FabricItemSettings()));
+        }
+
+        private static Block registerBlockWithoutItem(String name, Block block) {
+                return Registry.register(Registries.BLOCK, new Identifier(GardenKingMod.MOD_ID, name), block);
         }
 
         public static void registerModBlocks() {

--- a/src/main/java/net/jeremy/gardenkingmod/block/MarketBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/MarketBlock.java
@@ -1,34 +1,111 @@
 package net.jeremy.gardenkingmod.block;
 
+import net.jeremy.gardenkingmod.ModBlocks;
 import net.jeremy.gardenkingmod.block.entity.MarketBlockEntity;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.BlockWithEntity;
+import net.minecraft.block.ShapeContext;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
-import net.minecraft.util.ItemScatterer;
-import net.minecraft.screen.ScreenHandler;
+import net.minecraft.item.ItemPlacementContext;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ItemScatterer;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
-
-
+import net.minecraft.world.WorldView;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.DirectionProperty;
+import net.minecraft.state.property.Properties;
+import net.minecraft.screen.ScreenHandler;
 
 public class MarketBlock extends BlockWithEntity {
+        public static final DirectionProperty FACING = Properties.HORIZONTAL_FACING;
+
         public MarketBlock(Settings settings) {
                 super(settings);
+                this.setDefaultState(getStateManager().getDefaultState().with(FACING, Direction.NORTH));
+        }
+
+        @Override
+        protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+                builder.add(FACING);
+        }
+
+        @Override
+        public BlockState getPlacementState(ItemPlacementContext ctx) {
+                Direction facing = ctx.getHorizontalPlayerFacing().getOpposite();
+                BlockPos origin = ctx.getBlockPos();
+                WorldView worldView = ctx.getWorld();
+
+                for (MarketBlockPart.Part part : MarketBlockPart.Part.values()) {
+                        if (part == MarketBlockPart.Part.CENTER) {
+                                continue;
+                        }
+
+                        BlockPos targetPos = origin.add(part.getOffset(facing));
+                        if (!worldView.isAir(targetPos)) {
+                                return null;
+                        }
+                }
+
+                return getDefaultState().with(FACING, facing);
+        }
+
+        @Override
+        public void onPlaced(World world, BlockPos pos, BlockState state, LivingEntity placer, ItemStack itemStack) {
+                super.onPlaced(world, pos, state, placer, itemStack);
+
+                if (world.isClient) {
+                        return;
+                }
+
+                Direction facing = state.get(FACING);
+                for (MarketBlockPart.Part part : MarketBlockPart.Part.values()) {
+                        if (part == MarketBlockPart.Part.CENTER) {
+                                continue;
+                        }
+
+                        BlockPos targetPos = pos.add(part.getOffset(facing));
+                        BlockState partState = ModBlocks.MARKET_BLOCK_PART.getDefaultState()
+                                        .with(MarketBlockPart.FACING, facing)
+                                        .with(MarketBlockPart.PART, part);
+                        world.setBlockState(targetPos, partState, Block.NOTIFY_ALL | Block.FORCE_STATE);
+                }
+        }
+
+        @Override
+        public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+                return MarketBlockPart.getShape(MarketBlockPart.Part.CENTER, state.get(FACING));
+        }
+
+        @Override
+        public VoxelShape getCollisionShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+                return MarketBlockPart.getShape(MarketBlockPart.Part.CENTER, state.get(FACING));
+        }
+
+        @Override
+        public float getAmbientOcclusionLightLevel(BlockState state, BlockView world, BlockPos pos) {
+                return 1.0F;
         }
 
         @Override
         public BlockRenderType getRenderType(BlockState state) {
-            return BlockRenderType.ENTITYBLOCK_ANIMATED;
+                return BlockRenderType.ENTITYBLOCK_ANIMATED;
         }
 
         @Override
-        public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
+        public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand,
+                        BlockHitResult hit) {
                 if (!world.isClient) {
                         BlockEntity blockEntity = world.getBlockEntity(pos);
                         if (blockEntity instanceof MarketBlockEntity marketBlockEntity) {
@@ -42,6 +119,10 @@ public class MarketBlock extends BlockWithEntity {
         @Override
         public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
                 if (state.getBlock() != newState.getBlock()) {
+                        if (!world.isClient) {
+                                removePartBlocks(world, pos, state.get(FACING));
+                        }
+
                         BlockEntity blockEntity = world.getBlockEntity(pos);
                         if (blockEntity instanceof Inventory inventory) {
                                 ItemScatterer.spawn(world, pos, inventory);
@@ -49,6 +130,20 @@ public class MarketBlock extends BlockWithEntity {
                         }
 
                         super.onStateReplaced(state, world, pos, newState, moved);
+                }
+        }
+
+        private void removePartBlocks(World world, BlockPos origin, Direction facing) {
+                for (MarketBlockPart.Part part : MarketBlockPart.Part.values()) {
+                        if (part == MarketBlockPart.Part.CENTER) {
+                                continue;
+                        }
+
+                        BlockPos targetPos = origin.add(part.getOffset(facing));
+                        BlockState targetState = world.getBlockState(targetPos);
+                        if (targetState.getBlock() instanceof MarketBlockPart) {
+                                world.removeBlock(targetPos, false);
+                        }
                 }
         }
 

--- a/src/main/java/net/jeremy/gardenkingmod/block/MarketBlockPart.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/MarketBlockPart.java
@@ -1,0 +1,162 @@
+package net.jeremy.gardenkingmod.block;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRenderType;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.loot.context.LootContextParameterSet;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.DirectionProperty;
+import net.minecraft.state.property.EnumProperty;
+import net.minecraft.state.property.Properties;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.StringIdentifiable;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.BlockRotation;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+
+public class MarketBlockPart extends Block {
+        public static final DirectionProperty FACING = Properties.HORIZONTAL_FACING;
+        public static final EnumProperty<Part> PART = EnumProperty.of("part", Part.class);
+
+        private static final Map<Part, VoxelShape> BASE_SHAPES = createBaseShapes();
+
+        public MarketBlockPart(Settings settings) {
+                super(settings);
+                this.setDefaultState(getStateManager().getDefaultState().with(FACING, Direction.NORTH).with(PART,
+                                Part.CENTER));
+        }
+
+        private static Map<Part, VoxelShape> createBaseShapes() {
+                EnumMap<Part, VoxelShape> shapes = new EnumMap<>(Part.class);
+                for (Part part : Part.values()) {
+                        shapes.put(part, VoxelShapes.fullCube());
+                }
+                return shapes;
+        }
+
+        public static VoxelShape getShape(Part part, Direction facing) {
+                return BASE_SHAPES.getOrDefault(part, VoxelShapes.fullCube());
+        }
+
+        @Override
+        protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+                builder.add(FACING, PART);
+        }
+
+        @Override
+        public BlockRenderType getRenderType(BlockState state) {
+                return BlockRenderType.INVISIBLE;
+        }
+
+        public static BlockPos getOrigin(BlockPos partPos, BlockState state) {
+                BlockPos offset = state.get(PART).getOffset(state.get(FACING));
+                return partPos.subtract(offset);
+        }
+
+        @Override
+        public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand,
+                        BlockHitResult hit) {
+                BlockPos origin = getOrigin(pos, state);
+                BlockState originState = world.getBlockState(origin);
+                if (!(originState.getBlock() instanceof MarketBlock)) {
+                        return ActionResult.PASS;
+                }
+
+                BlockHitResult translatedHit = new BlockHitResult(hit.getPos(), hit.getSide(), origin,
+                                hit.isInsideBlock());
+                return originState.onUse(world, player, hand, translatedHit);
+        }
+
+        @Override
+        public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
+                if (state.getBlock() != newState.getBlock()) {
+                        if (!world.isClient) {
+                                BlockPos origin = getOrigin(pos, state);
+                                BlockState originState = world.getBlockState(origin);
+                                if (originState.getBlock() instanceof MarketBlock) {
+                                        world.breakBlock(origin, true);
+                                }
+                        }
+
+                        super.onStateReplaced(state, world, pos, newState, moved);
+                }
+        }
+
+        @Override
+        public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+                return getShape(state.get(PART), state.get(FACING));
+        }
+
+        @Override
+        public VoxelShape getCollisionShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+                return getShape(state.get(PART), state.get(FACING));
+        }
+
+        @Override
+        public float getAmbientOcclusionLightLevel(BlockState state, BlockView world, BlockPos pos) {
+                return 1.0F;
+        }
+
+        @Override
+        public ItemStack getPickStack(BlockView world, BlockPos pos, BlockState state) {
+                return ItemStack.EMPTY;
+        }
+
+        @Override
+        public List<ItemStack> getDroppedStacks(BlockState state, LootContextParameterSet.Builder builder) {
+                return Collections.emptyList();
+        }
+
+        public enum Part implements StringIdentifiable {
+                NORTH_WEST("north_west", new BlockPos(-1, 0, -1)),
+                NORTH("north", new BlockPos(0, 0, -1)),
+                NORTH_EAST("north_east", new BlockPos(1, 0, -1)),
+                WEST("west", new BlockPos(-1, 0, 0)),
+                CENTER("center", BlockPos.ORIGIN),
+                EAST("east", new BlockPos(1, 0, 0)),
+                SOUTH_WEST("south_west", new BlockPos(-1, 0, 1)),
+                SOUTH("south", new BlockPos(0, 0, 1)),
+                SOUTH_EAST("south_east", new BlockPos(1, 0, 1));
+
+                private final String name;
+                private final BlockPos offset;
+
+                Part(String name, BlockPos offset) {
+                        this.name = name;
+                        this.offset = offset;
+                }
+
+                public BlockPos getOffset(Direction facing) {
+                        return offset.rotate(rotationFromFacing(facing));
+                }
+
+                @Override
+                public String asString() {
+                        return name;
+                }
+        }
+
+        private static BlockRotation rotationFromFacing(Direction facing) {
+                return switch (facing) {
+                        case NORTH -> BlockRotation.NONE;
+                        case SOUTH -> BlockRotation.CLOCKWISE_180;
+                        case WEST -> BlockRotation.COUNTERCLOCKWISE_90;
+                        case EAST -> BlockRotation.CLOCKWISE_90;
+                        default -> BlockRotation.NONE;
+                };
+        }
+}

--- a/src/main/resources/assets/gardenkingmod/blockstates/market_block_part.json
+++ b/src/main/resources/assets/gardenkingmod/blockstates/market_block_part.json
@@ -1,0 +1,9 @@
+{
+  "multipart": [
+    {
+      "apply": {
+        "model": "minecraft:block/air"
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/loot_tables/blocks/market_block.json
+++ b/src/main/resources/data/gardenkingmod/loot_tables/blocks/market_block.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "gardenkingmod:market_block"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/loot_tables/blocks/market_block_part.json
+++ b/src/main/resources/data/gardenkingmod/loot_tables/blocks/market_block_part.json
@@ -1,0 +1,4 @@
+{
+  "type": "minecraft:block",
+  "pools": []
+}


### PR DESCRIPTION
## Summary
- mark the market stall controller block as non-opaque so it no longer blocks skylight for the multi-block footprint
- ensure both the controller and structural part blocks report full ambient occlusion light to avoid unintended shadows while keeping collision

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68cb9e943b9883219f877d8f2486f022