### PR TITLE
Fix fortune tooltip registration on client

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -10,6 +10,7 @@ import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.jeremy.gardenkingmod.client.model.MarketBlockModel;
 import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
+import net.jeremy.gardenkingmod.item.FortuneProvidingItem;
 import net.jeremy.gardenkingmod.network.ModPackets;
 import net.jeremy.gardenkingmod.screen.MarketScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreens;
@@ -55,14 +56,25 @@ public class GardenKingModClient implements ClientModInitializer {
                         });
                 });
 
-        ItemTooltipCallback.EVENT.register((stack, context, lines) -> CropTierRegistry.get(stack.getItem())
-                .ifPresent(tier -> {
+        ItemTooltipCallback.EVENT.register((stack, context, lines) -> {
+                if (stack.getItem() instanceof FortuneProvidingItem fortuneItem) {
+                        int fortuneLevel = fortuneItem.gardenkingmod$getFortuneLevel(stack);
+                        if (fortuneLevel > 0) {
+                                lines.add(Text.translatable("tooltip." + GardenKingMod.MOD_ID + ".built_in_fortune",
+                                                Text.translatable("enchantment.minecraft.fortune"),
+                                                Text.translatable("enchantment.level." + fortuneLevel))
+                                                .formatted(Formatting.GRAY));
+                        }
+                }
+
+                CropTierRegistry.get(stack.getItem()).ifPresent(tier -> {
                         String path = tier.id().getPath();
                         String suffix = path.contains("/") ? path.substring(path.lastIndexOf('/') + 1) : path;
                         Text tierName = Text
                                         .translatable("tooltip." + tier.id().getNamespace() + ".crop_tier." + suffix);
                         lines.add(Text.translatable("tooltip." + GardenKingMod.MOD_ID + ".crop_tier", tierName)
                                         .formatted(Formatting.GREEN));
-                }));
+                });
+        });
     }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/item/FortuneHoeItem.java
+++ b/src/main/java/net/jeremy/gardenkingmod/item/FortuneHoeItem.java
@@ -8,16 +8,16 @@ import net.minecraft.item.ToolMaterial;
  * A hoe item that provides a built-in fortune level without requiring an enchantment.
  */
 public class FortuneHoeItem extends HoeItem implements FortuneProvidingItem {
-        private final int fortuneLevel;
+    private final int fortuneLevel;
 
-        public FortuneHoeItem(ToolMaterial toolMaterial, int attackDamage, float attackSpeed, Settings settings,
-                        int fortuneLevel) {
-                super(toolMaterial, attackDamage, attackSpeed, settings);
-                this.fortuneLevel = fortuneLevel;
-        }
+    public FortuneHoeItem(ToolMaterial toolMaterial, int attackDamage, float attackSpeed, Settings settings,
+            int fortuneLevel) {
+        super(toolMaterial, attackDamage, attackSpeed, settings);
+        this.fortuneLevel = fortuneLevel;
+    }
 
-        @Override
-        public int gardenkingmod$getFortuneLevel(ItemStack stack) {
-                return fortuneLevel;
-        }
+    @Override
+    public int gardenkingmod$getFortuneLevel(ItemStack stack) {
+        return fortuneLevel;
+    }
 }

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -27,6 +27,7 @@
   "screen.gardenkingmod.market.sale_result_item": "%1$s %2$s",
   "screen.gardenkingmod.market.sell": "Sell",
   "tooltip.gardenkingmod.crop_tier": "Tier: %s",
+  "tooltip.gardenkingmod.built_in_fortune": "Built-in %s %s",
   "tooltip.gardenkingmod.crop_tier.tier_1": "Tier 1",
   "tooltip.gardenkingmod.crop_tier.tier_2": "Tier 2",
   "tooltip.gardenkingmod.crop_tier.tier_3": "Tier 3",


### PR DESCRIPTION
## Summary
- move the built-in fortune tooltip logic into the client ItemTooltipCallback to avoid server-only dependencies
- keep FortuneHoeItem free of client-only classes while still exposing its built-in fortune level

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d4512259988321bc45b66e56a03769