### PR TITLE
Make rotten crop definitions and items reloadable

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModDataGenerator.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModDataGenerator.java
@@ -14,14 +14,17 @@ import net.jeremy.gardenkingmod.datagen.RottenLanguageProvider;
 import net.jeremy.gardenkingmod.ModItems;
 
 public class GardenKingModDataGenerator implements DataGeneratorEntrypoint {
-        @Override
-        public void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator) {
-                FabricDataGenerator.Pack pack = fabricDataGenerator.createPack();
-                ModItems.getRottenItems();
-                List<RottenCropDefinition> definitions = RottenCropDefinitions.all();
+	@Override
+	public void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator) {
+		FabricDataGenerator.Pack pack = fabricDataGenerator.createPack();
+		RottenCropDefinitions.reload();
+		if (!ModItems.initializeRottenItems()) {
+			GardenKingMod.LOGGER.warn("No rotten crop definitions were available during data generation");
+		}
+		List<RottenCropDefinition> definitions = RottenCropDefinitions.all();
 
-                pack.addProvider((FabricDataOutput output) -> new RottenItemModelProvider(output, definitions));
-                pack.addProvider((FabricDataOutput output) -> new RottenLanguageProvider(output, definitions));
-                pack.addProvider((FabricDataOutput output) -> new RottenHarvestJsonProvider(output, definitions));
-        }
+		pack.addProvider((FabricDataOutput output) -> new RottenItemModelProvider(output, definitions));
+		pack.addProvider((FabricDataOutput output) -> new RottenLanguageProvider(output, definitions));
+		pack.addProvider((FabricDataOutput output) -> new RottenHarvestJsonProvider(output, definitions));
+	}
 }

--- a/src/main/java/net/jeremy/gardenkingmod/crop/RottenCropDefinitions.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/RottenCropDefinitions.java
@@ -30,46 +30,72 @@ import net.minecraft.util.Identifier;
  * runtime registration and data generation.
  */
 public final class RottenCropDefinitions {
-        private static final List<RottenCropDefinition> ALL = createDefinitions();
-        private static final Map<Identifier, RottenCropDefinition> BY_TARGET = indexBy(RottenCropDefinition::targetId);
-        private static final Map<Identifier, RottenCropDefinition> BY_CROP = indexBy(RottenCropDefinition::cropId);
-        private static final Map<Identifier, RottenCropDefinition> BY_LOOT_TABLE = indexBy(RottenCropDefinition::lootTableId);
-        private static final Map<Identifier, RottenCropDefinition> BY_ROTTEN_ITEM = indexBy(RottenCropDefinition::rottenItemId);
+	private static List<RottenCropDefinition> allDefinitions = List.of();
+	private static Map<Identifier, RottenCropDefinition> definitionsByTarget = Map.of();
+	private static Map<Identifier, RottenCropDefinition> definitionsByCrop = Map.of();
+	private static Map<Identifier, RottenCropDefinition> definitionsByLootTable = Map.of();
+	private static Map<Identifier, RottenCropDefinition> definitionsByRottenItem = Map.of();
+	private static boolean initialized;
 
-        private RottenCropDefinitions() {
-        }
+	private RottenCropDefinitions() {
+	}
 
-        public static List<RottenCropDefinition> all() {
-                return ALL;
-        }
+	public static List<RottenCropDefinition> all() {
+		ensureLoaded();
+		return allDefinitions;
+	}
 
-        public static Optional<RottenCropDefinition> findByTargetId(Identifier identifier) {
-                return Optional.ofNullable(BY_TARGET.get(identifier));
-        }
+	public static boolean hasDefinitions() {
+		return initialized && !allDefinitions.isEmpty();
+	}
 
-        public static Optional<RottenCropDefinition> findByCropId(Identifier identifier) {
-                return Optional.ofNullable(BY_CROP.get(identifier));
-        }
+	public static Optional<RottenCropDefinition> findByTargetId(Identifier identifier) {
+		ensureLoaded();
+		return Optional.ofNullable(definitionsByTarget.get(identifier));
+	}
 
-        public static Optional<RottenCropDefinition> findByLootTableId(Identifier identifier) {
-                return Optional.ofNullable(BY_LOOT_TABLE.get(identifier));
-        }
+	public static Optional<RottenCropDefinition> findByCropId(Identifier identifier) {
+		ensureLoaded();
+		return Optional.ofNullable(definitionsByCrop.get(identifier));
+	}
 
-        public static Optional<RottenCropDefinition> findByRottenItemId(Identifier identifier) {
-                return Optional.ofNullable(BY_ROTTEN_ITEM.get(identifier));
-        }
+	public static Optional<RottenCropDefinition> findByLootTableId(Identifier identifier) {
+		ensureLoaded();
+		return Optional.ofNullable(definitionsByLootTable.get(identifier));
+	}
 
-        private static Map<Identifier, RottenCropDefinition> indexBy(
-                        Function<RottenCropDefinition, Identifier> keyExtractor) {
-                Map<Identifier, RottenCropDefinition> map = new LinkedHashMap<>();
-                for (RottenCropDefinition definition : ALL) {
-                        map.put(keyExtractor.apply(definition), definition);
-                }
+	public static Optional<RottenCropDefinition> findByRottenItemId(Identifier identifier) {
+		ensureLoaded();
+		return Optional.ofNullable(definitionsByRottenItem.get(identifier));
+	}
 
-                return Collections.unmodifiableMap(map);
-        }
+	public static synchronized void reload() {
+		List<RottenCropDefinition> definitions = createDefinitions();
+		allDefinitions = definitions;
+		definitionsByTarget = indexBy(definitions, RottenCropDefinition::targetId);
+		definitionsByCrop = indexBy(definitions, RottenCropDefinition::cropId);
+		definitionsByLootTable = indexBy(definitions, RottenCropDefinition::lootTableId);
+		definitionsByRottenItem = indexBy(definitions, RottenCropDefinition::rottenItemId);
+		initialized = true;
+	}
 
-        private static List<RottenCropDefinition> createDefinitions() {
+	private static void ensureLoaded() {
+		if (!initialized) {
+			reload();
+		}
+	}
+
+	private static Map<Identifier, RottenCropDefinition> indexBy(List<RottenCropDefinition> definitions,
+			Function<RottenCropDefinition, Identifier> keyExtractor) {
+		Map<Identifier, RottenCropDefinition> map = new LinkedHashMap<>();
+		for (RottenCropDefinition definition : definitions) {
+			map.put(keyExtractor.apply(definition), definition);
+		}
+
+		return Collections.unmodifiableMap(map);
+	}
+
+	private static List<RottenCropDefinition> createDefinitions() {
                 Map<Identifier, RottenCropDefinition> definitionsByTarget = new LinkedHashMap<>();
                 Set<String> usedRottenPaths = new HashSet<>();
 


### PR DESCRIPTION
## Summary
- delay rotten crop definition creation until explicitly reloaded so the registry is populated before building indexes
- lazily register rotten items based on the refreshed definition list and avoid attempting registration when none are found
- refresh definitions and item registration in the data generator before wiring providers

## Testing
- ./gradlew runDatagen *(fails: net.fabricmc.loom.util.download.DownloadException: Failed download after 3 attempts)*

------
https://chatgpt.com/codex/tasks/task_e_68cde3e312888321bee1d36fab9936b3