### PR TITLE
Scale crop growth by tier multipliers

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/mixin/CropBlockMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/CropBlockMixin.java
@@ -1,0 +1,21 @@
+package net.jeremy.gardenkingmod.mixin;
+
+import net.jeremy.gardenkingmod.crop.CropTierRegistry;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.CropBlock;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(CropBlock.class)
+public abstract class CropBlockMixin {
+        @ModifyVariable(method = "randomTick(Lnet/minecraft/block/BlockState;Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/random/Random;)V",
+                        at = @At(value = "STORE"), ordinal = 0)
+        private float gardenkingmod$scaleGrowthChance(float moisture, BlockState state, ServerWorld world, BlockPos pos,
+                        Random random) {
+                return CropTierRegistry.scaleGrowthChance(state, moisture);
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java
@@ -1,0 +1,22 @@
+package net.jeremy.gardenkingmod.mixin;
+
+import net.jeremy.gardenkingmod.crop.CropTierRegistry;
+import net.minecraft.block.BlockState;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Pseudo
+@Mixin(targets = "com.epherical.croptopia.blocks.CropBlock", remap = false)
+public abstract class CroptopiaCropBlockMixin {
+        @ModifyVariable(method = "randomTick(Lnet/minecraft/block/BlockState;Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/random/Random;)V",
+                        at = @At(value = "STORE"), ordinal = 0, remap = false)
+        private float gardenkingmod$scaleGrowthChance(float moisture, BlockState state, ServerWorld world, BlockPos pos,
+                        Random random) {
+                return CropTierRegistry.scaleGrowthChance(state, moisture);
+        }
+}

--- a/src/main/resources/gardenkingmod.mixins.json
+++ b/src/main/resources/gardenkingmod.mixins.json
@@ -5,7 +5,9 @@
         "mixins": [
                 "ExampleMixin",
                 "PlayerEntityMixin",
-                "ServerPlayerEntityMixin"
+                "ServerPlayerEntityMixin",
+                "CropBlockMixin",
+                "CroptopiaCropBlockMixin"
         ],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
## Summary
- add a helper in `CropTierRegistry` that scales growth chances with tier multipliers while guarding edge cases
- apply the helper from new mixins targeting vanilla and Croptopia crop blocks so their random ticks respect tier scaling
- register the additional mixins in the configuration for conditional activation

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cbbe8b379483219bcb3223e7d38615