### PR TITLE
Enable debug logging for runClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ fabricApi {
 
 loom {
         runs {
+                client {
+                        client()
+                        vmArg "-Dfabric.log.level=debug"
+                }
                 gametest {
                         server()
                         name "Game Test"


### PR DESCRIPTION
## Summary
- configure the Loom client run configuration to pass `-Dfabric.log.level=debug` so runClient sessions capture loot-table debug logging

## Testing
- not run (configuration update only)


------
https://chatgpt.com/codex/tasks/task_e_68cee75a9ad88321b860d89959521db4