### PR TITLE
Align market GUI layout with updated texture

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -11,7 +11,18 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 
 public class MarketScreen extends HandledScreen<MarketScreenHandler> {
-        private static final Identifier TEXTURE = new Identifier(GardenKingMod.MOD_ID, "textures/gui/container/market_gui.png");
+        private static final Identifier TEXTURE = new Identifier(GardenKingMod.MOD_ID,
+                        "textures/gui/container/market_gui.png");
+
+        private static final int BACKGROUND_WIDTH = 176;
+        private static final int BACKGROUND_HEIGHT = 222;
+        private static final int PLAYER_INVENTORY_LABEL_Y = BACKGROUND_HEIGHT - 94;
+        private static final int SELL_BUTTON_WIDTH = 52;
+        private static final int SELL_BUTTON_HEIGHT = 20;
+        private static final int SCOREBOARD_BAND_TOP = 107;
+        private static final int SCOREBOARD_BAND_BOTTOM = 138;
+        private static final int SCOREBOARD_TEXT_PADDING = 7;
+        private static final int SCOREBOARD_TEXT_LINE_SPACING = 12;
 
         private ButtonWidget sellButton;
         private int lastItemsSold;
@@ -22,9 +33,9 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
 
         public MarketScreen(MarketScreenHandler handler, PlayerInventory inventory, Text title) {
                 super(handler, inventory, title);
-                this.backgroundWidth = 176;
-                this.backgroundHeight = 166;
-                this.playerInventoryTitleY = this.backgroundHeight - 88;
+                this.backgroundWidth = BACKGROUND_WIDTH;
+                this.backgroundHeight = BACKGROUND_HEIGHT;
+                this.playerInventoryTitleY = PLAYER_INVENTORY_LABEL_Y;
                 this.lastItemsSold = -1;
                 this.lastPayout = 0;
                 this.lastLifetimeTotal = -1;
@@ -35,12 +46,15 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         @Override
         protected void init() {
                 super.init();
+                int sellButtonX = x + (backgroundWidth - SELL_BUTTON_WIDTH) / 2;
+                int scoreboardBandHeight = SCOREBOARD_BAND_BOTTOM - SCOREBOARD_BAND_TOP + 1;
+                int sellButtonY = y + SCOREBOARD_BAND_TOP + (scoreboardBandHeight - SELL_BUTTON_HEIGHT) / 2;
                 sellButton = addDrawableChild(ButtonWidget.builder(Text.translatable("screen.gardenkingmod.market.sell"),
                                 button -> {
                                         if (client != null && client.interactionManager != null) {
                                                 client.interactionManager.clickButton(handler.syncId, 0);
                                         }
-                                }).dimensions(x + 62, y + 44, 52, 20).build());
+                                }).dimensions(sellButtonX, sellButtonY, SELL_BUTTON_WIDTH, SELL_BUTTON_HEIGHT).build());
         }
 
         @Override
@@ -87,12 +101,16 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
                         return;
                 }
 
-                int firstLineY = 70;
+                if (sellButton == null) {
+                        return;
+                }
+
+                int firstLineY = sellButton.getY() - this.y + SELL_BUTTON_HEIGHT + SCOREBOARD_TEXT_PADDING;
                 int firstLineX = (backgroundWidth - textRenderer.getWidth(saleResultLine)) / 2;
                 context.drawText(textRenderer, saleResultLine, firstLineX, firstLineY, 0xFFFFFF, false);
 
                 if (lastLifetimeTotal >= 0 && lifetimeResultLine != null && !lifetimeResultLine.getString().isEmpty()) {
-                        int secondLineY = firstLineY + 12;
+                        int secondLineY = firstLineY + SCOREBOARD_TEXT_LINE_SPACING;
                         int secondLineX = (backgroundWidth - textRenderer.getWidth(lifetimeResultLine)) / 2;
                         context.drawText(textRenderer, lifetimeResultLine, secondLineX, secondLineY, 0xFFFFFF, false);
                 }


### PR DESCRIPTION
## Summary
- update the market screen dimensions to match the new 176x222 GUI texture and reuse constants for layout math
- center the sell button in the scoreboard band and anchor the sale text to the button

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cc58bca4fc8321a412bb778833c71f