### PR TITLE
Handle Croptopia produce tiers and add market GameTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,20 @@ repositories {
 }
 
 fabricApi {
-	configureDataGeneration {
-		client = true
-	}
+        configureDataGeneration {
+                client = true
+        }
+}
+
+loom {
+        runs {
+                gametest {
+                        server()
+                        name "Game Test"
+                        vmArg "-Dfabric-api.gametest"
+                        vmArg "-Dfabric-api.gametest.report-file=${project.buildDir}/reports/gametest/test-results.txt"
+                }
+        }
 }
 
 dependencies {

--- a/src/main/java/net/jeremy/gardenkingmod/crop/CropTierRegistry.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/CropTierRegistry.java
@@ -6,9 +6,12 @@ import java.util.Optional;
 import net.jeremy.gardenkingmod.GardenKingMod;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.item.AliasedBlockItem;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.Identifier;
 
@@ -29,6 +32,12 @@ public final class CropTierRegistry {
         public static final TagKey<Block> TIER_3 = TagKey.of(RegistryKeys.BLOCK, TIER_3_ID);
         public static final TagKey<Block> TIER_4 = TagKey.of(RegistryKeys.BLOCK, TIER_4_ID);
         public static final TagKey<Block> TIER_5 = TagKey.of(RegistryKeys.BLOCK, TIER_5_ID);
+
+        private static final TagKey<Item> TIER_1_ITEM = TagKey.of(RegistryKeys.ITEM, TIER_1_ID);
+        private static final TagKey<Item> TIER_2_ITEM = TagKey.of(RegistryKeys.ITEM, TIER_2_ID);
+        private static final TagKey<Item> TIER_3_ITEM = TagKey.of(RegistryKeys.ITEM, TIER_3_ID);
+        private static final TagKey<Item> TIER_4_ITEM = TagKey.of(RegistryKeys.ITEM, TIER_4_ID);
+        private static final TagKey<Item> TIER_5_ITEM = TagKey.of(RegistryKeys.ITEM, TIER_5_ID);
 
         private static Map<Identifier, CropTier> tiers = Map.of();
         private static boolean initialized = false;
@@ -77,8 +86,33 @@ public final class CropTierRegistry {
         }
 
         public static Optional<CropTier> get(Item item) {
+                if (item == null) {
+                        return Optional.empty();
+                }
+
                 if (item instanceof BlockItem blockItem) {
                         return get(blockItem.getBlock().getDefaultState());
+                }
+
+                if (item instanceof AliasedBlockItem aliasedBlockItem) {
+                        return get(aliasedBlockItem.getBlock().getDefaultState());
+                }
+
+                RegistryEntry<Item> entry = Registries.ITEM.getEntry(item);
+                if (entry.isIn(TIER_1_ITEM)) {
+                        return get(TIER_1_ID);
+                }
+                if (entry.isIn(TIER_2_ITEM)) {
+                        return get(TIER_2_ID);
+                }
+                if (entry.isIn(TIER_3_ITEM)) {
+                        return get(TIER_3_ID);
+                }
+                if (entry.isIn(TIER_4_ITEM)) {
+                        return get(TIER_4_ID);
+                }
+                if (entry.isIn(TIER_5_ITEM)) {
+                        return get(TIER_5_ID);
                 }
 
                 return Optional.empty();

--- a/src/main/resources/data/gardenkingmod/tags/items/crop_tiers/tier_1.json
+++ b/src/main/resources/data/gardenkingmod/tags/items/crop_tiers/tier_1.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:wheat",
+    "minecraft:carrot",
+    "minecraft:potato",
+    "minecraft:beetroot",
+    "minecraft:wheat_seeds",
+    "minecraft:beetroot_seeds",
+    { "id": "croptopia:tomato", "required": false },
+    { "id": "croptopia:tomato_seed", "required": false },
+    { "id": "croptopia:tomato_seeds", "required": false }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/tags/items/crop_tiers/tier_2.json
+++ b/src/main/resources/data/gardenkingmod/tags/items/crop_tiers/tier_2.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:melon_slice",
+    "minecraft:pumpkin_seeds",
+    { "id": "croptopia:example_tier_2_crop_item", "required": false }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/tags/items/crop_tiers/tier_3.json
+++ b/src/main/resources/data/gardenkingmod/tags/items/crop_tiers/tier_3.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:sugar_cane",
+    "minecraft:sweet_berries",
+    "minecraft:cocoa_beans",
+    "minecraft:glow_berries",
+    { "id": "croptopia:example_tier_3_crop_item", "required": false }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/tags/items/crop_tiers/tier_4.json
+++ b/src/main/resources/data/gardenkingmod/tags/items/crop_tiers/tier_4.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:nether_wart",
+    "minecraft:twisting_vines",
+    "minecraft:weeping_vines",
+    { "id": "croptopia:example_tier_4_crop_item", "required": false }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/tags/items/crop_tiers/tier_5.json
+++ b/src/main/resources/data/gardenkingmod/tags/items/crop_tiers/tier_5.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:bamboo",
+    "minecraft:chorus_fruit",
+    { "id": "croptopia:example_tier_5_crop_item", "required": false }
+  ]
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,17 +14,20 @@
 	"license": "CC0-1.0",
 	"icon": "assets/gardenkingmod/icon.png",
 	"environment": "*",
-	"entrypoints": {
-		"main": [
-			"net.jeremy.gardenkingmod.GardenKingMod"
-		],
-        "client": [
-            "net.jeremy.gardenkingmod.GardenKingModClient"
-        ],
-		"fabric-datagen": [
-			"net.jeremy.gardenkingmod.GardenKingModDataGenerator"
-		]
-	},
+        "entrypoints": {
+                "main": [
+                        "net.jeremy.gardenkingmod.GardenKingMod"
+                ],
+                "client": [
+                        "net.jeremy.gardenkingmod.GardenKingModClient"
+                ],
+                "gametest": [
+                        "net.jeremy.gardenkingmod.GardenKingModGameTest"
+                ],
+                "fabric-datagen": [
+                        "net.jeremy.gardenkingmod.GardenKingModDataGenerator"
+                ]
+        },
 	"mixins": [
 		"gardenkingmod.mixins.json"
 	],

--- a/src/testmod/java/net/jeremy/gardenkingmod/GardenKingModGameTest.java
+++ b/src/testmod/java/net/jeremy/gardenkingmod/GardenKingModGameTest.java
@@ -1,0 +1,63 @@
+package net.jeremy.gardenkingmod;
+
+import java.util.Optional;
+
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.jeremy.gardenkingmod.block.entity.MarketBlockEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.test.GameTest;
+import net.minecraft.test.GameTestHelper;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+
+public final class GardenKingModGameTest implements FabricGameTest {
+        @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+        public void sellingCroptopiaTomatoAwardsCoins(GameTestHelper helper) {
+                helper.setBlock(BlockPos.ORIGIN, ModBlocks.MARKET_BLOCK.getDefaultState());
+
+                helper.runAtTickTime(1, () -> {
+                        MarketBlockEntity blockEntity = helper.getBlockEntity(BlockPos.ORIGIN);
+                        if (blockEntity == null) {
+                                helper.fail("Market block entity was not created");
+                                return;
+                        }
+
+                        Optional<Item> tomatoOptional = Registries.ITEM.getOrEmpty(new Identifier("croptopia", "tomato"));
+                        if (tomatoOptional.isEmpty()) {
+                                helper.fail("Croptopia tomato item is missing from the registry");
+                                return;
+                        }
+
+                        blockEntity.setStack(MarketBlockEntity.INPUT_SLOT, new ItemStack(tomatoOptional.get(), 64));
+
+                        ServerPlayerEntity player = helper.spawnPlayer(BlockPos.ORIGIN.up());
+                        boolean sold = blockEntity.sell(player);
+                        if (!sold) {
+                                helper.fail("Market failed to sell a stack of tomatoes");
+                                return;
+                        }
+
+                        int coinCount = 0;
+                        for (ItemStack inventoryStack : player.getInventory().main) {
+                                if (inventoryStack.isOf(ModItems.GARDEN_COIN)) {
+                                        coinCount += inventoryStack.getCount();
+                                }
+                        }
+
+                        if (coinCount <= 0) {
+                                helper.fail("Player did not receive any garden coins after selling tomatoes");
+                                return;
+                        }
+
+                        if (!blockEntity.getStack(MarketBlockEntity.INPUT_SLOT).isEmpty()) {
+                                helper.fail("Market input slot should be cleared after selling tomatoes");
+                                return;
+                        }
+
+                        helper.succeed();
+                });
+        }
+}


### PR DESCRIPTION
## Summary
- allow CropTierRegistry to resolve AliasedBlockItem seeds and tier-tagged items
- add crop tier item tags plus a gametest entrypoint and run configuration
- cover selling croptopia:tomato at the market with a Fabric GameTest

## Testing
- ./gradlew check
- ./gradlew runGametest *(fails in this environment: unable to download LWJGL artifacts from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb78ff3a48321b79da8dd4893fa28