### PR TITLE
Generate translations for rotten crops via datagen

### DIFF
--- a/src/main/generated/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/generated/assets/gardenkingmod/lang/en_us.json
@@ -18,6 +18,8 @@
   "tooltip.gardenkingmod.crop_tier.tier_3": "Tier 3",
   "tooltip.gardenkingmod.crop_tier.tier_4": "Tier 4",
   "tooltip.gardenkingmod.crop_tier.tier_5": "Tier 5",
-  "item.gardenkingmod.rotten_wheat": "Rotten Wheat",
-  "item.gardenkingmod.rotten_carrot": "Rotten Carrot"
+  "item.gardenkingmod.rotten_carrot": "Rotten Carrot",
+  "item.gardenkingmod.rotten_potato": "Rotten Potato",
+  "item.gardenkingmod.rotten_tomato": "Rotten Tomato",
+  "item.gardenkingmod.rotten_wheat": "Rotten Wheat"
 }

--- a/src/main/java/net/jeremy/gardenkingmod/datagen/RottenLanguageProvider.java
+++ b/src/main/java/net/jeremy/gardenkingmod/datagen/RottenLanguageProvider.java
@@ -20,6 +20,31 @@ public final class RottenLanguageProvider extends FabricLanguageProvider {
 
     @Override
     public void generateTranslations(TranslationBuilder translationBuilder) {
+                translationBuilder.add("block.gardenkingmod.market_block", "Garden Market");
+                translationBuilder.add("item.gardenkingmod.garden_coin", "Garden Coin");
+                translationBuilder.add("container.gardenkingmod.market", "Garden Market");
+                translationBuilder.add("screen.gardenkingmod.market.sell", "Sell");
+                translationBuilder.add("screen.gardenkingmod.market.sale_result",
+                                "You sold %1$s crops and earned %2$s garden coins.");
+                translationBuilder.add("screen.gardenkingmod.market.sale_result_detailed",
+                                "You sold %1$s and earned %2$s garden coins.");
+                translationBuilder.add("screen.gardenkingmod.market.sale_result_item", "%1$s %2$s");
+                translationBuilder.add("screen.gardenkingmod.market.lifetime",
+                                "Lifetime earnings: %1$s garden coins.");
+                translationBuilder.add("message.gardenkingmod.market.sold",
+                                "Sold %1$s Croptopia crops for %2$s coins.");
+                translationBuilder.add("message.gardenkingmod.market.sold.lifetime",
+                                "Sold %1$s Croptopia crops for %2$s coins. Lifetime earnings: %3$s coins.");
+                translationBuilder.add("message.gardenkingmod.market.empty", "There are no crops to sell.");
+                translationBuilder.add("message.gardenkingmod.market.invalid", "Only Crops and Food can be sold here!");
+                translationBuilder.add("scoreboard.gardenkingmod.garden_currency", "Garden Coins");
+                translationBuilder.add("tooltip.gardenkingmod.crop_tier", "Tier: %s");
+                translationBuilder.add("tooltip.gardenkingmod.crop_tier.tier_1", "Tier 1");
+                translationBuilder.add("tooltip.gardenkingmod.crop_tier.tier_2", "Tier 2");
+                translationBuilder.add("tooltip.gardenkingmod.crop_tier.tier_3", "Tier 3");
+                translationBuilder.add("tooltip.gardenkingmod.crop_tier.tier_4", "Tier 4");
+                translationBuilder.add("tooltip.gardenkingmod.crop_tier.tier_5", "Tier 5");
+
                 definitions.forEach(definition -> translationBuilder.add(
                         definition.rottenItemId().toTranslationKey("item"),
                         "Rotten " + definition.displayName()));


### PR DESCRIPTION
## Summary
- add the existing market UI and tooltip strings to the RottenLanguageProvider so they are emitted during datagen
- move the English language file under `src/main/generated` so the generated translations cover both static and rotten crop entries

## Testing
- `./gradlew runDatagen` *(fails: net.fabricmc.loom.util.download.DownloadException: Failed download after 3 attempts)*
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68d06d05e0b483219e45501bd5a8b615