### PR TITLE
Add crop tier tooltip for items

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -1,14 +1,18 @@
 package net.jeremy.gardenkingmod;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.jeremy.gardenkingmod.client.model.MarketBlockModel;
 import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
+import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.network.ModPackets;
 import net.jeremy.gardenkingmod.screen.MarketScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactories;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 
 public class GardenKingModClient implements ClientModInitializer {
     @Override
@@ -30,5 +34,15 @@ public class GardenKingModClient implements ClientModInitializer {
                                 }
                         });
                 });
+
+        ItemTooltipCallback.EVENT.register((stack, context, lines) -> CropTierRegistry.get(stack.getItem())
+                .ifPresent(tier -> {
+                        String path = tier.id().getPath();
+                        String suffix = path.contains("/") ? path.substring(path.lastIndexOf('/') + 1) : path;
+                        Text tierName = Text
+                                        .translatable("tooltip." + tier.id().getNamespace() + ".crop_tier." + suffix);
+                        lines.add(Text.translatable("tooltip." + GardenKingMod.MOD_ID + ".crop_tier", tierName)
+                                        .formatted(Formatting.GRAY));
+                }));
     }
 }

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -9,5 +9,11 @@
 "message.gardenkingmod.market.sold.lifetime": "Sold %1$s Croptopia crops for %2$s coins. Lifetime earnings: %3$s coins.",
 "message.gardenkingmod.market.empty": "There are no crops to sell.",
 "message.gardenkingmod.market.invalid": "Only Croptopia crops can be sold here!",
-"scoreboard.gardenkingmod.garden_currency": "Garden Coins"
+"scoreboard.gardenkingmod.garden_currency": "Garden Coins",
+"tooltip.gardenkingmod.crop_tier": "Tier: %s",
+"tooltip.gardenkingmod.crop_tier.tier_1": "Tier 1",
+"tooltip.gardenkingmod.crop_tier.tier_2": "Tier 2",
+"tooltip.gardenkingmod.crop_tier.tier_3": "Tier 3",
+"tooltip.gardenkingmod.crop_tier.tier_4": "Tier 4",
+"tooltip.gardenkingmod.crop_tier.tier_5": "Tier 5"
 }


### PR DESCRIPTION
## Summary
- register an item tooltip callback that appends the crop tier text for known tiered items
- add English localization strings for the crop tier tooltip and per-tier labels

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68ccdec7679c83218507bf36e4b52097