### PR TITLE
Expand market inventory and aggregate sales

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
@@ -29,15 +29,30 @@ public class MarketScreenHandler extends ScreenHandler {
                 checkSize(this.inventory, MarketBlockEntity.INVENTORY_SIZE);
                 this.inventory.onOpen(playerInventory.player);
 
-                this.addSlot(new Slot(this.inventory, MarketBlockEntity.INPUT_SLOT, 79, 34) {
-                        @Override
-                        public boolean canInsert(ItemStack stack) {
-                                return MarketBlockEntity.isSellable(stack);
-                        }
-                });
+                addMarketInventory();
 
                 addPlayerInventory(playerInventory);
                 addPlayerHotbar(playerInventory);
+        }
+
+        private void addMarketInventory() {
+                final int slotsPerRow = 9;
+                final int slotSize = 18;
+                final int startX = 8;
+                final int startY = 18;
+
+                for (int slotIndex = 0; slotIndex < MarketBlockEntity.INVENTORY_SIZE; ++slotIndex) {
+                        int column = slotIndex % slotsPerRow;
+                        int row = slotIndex / slotsPerRow;
+                        int x = startX + column * slotSize;
+                        int y = startY + row * slotSize;
+                        this.addSlot(new Slot(this.inventory, slotIndex, x, y) {
+                                @Override
+                                public boolean canInsert(ItemStack stack) {
+                                        return MarketBlockEntity.isSellable(stack);
+                                }
+                        });
+                }
         }
 
         private static MarketBlockEntity getBlockEntity(PlayerInventory playerInventory, BlockPos pos) {
@@ -74,13 +89,13 @@ public class MarketScreenHandler extends ScreenHandler {
                 if (slot != null && slot.hasStack()) {
                         ItemStack originalStack = slot.getStack();
                         newStack = originalStack.copy();
-                        if (index == MarketBlockEntity.INPUT_SLOT) {
-                                if (!this.insertItem(originalStack, MarketBlockEntity.INVENTORY_SIZE, this.slots.size(), true)) {
+                        if (index < MarketBlockEntity.INVENTORY_SIZE) {
+                                if (!this.insertItem(originalStack, MarketBlockEntity.INVENTORY_SIZE, this.slots.size(),
+                                                true)) {
                                         return ItemStack.EMPTY;
                                 }
                         } else if (!MarketBlockEntity.isSellable(originalStack)
-                                        || !this.insertItem(originalStack, MarketBlockEntity.INPUT_SLOT,
-                                                        MarketBlockEntity.INPUT_SLOT + 1, false)) {
+                                        || !this.insertItem(originalStack, 0, MarketBlockEntity.INVENTORY_SIZE, false)) {
                                 return ItemStack.EMPTY;
                         }
 
@@ -107,7 +122,12 @@ public class MarketScreenHandler extends ScreenHandler {
         }
 
         public boolean hasSellableItem() {
-                return MarketBlockEntity.isSellable(this.inventory.getStack(MarketBlockEntity.INPUT_SLOT));
+                for (int slot = 0; slot < MarketBlockEntity.INVENTORY_SIZE; slot++) {
+                        if (MarketBlockEntity.isSellable(this.inventory.getStack(slot))) {
+                                return true;
+                        }
+                }
+                return false;
         }
 
         private void addPlayerInventory(PlayerInventory playerInventory) {

--- a/src/testmod/java/net/jeremy/gardenkingmod/GardenKingModGameTest.java
+++ b/src/testmod/java/net/jeremy/gardenkingmod/GardenKingModGameTest.java
@@ -31,7 +31,8 @@ public final class GardenKingModGameTest implements FabricGameTest {
                                 return;
                         }
 
-                        blockEntity.setStack(MarketBlockEntity.INPUT_SLOT, new ItemStack(tomatoOptional.get(), 64));
+                        blockEntity.setStack(0, new ItemStack(tomatoOptional.get(), 64));
+                        blockEntity.setStack(1, new ItemStack(tomatoOptional.get(), 32));
 
                         ServerPlayerEntity player = helper.spawnPlayer(BlockPos.ORIGIN.up());
                         boolean sold = blockEntity.sell(player);
@@ -41,9 +42,12 @@ public final class GardenKingModGameTest implements FabricGameTest {
                         }
 
                         int coinCount = 0;
+                        int tomatoCount = 0;
                         for (ItemStack inventoryStack : player.getInventory().main) {
                                 if (inventoryStack.isOf(ModItems.GARDEN_COIN)) {
                                         coinCount += inventoryStack.getCount();
+                                } else if (inventoryStack.isOf(tomatoOptional.get())) {
+                                        tomatoCount += inventoryStack.getCount();
                                 }
                         }
 
@@ -52,8 +56,18 @@ public final class GardenKingModGameTest implements FabricGameTest {
                                 return;
                         }
 
-                        if (!blockEntity.getStack(MarketBlockEntity.INPUT_SLOT).isEmpty()) {
+                        if (!blockEntity.getStack(0).isEmpty()) {
                                 helper.fail("Market input slot should be cleared after selling tomatoes");
+                                return;
+                        }
+
+                        if (!blockEntity.getStack(1).isEmpty()) {
+                                helper.fail("Market should clear all processed slots after selling tomatoes");
+                                return;
+                        }
+
+                        if (tomatoCount != 32) {
+                                helper.fail("Player should receive the partial stack of tomatoes back after selling");
                                 return;
                         }
 


### PR DESCRIPTION
## Summary
- Expand the market block inventory to 45 slots, refresh its backing storage, and aggregate sales across every sellable stack while returning partial items to the player.
- Lay out the enlarged market inventory in the screen handler with updated quick-move logic and sell-button checks.
- Extend the market game test to cover multiple slots and verify partial crops are returned to the seller.

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cc67dabe28832194b31a7fa251bfa6