### PR TITLE
Handle shared loot tables when resolving crop tiers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ fabricApi {
 
 loom {
         runs {
+                client {
+                        client()
+                        vmArg "-Dfabric.log.level=debug"
+                }
                 gametest {
                         server()
                         name "Game Test"

--- a/src/main/java/net/jeremy/gardenkingmod/crop/CropDropModifier.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/CropDropModifier.java
@@ -148,6 +148,8 @@ public final class CropDropModifier {
         }
 
         private static Optional<TierScalingData> lookupScalingData(Identifier lootTableId) {
+                List<Identifier> matchingBlocks = new ArrayList<>();
+
                 for (Block block : Registries.BLOCK) {
                         Identifier blockLootTable = block.getLootTableId();
                         if (LootTables.EMPTY.equals(blockLootTable)) {
@@ -159,14 +161,19 @@ public final class CropDropModifier {
                         }
 
                         Identifier blockId = Registries.BLOCK.getId(block);
+                        matchingBlocks.add(blockId);
+
                         Optional<CropTier> tier = CropTierRegistry.get(block.getDefaultState());
 
                         if (tier.isPresent()) {
                                 return Optional.of(new TierScalingData(blockId, tier.get()));
                         }
+                }
 
-                        GardenKingMod.LOGGER.debug("Loot table {} (block {}) is not assigned to a crop tier; using vanilla drop counts", lootTableId, blockId);
-                        return Optional.empty();
+                if (!matchingBlocks.isEmpty()) {
+                        GardenKingMod.LOGGER.debug(
+                                        "Loot table {} is not assigned to a crop tier; using vanilla drop counts (owners: {})",
+                                        lootTableId, matchingBlocks);
                 }
 
                 return Optional.empty();

--- a/src/main/java/net/jeremy/gardenkingmod/crop/CropTierRegistry.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/CropTierRegistry.java
@@ -66,23 +66,13 @@ public final class CropTierRegistry {
                         return Optional.empty();
                 }
 
-                if (state.isIn(TIER_1)) {
-                        return get(TIER_1_ID);
-                }
-                if (state.isIn(TIER_2)) {
-                        return get(TIER_2_ID);
-                }
-                if (state.isIn(TIER_3)) {
-                        return get(TIER_3_ID);
-                }
-                if (state.isIn(TIER_4)) {
-                        return get(TIER_4_ID);
-                }
-                if (state.isIn(TIER_5)) {
-                        return get(TIER_5_ID);
+                Optional<CropTier> tier = resolveTier(state::isIn);
+                if (tier.isPresent()) {
+                        return tier;
                 }
 
-                return Optional.empty();
+                RegistryEntry<Block> entry = Registries.BLOCK.getEntry(state.getBlock());
+                return resolveTier(entry::isIn);
         }
 
         public static Optional<CropTier> get(Item item) {
@@ -151,5 +141,30 @@ public final class CropTierRegistry {
                 // Ensure the returned value still results in at least one random tick in
                 // reasonable time to keep hydration/bonemeal behaviour intact.
                 return Math.max(0.001f, scaledChance);
+        }
+
+        private static Optional<CropTier> resolveTier(TierMembership membership) {
+                if (membership.isIn(TIER_1)) {
+                        return get(TIER_1_ID);
+                }
+                if (membership.isIn(TIER_2)) {
+                        return get(TIER_2_ID);
+                }
+                if (membership.isIn(TIER_3)) {
+                        return get(TIER_3_ID);
+                }
+                if (membership.isIn(TIER_4)) {
+                        return get(TIER_4_ID);
+                }
+                if (membership.isIn(TIER_5)) {
+                        return get(TIER_5_ID);
+                }
+
+                return Optional.empty();
+        }
+
+        @FunctionalInterface
+        private interface TierMembership {
+                boolean isIn(TagKey<Block> tag);
         }
 }


### PR DESCRIPTION
## Summary
- fall back to resolving crop tiers through a block's registry entry tags when the block state is not yet bound
- centralize the tier tag checks to reuse them for both block states and registry entry lookups

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68cee75a9ad88321b860d89959521db4