### PR TITLE
Ensure crop tier lookup rebuild runs before loot modification

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/crop/CropDropModifier.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/CropDropModifier.java
@@ -53,6 +53,8 @@ public final class CropDropModifier {
 
         public static void register() {
                 LootTableEvents.MODIFY.register((resourceManager, lootManager, id, tableBuilder, source) -> {
+                        CropTierRegistry.ensureBlockLookup(resourceManager);
+
                         BonusHarvestDropManager bonusManager = BonusHarvestDropManager.getInstance();
 
                         bonusManager.ensureLoaded(resourceManager);


### PR DESCRIPTION
## Summary
- track the last resource manager and rebuild the crop tier lookup when needed before loot processing
- ensure the loot table modifier requests the lookup before computing tier scaling

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cfa444ff148321b63aeec469e7348a