### PR TITLE
Add shared crop no-drop chance handling for loot tables

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/crop/CropTier.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/CropTier.java
@@ -4,7 +4,8 @@ import net.minecraft.util.Identifier;
 
 /**
  * Describes a crop tier including the tier identifier along with modifiers that
- * influence growth speed and item drops.
+ * influence growth speed, item drops, and the probability of producing no
+ * harvest.
  */
-public record CropTier(Identifier id, float growthMultiplier, float dropMultiplier) {
+public record CropTier(Identifier id, float growthMultiplier, float dropMultiplier, float noDropChance) {
 }

--- a/src/main/java/net/jeremy/gardenkingmod/crop/CropTierRegistry.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/CropTierRegistry.java
@@ -51,11 +51,11 @@ public final class CropTierRegistry {
                 }
 
                 tiers = Map.ofEntries(
-                                Map.entry(TIER_1_ID, new CropTier(TIER_1_ID, 1.0f, 1.0f)),
-                                Map.entry(TIER_2_ID, new CropTier(TIER_2_ID, 0.9f, 1.15f)),
-                                Map.entry(TIER_3_ID, new CropTier(TIER_3_ID, 0.8f, 1.3f)),
-                                Map.entry(TIER_4_ID, new CropTier(TIER_4_ID, 0.7f, 1.5f)),
-                                Map.entry(TIER_5_ID, new CropTier(TIER_5_ID, 0.6f, 1.75f)));
+                                Map.entry(TIER_1_ID, new CropTier(TIER_1_ID, 1.0f, 1.0f, 0.0f)),
+                                Map.entry(TIER_2_ID, new CropTier(TIER_2_ID, 0.9f, 1.15f, 0.05f)),
+                                Map.entry(TIER_3_ID, new CropTier(TIER_3_ID, 0.8f, 1.3f, 0.1f)),
+                                Map.entry(TIER_4_ID, new CropTier(TIER_4_ID, 0.7f, 1.5f, 0.15f)),
+                                Map.entry(TIER_5_ID, new CropTier(TIER_5_ID, 0.6f, 1.75f, 0.2f)));
 
                 initialized = true;
                 GardenKingMod.LOGGER.debug("Registered {} crop tiers", tiers.size());


### PR DESCRIPTION
## Summary
- add a per-tier no-drop probability to the crop tier definition and registry
- roll the configured chance for crop loot pools before scaling counts so failed rolls return no drops

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cd6aff57288321bab47a5582c8ecd5