### PR TITLE
Automate rotten crop registration and datagen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,15 @@ version = project.mod_version
 group = project.maven_group
 
 base {
-	archivesName = project.archives_base_name
+        archivesName = project.archives_base_name
+}
+
+sourceSets {
+        main {
+                resources {
+                        srcDir "src/main/generated"
+                }
+        }
 }
 
 repositories {

--- a/src/main/generated/.gitignore
+++ b/src/main/generated/.gitignore
@@ -1,0 +1,4 @@
+# Generated data will be written here by the data generator.
+# The directory is kept in source control so Gradle can locate it.
+*
+!.gitignore

--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModDataGenerator.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModDataGenerator.java
@@ -1,11 +1,27 @@
 package net.jeremy.gardenkingmod;
 
+import java.util.List;
+
 import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+
+import net.jeremy.gardenkingmod.crop.RottenCropDefinition;
+import net.jeremy.gardenkingmod.crop.RottenCropDefinitions;
+import net.jeremy.gardenkingmod.datagen.RottenHarvestJsonProvider;
+import net.jeremy.gardenkingmod.datagen.RottenItemModelProvider;
+import net.jeremy.gardenkingmod.datagen.RottenLanguageProvider;
+import net.jeremy.gardenkingmod.ModItems;
 
 public class GardenKingModDataGenerator implements DataGeneratorEntrypoint {
-	@Override
-	public void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator) {
+        @Override
+        public void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator) {
+                FabricDataGenerator.Pack pack = fabricDataGenerator.createPack();
+                ModItems.getRottenItems();
+                List<RottenCropDefinition> definitions = RottenCropDefinitions.all();
 
-	}
+                pack.addProvider((FabricDataOutput output) -> new RottenItemModelProvider(output, definitions));
+                pack.addProvider((FabricDataOutput output) -> new RottenLanguageProvider(output, definitions));
+                pack.addProvider((FabricDataOutput output) -> new RottenHarvestJsonProvider(output, definitions));
+        }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/ModItems.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModItems.java
@@ -1,7 +1,18 @@
 package net.jeremy.gardenkingmod;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+
+import net.jeremy.gardenkingmod.crop.RottenCropDefinition;
+import net.jeremy.gardenkingmod.crop.RottenCropDefinitions;
+
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroups;
 import net.minecraft.registry.Registries;
