### PR TITLE
Add market sale result networking and UI feedback

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -1,9 +1,11 @@
 package net.jeremy.gardenkingmod;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.jeremy.gardenkingmod.client.model.MarketBlockModel;
 import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
+import net.jeremy.gardenkingmod.network.ModPackets;
 import net.jeremy.gardenkingmod.screen.MarketScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactories;
@@ -14,5 +16,19 @@ public class GardenKingModClient implements ClientModInitializer {
         HandledScreens.register(ModScreenHandlers.MARKET_SCREEN_HANDLER, MarketScreen::new);
         EntityModelLayerRegistry.registerModelLayer(MarketBlockModel.LAYER_LOCATION, MarketBlockModel::getTexturedModelData);
         BlockEntityRendererFactories.register(ModBlockEntities.MARKET_BLOCK_ENTITY, MarketBlockEntityRenderer::new);
+
+        ClientPlayNetworking.registerGlobalReceiver(ModPackets.MARKET_SALE_RESULT_PACKET,
+                (client, handler, buf, responseSender) -> {
+                        buf.readBlockPos();
+                        int itemsSold = buf.readVarInt();
+                        int payout = buf.readVarInt();
+                        int lifetimeTotal = buf.readVarInt();
+
+                        client.execute(() -> {
+                                if (client.currentScreen instanceof MarketScreen marketScreen) {
+                                        marketScreen.updateSaleResult(itemsSold, payout, lifetimeTotal);
+                                }
+                        });
+                });
     }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
@@ -2,10 +2,13 @@ package net.jeremy.gardenkingmod.block.entity;
 
 import java.util.Optional;
 
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
 import net.jeremy.gardenkingmod.ModBlockEntities;
 import net.jeremy.gardenkingmod.ModItems;
 import net.jeremy.gardenkingmod.ModScoreboards;
+import net.jeremy.gardenkingmod.network.ModPackets;
 import net.jeremy.gardenkingmod.crop.CropTier;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.screen.MarketScreenHandler;
@@ -214,6 +217,14 @@ public class MarketBlockEntity extends BlockEntity implements ExtendedScreenHand
                 }
 
                 int lifetimeTotal = ModScoreboards.addCurrency(player, payout);
+
+                PacketByteBuf buf = PacketByteBufs.create();
+                buf.writeBlockPos(pos);
+                buf.writeVarInt(itemsSold);
+                buf.writeVarInt(payout);
+                buf.writeVarInt(lifetimeTotal);
+                ServerPlayNetworking.send(player, ModPackets.MARKET_SALE_RESULT_PACKET, buf);
+
                 Text message = lifetimeTotal >= 0
                                 ? Text.translatable("message.gardenkingmod.market.sold.lifetime", itemsSold, payout,
                                                 lifetimeTotal)

--- a/src/main/java/net/jeremy/gardenkingmod/network/ModPackets.java
+++ b/src/main/java/net/jeremy/gardenkingmod/network/ModPackets.java
@@ -1,0 +1,12 @@
+package net.jeremy.gardenkingmod.network;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.minecraft.util.Identifier;
+
+public final class ModPackets {
+    private ModPackets() {
+    }
+
+    public static final Identifier MARKET_SALE_RESULT_PACKET =
+            new Identifier(GardenKingMod.MOD_ID, "market_sale_result");
+}

--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -5,19 +5,31 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 
 public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         private static final Identifier TEXTURE = new Identifier(GardenKingMod.MOD_ID, "textures/gui/container/market_gui.png");
 
         private ButtonWidget sellButton;
+        private int lastItemsSold;
+        private int lastPayout;
+        private int lastLifetimeTotal;
+        private MutableText saleResultLine;
+        private MutableText lifetimeResultLine;
 
         public MarketScreen(MarketScreenHandler handler, PlayerInventory inventory, Text title) {
                 super(handler, inventory, title);
                 this.backgroundWidth = 176;
                 this.backgroundHeight = 166;
-                this.playerInventoryTitleY = this.backgroundHeight - 94;
+                this.playerInventoryTitleY = this.backgroundHeight - 88;
+                this.lastItemsSold = -1;
+                this.lastPayout = 0;
+                this.lastLifetimeTotal = -1;
+                this.saleResultLine = Text.empty();
+                this.lifetimeResultLine = Text.empty();
         }
 
         @Override
