### PR TITLE
Route market feedback through screen packet

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -24,13 +24,15 @@ public class GardenKingModClient implements ClientModInitializer {
         ClientPlayNetworking.registerGlobalReceiver(ModPackets.MARKET_SALE_RESULT_PACKET,
                 (client, handler, buf, responseSender) -> {
                         buf.readBlockPos();
+                        boolean success = buf.readBoolean();
                         int itemsSold = buf.readVarInt();
                         int payout = buf.readVarInt();
                         int lifetimeTotal = buf.readVarInt();
+                        Text feedback = buf.readText();
 
                         client.execute(() -> {
                                 if (client.currentScreen instanceof MarketScreen marketScreen) {
-                                        marketScreen.updateSaleResult(itemsSold, payout, lifetimeTotal);
+                                        marketScreen.updateSaleResult(success, itemsSold, payout, lifetimeTotal, feedback);
                                 }
                         });
                 });

--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -74,23 +74,33 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
                 drawMouseoverTooltip(context, mouseX, mouseY);
         }
 
-        public void updateSaleResult(int itemsSold, int payout, int lifetimeTotal) {
+        public void updateSaleResult(boolean success, int itemsSold, int payout, int lifetimeTotal, Text feedback) {
                 this.lastItemsSold = itemsSold;
                 this.lastPayout = payout;
-                this.lastLifetimeTotal = lifetimeTotal >= 0 ? lifetimeTotal : -1;
+                this.lastLifetimeTotal = success && lifetimeTotal >= 0 ? lifetimeTotal : -1;
 
-                MutableText payoutText = Text.literal(Integer.toString(payout)).formatted(Formatting.GREEN);
-                this.saleResultLine = Text
-                                .translatable("screen.gardenkingmod.market.sale_result", itemsSold, payoutText)
-                                .formatted(Formatting.YELLOW);
-
-                if (this.lastLifetimeTotal >= 0) {
-                        MutableText lifetimeText = Text.literal(Integer.toString(this.lastLifetimeTotal))
-                                        .formatted(Formatting.GREEN);
-                        this.lifetimeResultLine = Text
-                                        .translatable("screen.gardenkingmod.market.lifetime", lifetimeText)
+                if (success) {
+                        MutableText payoutText = Text.literal(Integer.toString(payout)).formatted(Formatting.GREEN);
+                        this.saleResultLine = Text
+                                        .translatable("screen.gardenkingmod.market.sale_result", itemsSold, payoutText)
                                         .formatted(Formatting.YELLOW);
+
+                        if (this.lastLifetimeTotal >= 0) {
+                                MutableText lifetimeText = Text.literal(Integer.toString(this.lastLifetimeTotal))
+                                                .formatted(Formatting.GREEN);
+                                this.lifetimeResultLine = Text
+                                                .translatable("screen.gardenkingmod.market.lifetime", lifetimeText)
+                                                .formatted(Formatting.YELLOW);
+                        } else {
+                                this.lifetimeResultLine = Text.empty();
+                        }
                 } else {
+                        MutableText feedbackLine = feedback.copy();
+                        if (!feedbackLine.getString().isEmpty()) {
+                                this.saleResultLine = feedbackLine.formatted(Formatting.RED);
+                        } else {
+                                this.saleResultLine = Text.empty();
+                        }
                         this.lifetimeResultLine = Text.empty();
                 }
         }


### PR DESCRIPTION
## Summary
- stop using action-bar messages for market sales and send all outcomes to the client screen packet instead
- update the market screen to render success details and failure feedback from the synchronized packet data

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68ccfb1c72348321afdb0c002110392b