@@ -10,7 +21,27 @@ import net.minecraft.util.Identifier;
 
 public final class ModItems {
         public static final Item GARDEN_COIN = registerItem("garden_coin", new Item(new FabricItemSettings()));
-        public static final Item ROTTEN_WHEAT = registerItem("rotten_wheat", new Item(new FabricItemSettings()));
+
+        private static final Map<Identifier, Item> ROTTEN_ITEMS_BY_CROP;
+        private static final Map<Identifier, Item> ROTTEN_ITEMS_BY_TARGET;
+        private static final List<Item> ROTTEN_ITEMS;
+
+        static {
+                Map<Identifier, Item> byCrop = new LinkedHashMap<>();
+                Map<Identifier, Item> byTarget = new LinkedHashMap<>();
+                List<Item> items = new ArrayList<>();
+
+                for (RottenCropDefinition definition : RottenCropDefinitions.all()) {
+                        Item item = registerItem(definition.rottenItemId().getPath(), new Item(new FabricItemSettings()));
+                        byCrop.put(definition.cropId(), item);
+                        byTarget.put(definition.targetId(), item);
+                        items.add(item);
+                }
+
+                ROTTEN_ITEMS_BY_CROP = Collections.unmodifiableMap(byCrop);
+                ROTTEN_ITEMS_BY_TARGET = Collections.unmodifiableMap(byTarget);
+                ROTTEN_ITEMS = List.copyOf(items);
+        }
 
         private ModItems() {
         }
@@ -19,12 +50,24 @@ public final class ModItems {
                 return Registry.register(Registries.ITEM, new Identifier(GardenKingMod.MOD_ID, name), item);
         }
 
+        public static Item getRottenItemForCrop(Identifier cropId) {
+                return ROTTEN_ITEMS_BY_CROP.get(cropId);
+        }
+
+        public static Item getRottenItemForTarget(Identifier targetId) {
+                return ROTTEN_ITEMS_BY_TARGET.get(targetId);
+        }
+
+        public static Collection<Item> getRottenItems() {
+                return ROTTEN_ITEMS;
+        }
+
         public static void registerModItems() {
                 GardenKingMod.LOGGER.info("Registering mod items for {}", GardenKingMod.MOD_ID);
                 ItemGroupEvents.modifyEntriesEvent(ItemGroups.INGREDIENTS)
                                 .register(entries -> {
                                         entries.add(GARDEN_COIN);
-                                        entries.add(ROTTEN_WHEAT);
+                                        ROTTEN_ITEMS.forEach(entries::add);
                                 });
         }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/crop/RottenCropDefinition.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/RottenCropDefinition.java
@@ -1,0 +1,124 @@
+package net.jeremy.gardenkingmod.crop;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+
+import net.minecraft.util.Identifier;
+
+/**
+ * Captures the data needed to register a rotten crop item and generate the
+ * resources that power {@link RottenHarvestManager}.
+ */
+public record RottenCropDefinition(
+                Identifier cropId,
+                Identifier targetId,
+                Identifier lootTableId,
+                String rottenItemPath,
+                float extraNoDropChance,
+                float extraRottenChance) {
+        private static final String[] NAME_SUFFIXES = new String[] { "_crop", "_plant", "_bush", "_stem", "_block",
+                        "_leaves", "_vines", "_vine", "_sapling", "_buds", "_bud", "_roots" };
+
+        public RottenCropDefinition {
+                Objects.requireNonNull(cropId, "cropId");
+                Objects.requireNonNull(targetId, "targetId");
+                Objects.requireNonNull(lootTableId, "lootTableId");
+                Objects.requireNonNull(rottenItemPath, "rottenItemPath");
+        }
+
+        public RottenCropDefinition(Identifier cropId, Identifier targetId, Identifier lootTableId) {
+                this(cropId, targetId, lootTableId, defaultRottenItemPath(cropId), 0.0f, 0.0f);
+        }
+
+        public RottenCropDefinition(Identifier cropId, Identifier targetId, Identifier lootTableId,
+                        float extraNoDropChance, float extraRottenChance) {
+                this(cropId, targetId, lootTableId, defaultRottenItemPath(cropId), extraNoDropChance, extraRottenChance);
+        }
+
+        public Identifier rottenItemId() {
+                return new Identifier(GardenKingMod.MOD_ID, rottenItemPath);
+        }
+
+        public boolean hasExtraNoDropChance() {
+                return extraNoDropChance > 0.0f;
+        }
+
+        public boolean hasExtraRottenChance() {
+                return extraRottenChance > 0.0f;
+        }
+
+        public String displayName() {
+                return toDisplayName(cropId.getPath());
+        }
+
+        public static String toDisplayName(String path) {
+                String sanitized = sanitize(path);
+                String[] parts = sanitized.split("_");
+                StringBuilder builder = new StringBuilder();
+
+                for (String part : parts) {
+                        if (part.isEmpty()) {
+                                continue;
+                        }
+
+                        if (builder.length() > 0) {
+                                builder.append(' ');
+                        }
+
+                        String lower = part.toLowerCase(Locale.ROOT);
+                        builder.append(Character.toUpperCase(lower.charAt(0)));
+                        if (lower.length() > 1) {
+                                builder.append(lower.substring(1));
+                        }
+                }
+
+                if (builder.length() == 0) {
+                        return sanitize(path).replace('_', ' ');
+                }
+
+                return builder.toString();
+        }
+
+        private static String defaultRottenItemPath(Identifier cropId) {
+                return "rotten_" + cropId.getPath();
+        }
+
+        public static String sanitizedPath(String input) {
+                return sanitize(input);
+        }
+
+        private static String sanitize(String input) {
+                String sanitized = input;
+
+                for (String suffix : NAME_SUFFIXES) {
+                        if (sanitized.endsWith(suffix)) {
+                                sanitized = sanitized.substring(0, sanitized.length() - suffix.length());
+                                break;
+                        }
+                }
+
+                sanitized = sanitized.replaceAll("__+", "_");
+
+                if (sanitized.endsWith("ies")) {
+                        sanitized = sanitized.substring(0, sanitized.length() - 3) + "y";
+                } else if (sanitized.endsWith("oes")) {
+                        sanitized = sanitized.substring(0, sanitized.length() - 2);
+                } else if (sanitized.endsWith("ses")) {
+                        sanitized = sanitized.substring(0, sanitized.length() - 2);
+                } else if (sanitized.endsWith("s") && !sanitized.endsWith("ss") && !sanitized.endsWith("us")
+                                && !sanitized.endsWith("is")) {
+                        sanitized = sanitized.substring(0, sanitized.length() - 1);
+                }
+
+                sanitized = sanitized.replaceAll("^_+", "");
+                sanitized = sanitized.replaceAll("_+$", "");
+
+                if (sanitized.isEmpty()) {
+                        return input;
+                }
+
+                return sanitized;
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/crop/RottenCropDefinitions.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/RottenCropDefinitions.java
@@ -1,0 +1,194 @@
+package net.jeremy.gardenkingmod.crop;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.CocoaBlock;
+import net.minecraft.block.CropBlock;
+import net.minecraft.block.GourdBlock;
+import net.minecraft.block.NetherWartBlock;
+import net.minecraft.block.PitcherCropBlock;
+import net.minecraft.block.SweetBerryBushBlock;
+import net.minecraft.loot.LootTables;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.tag.BlockTags;
+import net.minecraft.util.Identifier;
+
+/**
+ * Builds the list of {@link RottenCropDefinition definitions} that power both
+ * runtime registration and data generation.
+ */
+public final class RottenCropDefinitions {
+        private static final List<RottenCropDefinition> ALL = createDefinitions();
+        private static final Map<Identifier, RottenCropDefinition> BY_TARGET = indexBy(RottenCropDefinition::targetId);
+        private static final Map<Identifier, RottenCropDefinition> BY_CROP = indexBy(RottenCropDefinition::cropId);
+        private static final Map<Identifier, RottenCropDefinition> BY_LOOT_TABLE = indexBy(RottenCropDefinition::lootTableId);
+        private static final Map<Identifier, RottenCropDefinition> BY_ROTTEN_ITEM = indexBy(RottenCropDefinition::rottenItemId);
+
+        private RottenCropDefinitions() {
+        }
+
+        public static List<RottenCropDefinition> all() {
+                return ALL;
+        }
+
+        public static Optional<RottenCropDefinition> findByTargetId(Identifier identifier) {
+                return Optional.ofNullable(BY_TARGET.get(identifier));
+        }
+
+        public static Optional<RottenCropDefinition> findByCropId(Identifier identifier) {
+                return Optional.ofNullable(BY_CROP.get(identifier));
+        }
+
+        public static Optional<RottenCropDefinition> findByLootTableId(Identifier identifier) {
+                return Optional.ofNullable(BY_LOOT_TABLE.get(identifier));
+        }
+
+        public static Optional<RottenCropDefinition> findByRottenItemId(Identifier identifier) {
+                return Optional.ofNullable(BY_ROTTEN_ITEM.get(identifier));
+        }
+
+        private static Map<Identifier, RottenCropDefinition> indexBy(
+                        Function<RottenCropDefinition, Identifier> keyExtractor) {
+                Map<Identifier, RottenCropDefinition> map = new LinkedHashMap<>();
+                for (RottenCropDefinition definition : ALL) {
+                        map.put(keyExtractor.apply(definition), definition);
+                }
+
+                return Collections.unmodifiableMap(map);
+        }
+
+        private static List<RottenCropDefinition> createDefinitions() {
+                Map<Identifier, RottenCropDefinition> definitionsByTarget = new LinkedHashMap<>();
+                Set<String> usedRottenPaths = new HashSet<>();
+
+                for (RottenCropDefinition definition : manualDefinitions()) {
+                        definitionsByTarget.put(definition.targetId(), definition);
+                        usedRottenPaths.add(definition.rottenItemId().getPath());
+                }
+
+                Map<Identifier, RottenCropOverride> overrides = createOverrides();
+
+                for (Identifier blockId : Registries.BLOCK.getIds()) {
+                        if (GardenKingMod.MOD_ID.equals(blockId.getNamespace())) {
+                                continue;
+                        }
+
+                        if (definitionsByTarget.containsKey(blockId)) {
+                                continue;
+                        }
+
+                        Block block = Registries.BLOCK.get(blockId);
+                        if (!isEligibleBlock(block, blockId)) {
+                                continue;
+                        }
+
+                        Identifier lootTableId = block.getLootTableId();
+                        if (LootTables.EMPTY.equals(lootTableId)) {
+                                continue;
+                        }
+
+                        RottenCropOverride override = overrides.get(blockId);
+                        Identifier targetId = override != null && override.targetId() != null ? override.targetId() : blockId;
+                        Identifier cropId = override != null && override.cropId() != null ? override.cropId()
+                                        : createCropIdentifier(blockId);
+                        Identifier resolvedLootTable = override != null && override.lootTableId() != null ? override.lootTableId()
+                                        : lootTableId;
+                        float extraNoDropChance = override != null ? override.extraNoDropChance() : 0.0f;
+                        float extraRottenChance = override != null ? override.extraRottenChance() : 0.0f;
+
+                        String rottenItemPath = uniqueRottenPath(cropId.getPath(), blockId, usedRottenPaths);
+                        usedRottenPaths.add(rottenItemPath);
+
+                        RottenCropDefinition definition = new RottenCropDefinition(cropId, targetId, resolvedLootTable,
+                                        rottenItemPath, extraNoDropChance, extraRottenChance);
+                        definitionsByTarget.put(targetId, definition);
+                }
+
+                List<RottenCropDefinition> definitions = new ArrayList<>(definitionsByTarget.values());
+                definitions.sort(Comparator.comparing(definition -> definition.rottenItemId().toString()));
+                return List.copyOf(definitions);
+        }
+
+        private static Identifier createCropIdentifier(Identifier blockId) {
+                String sanitizedPath = RottenCropDefinition.sanitizedPath(blockId.getPath());
+                if (sanitizedPath.isEmpty()) {
+                        sanitizedPath = blockId.getPath();
+                }
+
+                return new Identifier(blockId.getNamespace(), sanitizedPath);
+        }
+
+        private static String uniqueRottenPath(String basePath, Identifier blockId, Set<String> usedPaths) {
+                String candidate = "rotten_" + basePath;
+
+                if (usedPaths.contains(candidate)) {
+                        if (!"minecraft".equals(blockId.getNamespace())) {
+                                String namespaced = "rotten_" + blockId.getNamespace() + "_" + basePath;
+                                if (!usedPaths.contains(namespaced)) {
+                                        return namespaced;
+                                }
+                        }
+
+                        int attempt = 2;
+                        while (true) {
+                                String numbered = "rotten_" + basePath + "_" + attempt;
+                                if (!usedPaths.contains(numbered)) {
+                                        return numbered;
+                                }
+
+                                attempt++;
+                        }
+                }
+
+                return candidate;
+        }
+
+        private static boolean isEligibleBlock(Block block, Identifier blockId) {
+                if (block == null) {
+                        return false;
+                }
+
+                if (block.getDefaultState().isIn(BlockTags.CROPS)) {
+                        return true;
+                }
+
+                if (block instanceof CropBlock || block instanceof GourdBlock || block instanceof NetherWartBlock
+                                || block instanceof CocoaBlock || block instanceof SweetBerryBushBlock
+                                || block instanceof PitcherCropBlock) {
+                        return true;
+                }
+
+                String className = block.getClass().getName();
+                if (className.startsWith("com.epherical.croptopia.blocks.")
+                                && (className.endsWith("CroptopiaCropBlock") || className.endsWith("TallCropBlock")
+                                                || className.endsWith("LeafCropBlock"))) {
+                        return true;
+                }
+
+                return false;
+        }
+
+        private static List<RottenCropDefinition> manualDefinitions() {
+                return List.of();
+        }
+
+        private static Map<Identifier, RottenCropOverride> createOverrides() {
+                return Collections.emptyMap();
+        }
+
+        private record RottenCropOverride(Identifier cropId, Identifier targetId, Identifier lootTableId,
+                        float extraNoDropChance, float extraRottenChance) {
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/crop/RottenHarvestManager.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/RottenHarvestManager.java
@@ -13,6 +13,7 @@ import com.google.gson.JsonObject;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 
 import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.crop.RottenCropDefinitions;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
@@ -122,8 +123,15 @@ public final class RottenHarvestManager extends JsonDataLoader implements Identi
 
                         Optional<Item> itemOptional = Registries.ITEM.getOrEmpty(itemId);
                         if (itemOptional.isEmpty()) {
-                                GardenKingMod.LOGGER.warn("Unknown item {} referenced in {} for loot table {}", itemId, fileId, lootTableId);
+                                GardenKingMod.LOGGER.warn("Unknown item {} referenced in {} for loot table {}", itemId, fileId,
+                                                lootTableId);
                                 return null;
+                        }
+
+                        if (RottenCropDefinitions.findByRottenItemId(itemId).isEmpty()) {
+                                GardenKingMod.LOGGER.warn(
+                                                "Item {} referenced in {} for loot table {} is not a registered rotten crop",
+                                                itemId, fileId, lootTableId);
                         }
 
                         float extraNoDropChance = 0.0f;

--- a/src/main/java/net/jeremy/gardenkingmod/datagen/RottenHarvestJsonProvider.java
+++ b/src/main/java/net/jeremy/gardenkingmod/datagen/RottenHarvestJsonProvider.java
@@ -1,0 +1,59 @@
+package net.jeremy.gardenkingmod.datagen;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.gson.JsonObject;
+
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.crop.RottenCropDefinition;
+
+import net.minecraft.data.DataOutput;
+import net.minecraft.data.DataProvider;
+import net.minecraft.data.DataWriter;
+import net.minecraft.util.Identifier;
+
+/**
+ * Emits the rotten harvest configuration consumed by {@link GardenKingMod} at runtime.
+ */
+public final class RottenHarvestJsonProvider implements DataProvider {
+        private final FabricDataOutput dataOutput;
+        private final List<RottenCropDefinition> definitions;
+
+        public RottenHarvestJsonProvider(FabricDataOutput dataOutput, List<RottenCropDefinition> definitions) {
+                this.dataOutput = dataOutput;
+                this.definitions = definitions;
+        }
+
+        @Override
+        public CompletableFuture<?> run(DataWriter writer) {
+                JsonObject root = new JsonObject();
+
+                definitions.forEach(definition -> {
+                        JsonObject entry = new JsonObject();
+                        entry.addProperty("rotten_item", definition.rottenItemId().toString());
+
+                        if (definition.hasExtraNoDropChance()) {
+                                entry.addProperty("extra_no_drop_chance", definition.extraNoDropChance());
+                        }
+
+                        if (definition.hasExtraRottenChance()) {
+                                entry.addProperty("extra_rotten_chance", definition.extraRottenChance());
+                        }
+
+                        root.add(definition.targetId().toString(), entry);
+                });
+
+                DataOutput.PathResolver resolver = dataOutput.getResolver(DataOutput.OutputType.DATA_PACK, "rotten_harvest");
+                Path path = resolver.resolveJson(new Identifier(GardenKingMod.MOD_ID, "rotten_harvest"));
+                return DataProvider.writeToPath(writer, root, path);
+        }
+
+        @Override
+        public String getName() {
+                return "Garden King Rotten Harvest";
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/datagen/RottenItemModelProvider.java
+++ b/src/main/java/net/jeremy/gardenkingmod/datagen/RottenItemModelProvider.java
@@ -1,0 +1,41 @@
+package net.jeremy.gardenkingmod.datagen;
+
+import java.util.List;
+
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricModelProvider;
+
+import net.jeremy.gardenkingmod.ModItems;
+import net.jeremy.gardenkingmod.crop.RottenCropDefinition;
+
+import net.minecraft.data.client.BlockStateModelGenerator;
+import net.minecraft.data.client.ItemModelGenerator;
+import net.minecraft.data.client.Models;
+import net.minecraft.item.Item;
+
+/**
+ * Generates simple generated item models for every rotten crop item.
+ */
+public final class RottenItemModelProvider extends FabricModelProvider {
+        private final List<RottenCropDefinition> definitions;
+
+        public RottenItemModelProvider(FabricDataOutput dataOutput, List<RottenCropDefinition> definitions) {
+                super(dataOutput);
+                this.definitions = definitions;
+        }
+
+        @Override
+        public void generateBlockStateModels(BlockStateModelGenerator blockStateModelGenerator) {
+                // No block states are required for rotten items.
+        }
+
+        @Override
+        public void generateItemModels(ItemModelGenerator itemModelGenerator) {
+                definitions.forEach(definition -> {
+                        Item rottenItem = ModItems.getRottenItemForTarget(definition.targetId());
+                        if (rottenItem != null) {
+                                itemModelGenerator.register(rottenItem, Models.GENERATED);
+                        }
+                });
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/datagen/RottenLanguageProvider.java
+++ b/src/main/java/net/jeremy/gardenkingmod/datagen/RottenLanguageProvider.java
@@ -1,0 +1,26 @@
+package net.jeremy.gardenkingmod.datagen;
+
+import java.util.List;
+
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider;
+
+import net.jeremy.gardenkingmod.crop.RottenCropDefinition;
+
+/**
+ * Writes English translations for each generated rotten crop item.
+ */
+public final class RottenLanguageProvider extends FabricLanguageProvider {
+        private final List<RottenCropDefinition> definitions;
+
+        public RottenLanguageProvider(FabricDataOutput dataOutput, List<RottenCropDefinition> definitions) {
+                super(dataOutput);
+                this.definitions = definitions;
+        }
+
+        @Override
+        public void generateTranslations(TranslationBuilder translationBuilder) {
+                definitions.forEach(definition -> translationBuilder.add(definition.rottenItemId(),
+                                "Rotten " + definition.displayName()));
+        }
+}


### PR DESCRIPTION
## Summary
- introduce a shared rotten crop definition list that registers every rotten item at runtime
- generate rotten harvest data, language entries, and item models from those definitions via Fabric datagen
- point Gradle at the generated resources directory and drop the hand-authored rotten harvest JSON

## Testing
- `./gradlew runDatagen` *(fails: asset download retry limit)*
- `./gradlew --offline runDatagen` *(fails: asset download retry limit)*
- `./gradlew --offline compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68cdc6b384b08321ab01805258b8cd1b