### PR TITLE
Ensure rotten harvest datagen always outputs extra chances

### DIFF
--- a/src/main/generated/data/gardenkingmod/rotten_harvest/rotten_harvest.json
+++ b/src/main/generated/data/gardenkingmod/rotten_harvest/rotten_harvest.json
@@ -1,0 +1,7 @@
+{
+  "minecraft:wheat": {
+    "rotten_item": "minecraft:rotten_flesh",
+    "extra_no_drop_chance": 0.05,
+    "extra_rotten_chance": 0.1
+  }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/datagen/RottenHarvestJsonProvider.java
+++ b/src/main/java/net/jeremy/gardenkingmod/datagen/RottenHarvestJsonProvider.java
@@ -36,13 +36,8 @@ public final class RottenHarvestJsonProvider implements DataProvider {
                         JsonObject entry = new JsonObject();
                         entry.addProperty("rotten_item", definition.rottenItemId().toString());
 
-                        if (definition.hasExtraNoDropChance()) {
-                                entry.addProperty("extra_no_drop_chance", definition.extraNoDropChance());
-                        }
-
-                        if (definition.hasExtraRottenChance()) {
-                                entry.addProperty("extra_rotten_chance", definition.extraRottenChance());
-                        }
+                        entry.addProperty("extra_no_drop_chance", definition.extraNoDropChance());
+                        entry.addProperty("extra_rotten_chance", definition.extraRottenChance());
 
                         root.add(definition.targetId().toString(), entry);
                 });


### PR DESCRIPTION
## Summary
- update `RottenHarvestJsonProvider` so extra chance fields are always emitted
- refresh the generated rotten harvest data file

## Testing
- ./gradlew runDatagen *(fails: dependency downloads are blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce432091cc83219ae65186d8b80903