### PR TITLE
Handle shared loot tables when resolving crop tiers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ fabricApi {
 
 loom {
         runs {
+                client {
+                        client()
+                        vmArg "-Dfabric.log.level=debug"
+                }
                 gametest {
                         server()
                         name "Game Test"

--- a/src/main/java/net/jeremy/gardenkingmod/crop/CropDropModifier.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/CropDropModifier.java
@@ -148,6 +148,8 @@ public final class CropDropModifier {
         }
 
         private static Optional<TierScalingData> lookupScalingData(Identifier lootTableId) {
+                List<Identifier> matchingBlocks = new ArrayList<>();
+
                 for (Block block : Registries.BLOCK) {
                         Identifier blockLootTable = block.getLootTableId();
                         if (LootTables.EMPTY.equals(blockLootTable)) {
@@ -159,14 +161,19 @@ public final class CropDropModifier {
                         }
 
                         Identifier blockId = Registries.BLOCK.getId(block);
+                        matchingBlocks.add(blockId);
+
                         Optional<CropTier> tier = CropTierRegistry.get(block.getDefaultState());
 
                         if (tier.isPresent()) {
                                 return Optional.of(new TierScalingData(blockId, tier.get()));
                         }
+                }
 
-                        GardenKingMod.LOGGER.debug("Loot table {} (block {}) is not assigned to a crop tier; using vanilla drop counts", lootTableId, blockId);
-                        return Optional.empty();
+                if (!matchingBlocks.isEmpty()) {
+                        GardenKingMod.LOGGER.debug(
+                                        "Loot table {} is not assigned to a crop tier; using vanilla drop counts (owners: {})",
+                                        lootTableId, matchingBlocks);
                 }
 
                 return Optional.empty();


### PR DESCRIPTION
## Summary
- continue scanning every block that shares a loot table before falling back to vanilla behaviour
- log the complete set of matching blocks when no crop tier can be resolved

## Testing
- `./gradlew build` *(fails: Could not download LWJGL dependencies from Maven Central — HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cee75a9ad88321b860d89959521db4