### PR TITLE
Support extra rotten chance in rotten harvest entries

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/crop/CropDropModifier.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/CropDropModifier.java
@@ -88,10 +88,9 @@ public final class CropDropModifier {
 
                         Optional<RottenHarvestEntry> rottenEntry = RottenHarvestManager.getInstance().getRottenHarvest(id);
                         float extraNoDropChance = rottenEntry.map(RottenHarvestEntry::extraNoDropChance).orElse(0.0f);
+                        float extraRottenChance = rottenEntry.map(RottenHarvestEntry::extraRottenChance).orElse(0.0f);
                         float combinedNoDropChance = MathHelper.clamp(baseNoDropChance + extraNoDropChance, 0.0f, 1.0f);
-                        float combinedRottenChance = MathHelper.clamp(
-                                        baseRottenChance + RottenHarvestManager.getInstance().getExtraRottenChance(id), 0.0f,
-                                        1.0f);
+                        float combinedRottenChance = MathHelper.clamp(baseRottenChance + extraRottenChance, 0.0f, 1.0f);
 
                         boolean applyScaling = multiplier > 1.0001f;
                         boolean applyNoDrop = combinedNoDropChance > 0.0f;

--- a/src/main/java/net/jeremy/gardenkingmod/crop/RottenHarvestManager.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/RottenHarvestManager.java
@@ -56,12 +56,11 @@ public final class RottenHarvestManager extends JsonDataLoader implements Identi
 
         /**
          * Returns any additional rotten chance supplied by datapacks for the provided
-         * loot table. The current schema does not expose extra rotten odds, so the
-         * method always returns {@code 0.0f} but remains available for future
-         * compatibility.
+         * loot table.
          */
         public float getExtraRottenChance(Identifier lootTableId) {
-                return 0.0f;
+                RottenHarvestEntry entry = rottenHarvests.get(lootTableId);
+                return entry == null ? 0.0f : entry.extraRottenChance();
         }
 
         @Override
@@ -132,7 +131,12 @@ public final class RottenHarvestManager extends JsonDataLoader implements Identi
                                 extraNoDropChance = MathHelper.clamp(JsonHelper.getFloat(object, "extra_no_drop_chance"), 0.0f, 1.0f);
                         }
 
-                        return new RottenHarvestEntry(itemOptional.get(), extraNoDropChance);
+                        float extraRottenChance = 0.0f;
+                        if (object.has("extra_rotten_chance")) {
+                                extraRottenChance = MathHelper.clamp(JsonHelper.getFloat(object, "extra_rotten_chance"), 0.0f, 1.0f);
+                        }
+
+                        return new RottenHarvestEntry(itemOptional.get(), extraNoDropChance, extraRottenChance);
                 } catch (IllegalArgumentException exception) {
                         GardenKingMod.LOGGER.warn("Failed to parse rotten harvest entry for {} in {}", lootTableId, fileId, exception);
                         return null;
@@ -170,6 +174,6 @@ public final class RottenHarvestManager extends JsonDataLoader implements Identi
                 return identifier;
         }
 
-        public record RottenHarvestEntry(Item rottenItem, float extraNoDropChance) {
+        public record RottenHarvestEntry(Item rottenItem, float extraNoDropChance, float extraRottenChance) {
         }
 }

--- a/src/main/resources/data/gardenkingmod/rotten_harvest/rotten_harvest.json
+++ b/src/main/resources/data/gardenkingmod/rotten_harvest/rotten_harvest.json
@@ -1,6 +1,7 @@
 {
   "minecraft:wheat": {
     "rotten_item": "minecraft:rotten_flesh",
-    "extra_no_drop_chance": 0.05
+    "extra_no_drop_chance": 0.05,
+    "extra_rotten_chance": 0.1
   }
 }


### PR DESCRIPTION
## Summary
- store optional extra rotten chance in rotten harvest definitions and expose it through the manager
- factor the rotten drop calculation in the crop drop modifier to use the configured chance
- document the new datapack field with an updated rotten harvest example

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cdb8a4be708321aaac8818b357eb26