### PR TITLE
Use rotten crop definitions for item model generation

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/datagen/RottenItemModelProvider.java
+++ b/src/main/java/net/jeremy/gardenkingmod/datagen/RottenItemModelProvider.java
@@ -5,13 +5,13 @@ import java.util.List;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricModelProvider;
 
-import net.jeremy.gardenkingmod.ModItems;
 import net.jeremy.gardenkingmod.crop.RottenCropDefinition;
 
 import net.minecraft.data.client.BlockStateModelGenerator;
 import net.minecraft.data.client.ItemModelGenerator;
 import net.minecraft.data.client.Models;
-import net.minecraft.item.Item;
+import net.minecraft.data.client.TextureMap;
+import net.minecraft.util.Identifier;
 
 /**
  * Generates simple generated item models for every rotten crop item.
@@ -32,10 +32,11 @@ public final class RottenItemModelProvider extends FabricModelProvider {
         @Override
         public void generateItemModels(ItemModelGenerator itemModelGenerator) {
                 definitions.forEach(definition -> {
-                        Item rottenItem = ModItems.getRottenItemForTarget(definition.targetId());
-                        if (rottenItem != null) {
-                                itemModelGenerator.register(rottenItem, Models.GENERATED);
-                        }
+                        Identifier rottenItemId = definition.rottenItemId();
+                        Identifier textureId = new Identifier(rottenItemId.getNamespace(),
+                                        "item/" + rottenItemId.getPath());
+                        Models.GENERATED.upload(rottenItemId, TextureMap.layer0(textureId),
+                                        itemModelGenerator.writer);
                 });
         }
 }


### PR DESCRIPTION
## Summary
- build each rotten crop item model directly from the crop definitions instead of consulting the runtime item registry
- upload generated item models with the expected rotten item textures via the shared model writer

## Testing
- `./gradlew runDatagen` *(fails: downloadAssets cannot reach required resources in this environment)*
- `./gradlew runDatagen -x downloadAssets` *(fails: dependency downloads are blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0611602e883218effb6b130d3a84c