### PR TITLE
Allow market to sell vanilla items

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
@@ -48,7 +48,12 @@ public class MarketBlockEntity extends BlockEntity implements ExtendedScreenHand
                 }
 
                 Identifier identifier = Registries.ITEM.getId(stack.getItem());
-                return identifier != null && "croptopia".equals(identifier.getNamespace());
+                if (identifier == null) {
+                        return false;
+                }
+
+                String namespace = identifier.getNamespace();
+                return "croptopia".equals(namespace) || "minecraft".equals(namespace);
         }
 
         @Override


### PR DESCRIPTION
## Summary
- update the market sellable check to accept items from the `croptopia` and `minecraft` namespaces
- keep a null guard for missing identifiers when evaluating sellable stacks

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cc78bd9b988321831c8bdecc0c7506