### PR TITLE
Precompute crop tier block lookup

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/crop/CropDropModifier.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/CropDropModifier.java
@@ -189,7 +189,7 @@ public final class CropDropModifier {
                         Identifier blockId = Registries.BLOCK.getId(block);
                         matchingBlocks.add(blockId);
 
-                        Optional<CropTier> tier = CropTierRegistry.get(block.getDefaultState());
+                        Optional<CropTier> tier = CropTierRegistry.get(block);
 
                         if (tier.isPresent()) {
                                 return Optional.of(new TierScalingData(blockId, tier.get()));


### PR DESCRIPTION
## Summary
- register a server data reload listener that rebuilds a block-to-tier cache after tags load
- expose lookup helpers that use the cache for block and item tier resolution
- update the crop drop modifier to rely on the cached lookup during loot table processing

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68cf9a9404588321b6e671a483ef514c