### PR TITLE
Add crop tier registry with default tags

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
@@ -2,6 +2,8 @@ package net.jeremy.gardenkingmod;
 
 import net.fabricmc.api.ModInitializer;
 
+import net.jeremy.gardenkingmod.crop.CropTierRegistry;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,6 +18,8 @@ public class GardenKingMod implements ModInitializer {
                 ModBlockEntities.registerBlockEntities();
                 ModScreenHandlers.registerScreenHandlers();
                 ModScoreboards.registerScoreboards();
+
+                CropTierRegistry.init();
 
                 LOGGER.info("Garden King Mod initialized");
         }

--- a/src/main/java/net/jeremy/gardenkingmod/crop/CropTier.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/CropTier.java
@@ -1,0 +1,10 @@
+package net.jeremy.gardenkingmod.crop;
+
+import net.minecraft.util.Identifier;
+
+/**
+ * Describes a crop tier including the tier identifier along with modifiers that
+ * influence growth speed and item drops.
+ */
+public record CropTier(Identifier id, float growthMultiplier, float dropMultiplier) {
+}

--- a/src/main/java/net/jeremy/gardenkingmod/crop/CropTierRegistry.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/CropTierRegistry.java
@@ -1,0 +1,90 @@
+package net.jeremy.gardenkingmod.crop;
+
+import java.util.Map;
+import java.util.Optional;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Identifier;
+
+/**
+ * Registry that exposes the hard-coded crop tiers used by Garden King. The
+ * registry relies on block tags for tier lookups to allow datapacks to extend
+ * the system without requiring an extra configuration file.
+ */
+public final class CropTierRegistry {
+        private static final Identifier TIER_1_ID = new Identifier(GardenKingMod.MOD_ID, "crop_tiers/tier_1");
+        private static final Identifier TIER_2_ID = new Identifier(GardenKingMod.MOD_ID, "crop_tiers/tier_2");
+        private static final Identifier TIER_3_ID = new Identifier(GardenKingMod.MOD_ID, "crop_tiers/tier_3");
+        private static final Identifier TIER_4_ID = new Identifier(GardenKingMod.MOD_ID, "crop_tiers/tier_4");
+        private static final Identifier TIER_5_ID = new Identifier(GardenKingMod.MOD_ID, "crop_tiers/tier_5");
+
+        public static final TagKey<Block> TIER_1 = TagKey.of(RegistryKeys.BLOCK, TIER_1_ID);
+        public static final TagKey<Block> TIER_2 = TagKey.of(RegistryKeys.BLOCK, TIER_2_ID);
+        public static final TagKey<Block> TIER_3 = TagKey.of(RegistryKeys.BLOCK, TIER_3_ID);
+        public static final TagKey<Block> TIER_4 = TagKey.of(RegistryKeys.BLOCK, TIER_4_ID);
+        public static final TagKey<Block> TIER_5 = TagKey.of(RegistryKeys.BLOCK, TIER_5_ID);
+
+        private static Map<Identifier, CropTier> tiers = Map.of();
+        private static boolean initialized = false;
+
+        private CropTierRegistry() {
+        }
+
+        public static void init() {
+                if (initialized) {
+                        return;
+                }
+
+                tiers = Map.ofEntries(
+                                Map.entry(TIER_1_ID, new CropTier(TIER_1_ID, 1.0f, 1.0f)),
+                                Map.entry(TIER_2_ID, new CropTier(TIER_2_ID, 0.9f, 1.15f)),
+                                Map.entry(TIER_3_ID, new CropTier(TIER_3_ID, 0.8f, 1.3f)),
+                                Map.entry(TIER_4_ID, new CropTier(TIER_4_ID, 0.7f, 1.5f)),
+                                Map.entry(TIER_5_ID, new CropTier(TIER_5_ID, 0.6f, 1.75f)));
+
+                initialized = true;
+                GardenKingMod.LOGGER.debug("Registered {} crop tiers", tiers.size());
+        }
+
+        public static Optional<CropTier> get(BlockState state) {
+                if (state == null) {
+                        return Optional.empty();
+                }
+
+                if (state.isIn(TIER_1)) {
+                        return get(TIER_1_ID);
+                }
+                if (state.isIn(TIER_2)) {
+                        return get(TIER_2_ID);
+                }
+                if (state.isIn(TIER_3)) {
+                        return get(TIER_3_ID);
+                }
+                if (state.isIn(TIER_4)) {
+                        return get(TIER_4_ID);
+                }
+                if (state.isIn(TIER_5)) {
+                        return get(TIER_5_ID);
+                }
+
+                return Optional.empty();
+        }
+
+        public static Optional<CropTier> get(Item item) {
+                if (item instanceof BlockItem blockItem) {
+                        return get(blockItem.getBlock().getDefaultState());
+                }
+
+                return Optional.empty();
+        }
+
+        public static Optional<CropTier> get(Identifier id) {
+                return Optional.ofNullable(tiers.get(id));
+        }
+}

--- a/src/main/resources/data/gardenkingmod/tags/blocks/crop_tiers/tier_1.json
+++ b/src/main/resources/data/gardenkingmod/tags/blocks/crop_tiers/tier_1.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:wheat",
+    "minecraft:carrots",
+    "minecraft:potatoes",
+    "minecraft:beetroots",
+    { "id": "croptopia:example_tier_1_crop", "required": false }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/tags/blocks/crop_tiers/tier_2.json
+++ b/src/main/resources/data/gardenkingmod/tags/blocks/crop_tiers/tier_2.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:melon_stem",
+    "minecraft:attached_melon_stem",
+    "minecraft:pumpkin_stem",
+    "minecraft:attached_pumpkin_stem",
+    { "id": "croptopia:example_tier_2_crop", "required": false }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/tags/blocks/crop_tiers/tier_3.json
+++ b/src/main/resources/data/gardenkingmod/tags/blocks/crop_tiers/tier_3.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:sugar_cane",
+    "minecraft:sweet_berry_bush",
+    "minecraft:cocoa",
+    "minecraft:cave_vines",
+    "minecraft:cave_vines_plant",
+    { "id": "croptopia:example_tier_3_crop", "required": false }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/tags/blocks/crop_tiers/tier_4.json
+++ b/src/main/resources/data/gardenkingmod/tags/blocks/crop_tiers/tier_4.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:nether_wart",
+    "minecraft:twisting_vines",
+    "minecraft:twisting_vines_plant",
+    "minecraft:weeping_vines",
+    "minecraft:weeping_vines_plant",
+    { "id": "croptopia:example_tier_4_crop", "required": false }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/tags/blocks/crop_tiers/tier_5.json
+++ b/src/main/resources/data/gardenkingmod/tags/blocks/crop_tiers/tier_5.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:bamboo",
+    "minecraft:chorus_flower",
+    "minecraft:chorus_plant",
+    { "id": "croptopia:example_tier_5_crop", "required": false }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a CropTier record for storing growth and drop multipliers
- create a CropTierRegistry with tier tags, defaults, and helper lookups
- provide vanilla crop tier block tags and initialize the registry during mod startup

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68cbaf726db08321b34c17cd799b6702