### PR TITLE
Display Ruby Hoe fortune level

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/item/FortuneHoeItem.java
+++ b/src/main/java/net/jeremy/gardenkingmod/item/FortuneHoeItem.java
@@ -1,8 +1,16 @@
 package net.jeremy.gardenkingmod.item;
 
+import java.util.List;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.client.item.TooltipContext;
 import net.minecraft.item.HoeItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolMaterial;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.world.World;
 
 /**
  * A hoe item that provides a built-in fortune level without requiring an enchantment.
@@ -19,5 +27,13 @@ public class FortuneHoeItem extends HoeItem implements FortuneProvidingItem {
         @Override
         public int gardenkingmod$getFortuneLevel(ItemStack stack) {
                 return fortuneLevel;
+        }
+
+        @Override
+        public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+                super.appendTooltip(stack, world, tooltip, context);
+                tooltip.add(Text.translatable("tooltip.gardenkingmod.built_in_fortune",
+                                Text.translatable("enchantment.minecraft.fortune"),
+                                Text.translatable("enchantment.level." + fortuneLevel)).formatted(Formatting.GRAY));
         }
 }

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -27,6 +27,7 @@
   "screen.gardenkingmod.market.sale_result_item": "%1$s %2$s",
   "screen.gardenkingmod.market.sell": "Sell",
   "tooltip.gardenkingmod.crop_tier": "Tier: %s",
+  "tooltip.gardenkingmod.built_in_fortune": "Built-in %s %s",
   "tooltip.gardenkingmod.crop_tier.tier_1": "Tier 1",
   "tooltip.gardenkingmod.crop_tier.tier_2": "Tier 2",
   "tooltip.gardenkingmod.crop_tier.tier_3": "Tier 3",


### PR DESCRIPTION
## Summary
- show the built-in fortune level on fortune-providing hoes via an item tooltip
- add a translation string for the new tooltip text

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d4512259988321bc45b66e56a03769