### PR TITLE
Load rotten crop definitions from JSON

### DIFF
--- a/src/main/resources/data/gardenkingmod/rotten_crops.json
+++ b/src/main/resources/data/gardenkingmod/rotten_crops.json
@@ -1,0 +1,9 @@
+{
+  "entries": [
+    {
+      "target": "minecraft:wheat",
+      "crop": "minecraft:wheat",
+      "rotten_item": "gardenkingmod:rotten_wheat"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- read rotten crop registrations from a curated JSON resource instead of scanning every crop
- validate manual entries and reuse them for runtime registration and data generation
- add a starter `rotten_crops.json` that registers `gardenkingmod:rotten_wheat`

## Testing
- `./gradlew runDatagen` *(fails: net.fabricmc.loom.util.download.DownloadException: Failed download after 3 attempts)*

------
https://chatgpt.com/codex/tasks/task_e_68ce62d6bf888321831a63a014c8e1fb