@@ -28,7 +40,7 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
                                         if (client != null && client.interactionManager != null) {
                                                 client.interactionManager.clickButton(handler.syncId, 0);
                                         }
-                                }).dimensions(x + 62, y + 60, 52, 20).build());
+                                }).dimensions(x + 62, y + 44, 52, 20).build());
         }
 
         @Override
@@ -44,5 +56,45 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
                 }
                 super.render(context, mouseX, mouseY, delta);
                 drawMouseoverTooltip(context, mouseX, mouseY);
+        }
+
+        public void updateSaleResult(int itemsSold, int payout, int lifetimeTotal) {
+                this.lastItemsSold = itemsSold;
+                this.lastPayout = payout;
+                this.lastLifetimeTotal = lifetimeTotal >= 0 ? lifetimeTotal : -1;
+
+                MutableText payoutText = Text.literal(Integer.toString(payout)).formatted(Formatting.GREEN);
+                this.saleResultLine = Text
+                                .translatable("screen.gardenkingmod.market.sale_result", itemsSold, payoutText)
+                                .formatted(Formatting.YELLOW);
+
+                if (this.lastLifetimeTotal >= 0) {
+                        MutableText lifetimeText = Text.literal(Integer.toString(this.lastLifetimeTotal))
+                                        .formatted(Formatting.GREEN);
+                        this.lifetimeResultLine = Text
+                                        .translatable("screen.gardenkingmod.market.lifetime", lifetimeText)
+                                        .formatted(Formatting.YELLOW);
+                } else {
+                        this.lifetimeResultLine = Text.empty();
+                }
+        }
+
+        @Override
+        protected void drawForeground(DrawContext context, int mouseX, int mouseY) {
+                super.drawForeground(context, mouseX, mouseY);
+
+                if (lastItemsSold < 0 || saleResultLine == null || saleResultLine.getString().isEmpty()) {
+                        return;
+                }
+
+                int firstLineY = 70;
+                int firstLineX = (backgroundWidth - textRenderer.getWidth(saleResultLine)) / 2;
+                context.drawText(textRenderer, saleResultLine, firstLineX, firstLineY, 0xFFFFFF, false);
+
+                if (lastLifetimeTotal >= 0 && lifetimeResultLine != null && !lifetimeResultLine.getString().isEmpty()) {
+                        int secondLineY = firstLineY + 12;
+                        int secondLineX = (backgroundWidth - textRenderer.getWidth(lifetimeResultLine)) / 2;
+                        context.drawText(textRenderer, lifetimeResultLine, secondLineX, secondLineY, 0xFFFFFF, false);
+                }
         }
 }

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -3,6 +3,8 @@
 "item.gardenkingmod.garden_coin": "Garden Coin",
 "container.gardenkingmod.market": "Garden Market",
 "screen.gardenkingmod.market.sell": "Sell",
+"screen.gardenkingmod.market.sale_result": "You sold %1$s crop and earned %2$s garden coins.",
+"screen.gardenkingmod.market.lifetime": "Lifetime earnings: %1$s garden coins.",
 "message.gardenkingmod.market.sold": "Sold %1$s Croptopia crops for %2$s coins.",
 "message.gardenkingmod.market.sold.lifetime": "Sold %1$s Croptopia crops for %2$s coins. Lifetime earnings: %3$s coins.",
 "message.gardenkingmod.market.empty": "There are no crops to sell.",


### PR DESCRIPTION
## Summary
- add a shared MARKET_SALE_RESULT_PACKET identifier for market sale messages
- send the sale result payload from the server and handle it on the client to update the active market screen
- persist the last sale details in MarketScreen, render the colored messages, and add matching translations

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cbcd59ec848321a57ecfcc896ea72c