### PR TITLE
Add scarecrow warding block with aura and flee goal

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -13,6 +13,7 @@ import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.item.FortuneProvidingItem;
 import net.jeremy.gardenkingmod.network.ModPackets;
 import net.jeremy.gardenkingmod.screen.MarketScreen;
+import net.jeremy.gardenkingmod.screen.ScarecrowScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactories;
 import net.minecraft.item.Item;
@@ -25,6 +26,7 @@ public class GardenKingModClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         HandledScreens.register(ModScreenHandlers.MARKET_SCREEN_HANDLER, MarketScreen::new);
+        HandledScreens.register(ModScreenHandlers.SCARECROW_SCREEN_HANDLER, ScarecrowScreen::new);
         EntityModelLayerRegistry.registerModelLayer(MarketBlockModel.LAYER_LOCATION, MarketBlockModel::getTexturedModelData);
         BlockEntityRendererFactories.register(ModBlockEntities.MARKET_BLOCK_ENTITY, MarketBlockEntityRenderer::new);
 

--- a/src/main/java/net/jeremy/gardenkingmod/ModBlockEntities.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModBlockEntities.java
@@ -2,6 +2,7 @@ package net.jeremy.gardenkingmod;
 
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
 import net.jeremy.gardenkingmod.block.entity.MarketBlockEntity;
+import net.jeremy.gardenkingmod.block.ward.ScarecrowBlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
@@ -11,6 +12,10 @@ public final class ModBlockEntities {
         public static final BlockEntityType<MarketBlockEntity> MARKET_BLOCK_ENTITY = Registry.register(
                         Registries.BLOCK_ENTITY_TYPE, new Identifier(GardenKingMod.MOD_ID, "market_block"),
                         FabricBlockEntityTypeBuilder.create(MarketBlockEntity::new, ModBlocks.MARKET_BLOCK).build());
+
+        public static final BlockEntityType<ScarecrowBlockEntity> SCARECROW_BLOCK_ENTITY = Registry.register(
+                        Registries.BLOCK_ENTITY_TYPE, new Identifier(GardenKingMod.MOD_ID, "scarecrow"),
+                        FabricBlockEntityTypeBuilder.create(ScarecrowBlockEntity::new, ModBlocks.SCARECROW_BLOCK).build());
 
         private ModBlockEntities() {
         }

--- a/src/main/java/net/jeremy/gardenkingmod/ModBlocks.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModBlocks.java
@@ -5,6 +5,7 @@ import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.jeremy.gardenkingmod.block.MarketBlock;
 import net.jeremy.gardenkingmod.block.MarketBlockPart;
+import net.jeremy.gardenkingmod.block.ward.ScarecrowBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.item.BlockItem;
@@ -16,9 +17,11 @@ import net.minecraft.util.Identifier;
 
 public final class ModBlocks {
         public static final Block MARKET_BLOCK = registerBlock("market_block",
-
                         new MarketBlock(
                                         FabricBlockSettings.copyOf(Blocks.OAK_PLANKS).strength(2.5f).nonOpaque()));
+
+        public static final Block SCARECROW_BLOCK = registerBlock("scarecrow",
+                        new ScarecrowBlock(FabricBlockSettings.copyOf(Blocks.HAY_BLOCK).strength(1.5f).nonOpaque()));
 
         public static final Block RUBY_BLOCK = registerBlock("ruby_block",
                         new Block(FabricBlockSettings.copyOf(Blocks.DIAMOND_BLOCK)));
@@ -44,7 +47,10 @@ public final class ModBlocks {
 
         public static void registerModBlocks() {
                 GardenKingMod.LOGGER.info("Registering mod blocks for {}", GardenKingMod.MOD_ID);
-                ItemGroupEvents.modifyEntriesEvent(ItemGroups.FUNCTIONAL).register(entries -> entries.add(MARKET_BLOCK));
+                ItemGroupEvents.modifyEntriesEvent(ItemGroups.FUNCTIONAL).register(entries -> {
+                        entries.add(MARKET_BLOCK);
+                        entries.add(SCARECROW_BLOCK);
+                });
                 ItemGroupEvents.modifyEntriesEvent(ItemGroups.BUILDING_BLOCKS).register(entries -> entries.add(RUBY_BLOCK));
         }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/ModScreenHandlers.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModScreenHandlers.java
@@ -2,6 +2,7 @@ package net.jeremy.gardenkingmod;
 
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.jeremy.gardenkingmod.screen.MarketScreenHandler;
+import net.jeremy.gardenkingmod.screen.ScarecrowScreenHandler;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.screen.ScreenHandlerType;
@@ -11,6 +12,10 @@ public final class ModScreenHandlers {
         public static final ScreenHandlerType<MarketScreenHandler> MARKET_SCREEN_HANDLER = Registry.register(
                         Registries.SCREEN_HANDLER, new Identifier(GardenKingMod.MOD_ID, "market"),
                         new ExtendedScreenHandlerType<>(MarketScreenHandler::new));
+
+        public static final ScreenHandlerType<ScarecrowScreenHandler> SCARECROW_SCREEN_HANDLER = Registry.register(
+                        Registries.SCREEN_HANDLER, new Identifier(GardenKingMod.MOD_ID, "scarecrow"),
+                        new ExtendedScreenHandlerType<>(ScarecrowScreenHandler::new));
 
         private ModScreenHandlers() {
         }

--- a/src/main/java/net/jeremy/gardenkingmod/block/ward/ScarecrowAuraComponent.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/ward/ScarecrowAuraComponent.java
@@ -1,0 +1,109 @@
+package net.jeremy.gardenkingmod.block.ward;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+
+public final class ScarecrowAuraComponent {
+        public static final int BASE_HORIZONTAL_RADIUS = 12;
+        public static final int BASE_VERTICAL_RADIUS = 8;
+        public static final int PULSE_INTERVAL_TICKS = 40;
+        public static final int PULSE_DURATION_TICKS = 45;
+
+        private static final Map<ServerWorld, Set<ScarecrowBlockEntity>> ACTIVE = new WeakHashMap<>();
+
+        private final ScarecrowBlockEntity owner;
+        private int pulseCooldown;
+        private long lastPulseTick;
+
+        ScarecrowAuraComponent(ScarecrowBlockEntity owner) {
+                this.owner = owner;
+                this.pulseCooldown = 0;
+                this.lastPulseTick = 0L;
+        }
+
+        static void register(ServerWorld world, ScarecrowBlockEntity entity) {
+                ACTIVE.computeIfAbsent(world, key -> Collections.newSetFromMap(new IdentityHashMap<>())).add(entity);
+        }
+
+        static void unregister(ScarecrowBlockEntity entity) {
+                if (!(entity.getWorld() instanceof ServerWorld serverWorld)) {
+                        return;
+                }
+                Set<ScarecrowBlockEntity> entities = ACTIVE.get(serverWorld);
+                if (entities == null) {
+                        return;
+                }
+                entities.remove(entity);
+                if (entities.isEmpty()) {
+                        ACTIVE.remove(serverWorld);
+                }
+        }
+
+        public static Optional<ScarecrowBlockEntity> findNearestActiveAura(ServerWorld world, Vec3d position) {
+                Set<ScarecrowBlockEntity> entities = ACTIVE.get(world);
+                if (entities == null || entities.isEmpty()) {
+                        return Optional.empty();
+                }
+                long time = world.getTime();
+                return entities.stream().filter(entity -> entity.isAuraActive())
+                                .filter(entity -> entity.hasRecentPulse(time))
+                                .filter(entity -> entity.isWithinAura(position))
+                                .min(Comparator.comparingDouble(entity -> squaredDistance(entity.getPos(), position)));
+        }
+
+        private static double squaredDistance(BlockPos pos, Vec3d position) {
+                double dx = position.x - (pos.getX() + 0.5);
+                double dy = position.y - (pos.getY() + 0.5);
+                double dz = position.z - (pos.getZ() + 0.5);
+                return dx * dx + dy * dy + dz * dz;
+        }
+
+        void tick(ServerWorld world) {
+                if (!owner.isAuraActive()) {
+                        return;
+                }
+
+                if (this.pulseCooldown > 0) {
+                        this.pulseCooldown--;
+                } else {
+                        this.pulseCooldown = Math.max(10, PULSE_INTERVAL_TICKS - owner.getUpgradeLevel());
+                        this.lastPulseTick = world.getTime();
+                }
+        }
+
+        double getHorizontalRadius() {
+                return BASE_HORIZONTAL_RADIUS + owner.getUpgradeRadiusBonus();
+        }
+
+        double getVerticalRadius() {
+                return BASE_VERTICAL_RADIUS + owner.getUpgradeVerticalBonus();
+        }
+
+        boolean isPulseActive(long worldTime) {
+                return worldTime - this.lastPulseTick <= PULSE_DURATION_TICKS;
+        }
+
+        void initialize(long worldTime) {
+                this.lastPulseTick = worldTime;
+        }
+
+        void saveNbt(NbtCompound nbt) {
+                nbt.putInt("AuraCooldown", this.pulseCooldown);
+                nbt.putLong("AuraLastPulse", this.lastPulseTick);
+        }
+
+        void loadNbt(NbtCompound nbt) {
+                this.pulseCooldown = nbt.getInt("AuraCooldown");
+                this.lastPulseTick = nbt.getLong("AuraLastPulse");
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/block/ward/ScarecrowBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/ward/ScarecrowBlock.java
@@ -1,0 +1,148 @@
+package net.jeremy.gardenkingmod.block.ward;
+
+import net.jeremy.gardenkingmod.ModBlockEntities;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRenderType;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.BlockWithEntity;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityTicker;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemPlacementContext;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.NamedScreenHandlerFactory;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.ItemScatterer;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
+import net.minecraft.world.WorldView;
+
+public class ScarecrowBlock extends BlockWithEntity {
+        private static final VoxelShape SHAPE = Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 16.0, 14.0);
+        public static final BooleanProperty POWERED = BooleanProperty.of("powered");
+
+        public ScarecrowBlock(Settings settings) {
+                super(settings);
+                this.setDefaultState(this.stateManager.getDefaultState().with(POWERED, false));
+        }
+
+        @Override
+        protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+                builder.add(POWERED);
+        }
+
+        @Override
+        public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+                return SHAPE;
+        }
+
+        @Override
+        public BlockRenderType getRenderType(BlockState state) {
+                return BlockRenderType.MODEL;
+        }
+
+        @Override
+        public boolean canPlaceAt(BlockState state, WorldView world, BlockPos pos) {
+                BlockState below = world.getBlockState(pos.down());
+                boolean hasHeadroom = world.getBlockState(pos.up()).isAir();
+                boolean sturdy = below.isSideSolidFullSquare(world, pos.down(), Direction.UP)
+                                || below.isOf(Blocks.FARMLAND) || below.isOf(Blocks.DIRT) || below.isOf(Blocks.COARSE_DIRT)
+                                || below.isOf(Blocks.GRASS_BLOCK) || below.isOf(Blocks.ROOTED_DIRT);
+                return hasHeadroom && sturdy;
+        }
+
+        @Override
+        public BlockState getPlacementState(ItemPlacementContext ctx) {
+                WorldView worldView = ctx.getWorld();
+                BlockPos pos = ctx.getBlockPos();
+                if (!worldView.getBlockState(pos.up()).canReplace(ctx)) {
+                        return null;
+                }
+                boolean powered = worldView.isReceivingRedstonePower(pos) || worldView.isReceivingRedstonePower(pos.up());
+                BlockState baseState = super.getPlacementState(ctx);
+                if (baseState == null) {
+                        return null;
+                }
+                return baseState.with(POWERED, powered);
+        }
+
+        @Override
+        public BlockState getStateForNeighborUpdate(BlockState state, Direction direction, BlockState neighborState,
+                        WorldAccess world, BlockPos pos, BlockPos neighborPos) {
+                if (!state.canPlaceAt(world, pos)) {
+                        world.scheduleBlockTick(pos, this, 1);
+                }
+                boolean powered = world.isReceivingRedstonePower(pos) || world.isReceivingRedstonePower(pos.up());
+                if (powered != state.get(POWERED)) {
+                        return state.with(POWERED, powered);
+                }
+                return state;
+        }
+
+        @Override
+        public void scheduledTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
+                if (!state.canPlaceAt(world, pos)) {
+                        dropStack(world, pos, new ItemStack(this));
+                        world.breakBlock(pos, false);
+                }
+        }
+
+        @Override
+        public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
+                if (state.isOf(newState.getBlock())) {
+                        super.onStateReplaced(state, world, pos, newState, moved);
+                        return;
+                }
+
+                BlockEntity blockEntity = world.getBlockEntity(pos);
+                if (blockEntity instanceof ScarecrowBlockEntity scarecrow) {
+                        ItemScatterer.spawn(world, pos, scarecrow);
+                        world.updateComparators(pos, this);
+                }
+
+                super.onStateReplaced(state, world, pos, newState, moved);
+        }
+
+        @Override
+        public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand,
+                        BlockHitResult hit) {
+                if (world.isClient) {
+                        return ActionResult.SUCCESS;
+                }
+
+                BlockEntity blockEntity = world.getBlockEntity(pos);
+                if (blockEntity instanceof ScarecrowBlockEntity scarecrow) {
+                        NamedScreenHandlerFactory factory = scarecrow;
+                        player.openHandledScreen(factory);
+                        return ActionResult.CONSUME;
+                }
+                return ActionResult.PASS;
+        }
+
+        @Override
+        public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
+                return new ScarecrowBlockEntity(pos, state);
+        }
+
+        @Override
+        public <T extends BlockEntity> BlockEntityTicker<T> getTicker(World world, BlockState state,
+                        BlockEntityType<T> type) {
+                if (world.isClient) {
+                        return null;
+                }
+                return checkType(type, ModBlockEntities.SCARECROW_BLOCK_ENTITY, ScarecrowBlockEntity::tick);
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/block/ward/ScarecrowBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/ward/ScarecrowBlockEntity.java
@@ -1,0 +1,307 @@
+package net.jeremy.gardenkingmod.block.ward;
+
+import net.jeremy.gardenkingmod.ModBlockEntities;
+import net.jeremy.gardenkingmod.screen.ScarecrowScreenHandler;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.Inventories;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.listener.ClientPlayPacketListener;
+import net.minecraft.network.packet.Packet;
+import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
+import net.minecraft.registry.tag.ItemTags;
+import net.minecraft.screen.NamedScreenHandlerFactory;
+import net.minecraft.screen.PropertyDelegate;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
+import net.minecraft.util.collection.DefaultedList;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+
+public class ScarecrowBlockEntity extends BlockEntity implements NamedScreenHandlerFactory, Inventory {
+        public static final int INVENTORY_SIZE = 1;
+        public static final int MAX_DURABILITY = 64;
+
+        private static final Text TITLE = Text.translatable("container.gardenkingmod.scarecrow");
+
+        private DefaultedList<ItemStack> inventory = DefaultedList.ofSize(INVENTORY_SIZE, ItemStack.EMPTY);
+        private final PropertyDelegate propertyDelegate;
+        private final ScarecrowAuraComponent auraComponent;
+        private int durability;
+        private long lastRepelTick;
+
+        public ScarecrowBlockEntity(BlockPos pos, BlockState state) {
+                super(ModBlockEntities.SCARECROW_BLOCK_ENTITY, pos, state);
+                this.auraComponent = new ScarecrowAuraComponent(this);
+                this.durability = MAX_DURABILITY;
+                this.propertyDelegate = new PropertyDelegate() {
+                        @Override
+                        public int get(int index) {
+                                return switch (index) {
+                                        case 0 -> durability;
+                                        case 1 -> MAX_DURABILITY;
+                                        case 2 -> (int) Math.round(auraComponent.getHorizontalRadius());
+                                        case 3 -> (int) Math.round(auraComponent.getVerticalRadius());
+                                        default -> 0;
+                                };
+                        }
+
+                        @Override
+                        public void set(int index, int value) {
+                                if (index == 0) {
+                                        durability = Math.max(0, Math.min(value, MAX_DURABILITY));
+                                }
+                        }
+
+                        @Override
+                        public int size() {
+                                return 4;
+                        }
+                };
+        }
+
+        public static void tick(World world, BlockPos pos, BlockState state, ScarecrowBlockEntity blockEntity) {
+                if (!(world instanceof ServerWorld serverWorld)) {
+                        return;
+                }
+
+                blockEntity.auraComponent.tick(serverWorld);
+        }
+
+        @Override
+        public void readNbt(NbtCompound nbt) {
+                super.readNbt(nbt);
+                this.inventory = DefaultedList.ofSize(INVENTORY_SIZE, ItemStack.EMPTY);
+                Inventories.readNbt(nbt, this.inventory);
+                this.durability = Math.max(0, Math.min(nbt.getInt("Durability"), MAX_DURABILITY));
+                this.auraComponent.loadNbt(nbt);
+        }
+
+        @Override
+        protected void writeNbt(NbtCompound nbt) {
+                super.writeNbt(nbt);
+                Inventories.writeNbt(nbt, this.inventory);
+                nbt.putInt("Durability", this.durability);
+                this.auraComponent.saveNbt(nbt);
+        }
+
+        @Override
+        public int size() {
+                return INVENTORY_SIZE;
+        }
+
+        @Override
+        public boolean isEmpty() {
+                return this.inventory.stream().allMatch(ItemStack::isEmpty);
+        }
+
+        @Override
+        public ItemStack getStack(int slot) {
+                return this.inventory.get(slot);
+        }
+
+        @Override
+        public ItemStack removeStack(int slot, int amount) {
+                ItemStack stack = Inventories.splitStack(this.inventory, slot, amount);
+                if (!stack.isEmpty()) {
+                        markDirtyAndSync();
+                }
+                return stack;
+        }
+
+        @Override
+        public ItemStack removeStack(int slot) {
+                ItemStack stack = Inventories.removeStack(this.inventory, slot);
+                if (!stack.isEmpty()) {
+                        markDirtyAndSync();
+                }
+                return stack;
+        }
+
+        @Override
+        public void setStack(int slot, ItemStack stack) {
+                if (!stack.isEmpty() && !this.isValid(slot, stack)) {
+                        return;
+                }
+                this.inventory.set(slot, stack);
+                if (stack.getCount() > this.getMaxCountPerStack()) {
+                        stack.setCount(this.getMaxCountPerStack());
+                }
+                markDirtyAndSync();
+        }
+
+        @Override
+        public boolean canPlayerUse(PlayerEntity player) {
+                if (this.world == null || this.world.getBlockEntity(this.pos) != this) {
+                        return false;
+                }
+                return player.squaredDistanceTo(Vec3d.ofCenter(this.pos)) <= 64.0;
+        }
+
+        @Override
+        public void clear() {
+                this.inventory.clear();
+                markDirtyAndSync();
+        }
+
+        @Override
+        public void onOpen(PlayerEntity player) {
+        }
+
+        @Override
+        public void onClose(PlayerEntity player) {
+        }
+
+        @Override
+        public Text getDisplayName() {
+                return TITLE;
+        }
+
+        @Override
+        public ScreenHandler createMenu(int syncId, PlayerInventory playerInventory, PlayerEntity player) {
+                if (!canPlayerUse(player)) {
+                        return null;
+                }
+                return new ScarecrowScreenHandler(syncId, playerInventory, this, this.propertyDelegate);
+        }
+
+        public PropertyDelegate getPropertyDelegate() {
+                return this.propertyDelegate;
+        }
+
+        public ScarecrowAuraComponent getAuraComponent() {
+                return this.auraComponent;
+        }
+
+        public boolean isValidUpgrade(ItemStack stack) {
+                return stack.isIn(ItemTags.FLOWERS) || stack.isIn(ItemTags.WOOL_CARPETS);
+        }
+
+        public boolean isAuraActive() {
+                return this.durability > 0 && this.world != null && !this.world.getBlockState(this.pos)
+                                .get(ScarecrowBlock.POWERED);
+        }
+
+        public void onCrowRepelled(ServerWorld world) {
+                if (world.getTime() == this.lastRepelTick) {
+                        return;
+                }
+                this.lastRepelTick = world.getTime();
+                if (this.durability <= 0) {
+                        return;
+                }
+                this.durability = Math.max(0, this.durability - 1);
+                markDirtyAndSync();
+                if (this.durability <= 0) {
+                        world.breakBlock(this.pos, true);
+                }
+        }
+
+        public int getDurability() {
+                return this.durability;
+        }
+
+        public void setDurability(int durability) {
+                this.durability = Math.max(0, Math.min(durability, MAX_DURABILITY));
+                markDirtyAndSync();
+        }
+
+        public double getUpgradeRadiusBonus() {
+                ItemStack stack = this.inventory.get(0);
+                if (stack.isEmpty()) {
+                        return 0.0;
+                }
+                return Math.min(6.0, stack.getCount() * 0.5);
+        }
+
+        public double getUpgradeVerticalBonus() {
+                ItemStack stack = this.inventory.get(0);
+                if (stack.isEmpty()) {
+                        return 0.0;
+                }
+                return Math.min(4.0, stack.getCount() * 0.25);
+        }
+
+        public int getUpgradeLevel() {
+                ItemStack stack = this.inventory.get(0);
+                return stack.isEmpty() ? 0 : Math.min(16, stack.getCount());
+        }
+
+        public double getHorizontalAuraRadius() {
+                return this.auraComponent.getHorizontalRadius();
+        }
+
+        public double getVerticalAuraRadius() {
+                return this.auraComponent.getVerticalRadius();
+        }
+
+        public void markDirtyAndSync() {
+                markDirty();
+                if (this.world instanceof ServerWorld serverWorld) {
+                        serverWorld.getChunkManager().markForUpdate(this.pos);
+                }
+        }
+
+        @Override
+        public boolean isValid(int slot, ItemStack stack) {
+                return slot == 0 && this.isValidUpgrade(stack);
+        }
+
+        @Override
+        public int getMaxCountPerStack() {
+                return 16;
+        }
+
+        public boolean isWithinAura(Vec3d position) {
+                double horizontalRadius = getHorizontalAuraRadius();
+                double verticalRadius = getVerticalAuraRadius();
+                Vec3d center = Vec3d.ofCenter(this.pos);
+                double dx = position.x - center.x;
+                double dz = position.z - center.z;
+                double dy = Math.abs(position.y - center.y);
+                return Math.sqrt(dx * dx + dz * dz) <= horizontalRadius && dy <= verticalRadius;
+        }
+
+        public boolean hasRecentPulse(long time) {
+                return this.auraComponent.isPulseActive(time);
+        }
+
+        @Override
+        public void setWorld(World world) {
+                super.setWorld(world);
+                if (world instanceof ServerWorld serverWorld) {
+                        ScarecrowAuraComponent.register(serverWorld, this);
+                        this.auraComponent.initialize(serverWorld.getTime());
+                }
+        }
+
+        @Override
+        public void markRemoved() {
+                super.markRemoved();
+                ScarecrowAuraComponent.unregister(this);
+        }
+
+        @Override
+        public void cancelRemoval() {
+                super.cancelRemoval();
+                if (this.world instanceof ServerWorld serverWorld) {
+                        ScarecrowAuraComponent.register(serverWorld, this);
+                }
+        }
+
+        @Override
+        public Packet<ClientPlayPacketListener> toUpdatePacket() {
+                return BlockEntityUpdateS2CPacket.create(this);
+        }
+
+        @Override
+        public NbtCompound toInitialChunkDataNbt() {
+                return createNbt();
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/entity/crow/goal/CrowFleeWardingGoal.java
+++ b/src/main/java/net/jeremy/gardenkingmod/entity/crow/goal/CrowFleeWardingGoal.java
@@ -1,0 +1,144 @@
+package net.jeremy.gardenkingmod.entity.crow.goal;
+
+import java.util.EnumSet;
+import java.util.Optional;
+
+import net.jeremy.gardenkingmod.block.ward.ScarecrowAuraComponent;
+import net.jeremy.gardenkingmod.block.ward.ScarecrowBlockEntity;
+import net.minecraft.entity.ai.goal.Goal;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.entity.mob.PathAwareEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+
+public class CrowFleeWardingGoal extends Goal {
+        private static final int STATUS_EFFECT_DURATION = 60;
+        private static final int DAMAGE_INTERVAL = 20;
+
+        private final PathAwareEntity crow;
+        private final double speed;
+
+        private ScarecrowBlockEntity scarecrow;
+        private Vec3d targetPos;
+        private int ticksInAura;
+
+        public CrowFleeWardingGoal(PathAwareEntity crow, double speed) {
+                this.crow = crow;
+                this.speed = speed;
+                this.setControls(EnumSet.of(Control.MOVE, Control.LOOK));
+        }
+
+        @Override
+        public boolean canStart() {
+                if (!(this.crow.getWorld() instanceof ServerWorld serverWorld)) {
+                        return false;
+                }
+
+                Optional<ScarecrowBlockEntity> optionalScarecrow = ScarecrowAuraComponent
+                                .findNearestActiveAura(serverWorld, this.crow.getPos());
+                if (optionalScarecrow.isEmpty()) {
+                        return false;
+                }
+
+                this.scarecrow = optionalScarecrow.get();
+                this.targetPos = computeFleeTarget(this.scarecrow);
+                return this.targetPos != null;
+        }
+
+        @Override
+        public boolean shouldContinue() {
+                if (this.scarecrow == null) {
+                        return false;
+                }
+
+                if (!(this.crow.getWorld() instanceof ServerWorld serverWorld)) {
+                        return false;
+                }
+
+                if (!this.scarecrow.hasRecentPulse(serverWorld.getTime())) {
+                                return false;
+                }
+
+                boolean insideAura = this.scarecrow.isWithinAura(this.crow.getPos());
+                return insideAura || !this.crow.getNavigation().isIdle();
+        }
+
+        @Override
+        public void start() {
+                if (this.targetPos != null) {
+                        this.crow.getNavigation().startMovingTo(this.targetPos.x, this.targetPos.y, this.targetPos.z,
+                                        this.speed);
+                }
+                this.ticksInAura = 0;
+        }
+
+        @Override
+        public void stop() {
+                this.scarecrow = null;
+                this.targetPos = null;
+                this.ticksInAura = 0;
+        }
+
+        @Override
+        public void tick() {
+                if (!(this.crow.getWorld() instanceof ServerWorld serverWorld)) {
+                        return;
+                }
+
+                if (this.scarecrow == null) {
+                        return;
+                }
+
+                if (this.scarecrow.isWithinAura(this.crow.getPos())) {
+                        this.ticksInAura++;
+                        applyRepelEffects(serverWorld);
+
+                        if (this.crow.getNavigation().isIdle()) {
+                                this.targetPos = computeFleeTarget(this.scarecrow);
+                                if (this.targetPos != null) {
+                                        this.crow.getNavigation().startMovingTo(this.targetPos.x, this.targetPos.y,
+                                                        this.targetPos.z, this.speed);
+                                }
+                        }
+                } else if (this.targetPos == null || this.crow.getNavigation().isIdle()) {
+                        this.targetPos = computeFleeTarget(this.scarecrow);
+                        if (this.targetPos != null) {
+                                this.crow.getNavigation().startMovingTo(this.targetPos.x, this.targetPos.y,
+                                                this.targetPos.z, this.speed);
+                        }
+                }
+        }
+
+        private void applyRepelEffects(ServerWorld world) {
+                if (!this.crow.hasStatusEffect(StatusEffects.SLOWNESS)) {
+                        this.crow.addStatusEffect(new StatusEffectInstance(StatusEffects.SLOWNESS, STATUS_EFFECT_DURATION,
+                                        0, false, false, true));
+                }
+
+                if (this.ticksInAura % DAMAGE_INTERVAL == 0) {
+                        this.scarecrow.onCrowRepelled(world);
+                }
+        }
+
+        private Vec3d computeFleeTarget(ScarecrowBlockEntity scarecrow) {
+                Vec3d scarecrowCenter = Vec3d.ofCenter(scarecrow.getPos());
+                Vec3d current = this.crow.getPos();
+                Vec3d away = current.subtract(scarecrowCenter);
+                double horizontalRadius = scarecrow.getHorizontalAuraRadius() + 6.0;
+
+                if (away.lengthSquared() < 1.0E-4) {
+                        double yaw = this.crow.getRandom().nextDouble() * MathHelper.TAU;
+                        away = new Vec3d(MathHelper.cos((float) yaw), 0.0, MathHelper.sin((float) yaw));
+                }
+
+                away = away.normalize().multiply(horizontalRadius);
+                Vec3d target = current.add(away);
+                double clampedY = MathHelper.clamp(target.y,
+                                scarecrow.getPos().getY() - scarecrow.getVerticalAuraRadius(),
+                                scarecrow.getPos().getY() + scarecrow.getVerticalAuraRadius());
+
+                return new Vec3d(target.x, clampedY, target.z);
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
@@ -1,0 +1,41 @@
+package net.jeremy.gardenkingmod.screen;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.render.GameRenderer;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
+        private static final Identifier TEXTURE = new Identifier("minecraft", "textures/gui/container/hopper.png");
+        private static final int BACKGROUND_WIDTH = 176;
+        private static final int BACKGROUND_HEIGHT = 133;
+        private static final int PLAYER_LABEL_Y = 40;
+
+        public ScarecrowScreen(ScarecrowScreenHandler handler, PlayerInventory inventory, Text title) {
+                super(handler, inventory, title);
+                this.backgroundWidth = BACKGROUND_WIDTH;
+                this.backgroundHeight = BACKGROUND_HEIGHT;
+                this.playerInventoryTitleY = PLAYER_LABEL_Y;
+        }
+
+        @Override
+        protected void drawBackground(DrawContext context, float delta, int mouseX, int mouseY) {
+                RenderSystem.setShader(GameRenderer::getPositionTexProgram);
+                RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+                RenderSystem.setShaderTexture(0, TEXTURE);
+                int x = (width - backgroundWidth) / 2;
+                int y = (height - backgroundHeight) / 2;
+                context.drawTexture(TEXTURE, x, y, 0, 0, backgroundWidth, backgroundHeight);
+        }
+
+        @Override
+        public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+                renderBackground(context);
+                super.render(context, mouseX, mouseY, delta);
+                drawMouseoverTooltip(context, mouseX, mouseY);
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreenHandler.java
@@ -1,0 +1,140 @@
+package net.jeremy.gardenkingmod.screen;
+
+import net.jeremy.gardenkingmod.ModScreenHandlers;
+import net.jeremy.gardenkingmod.block.ward.ScarecrowBlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.screen.ArrayPropertyDelegate;
+import net.minecraft.screen.PropertyDelegate;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.util.math.BlockPos;
+
+public class ScarecrowScreenHandler extends ScreenHandler {
+        private static final int UPGRADE_SLOT_INDEX = 0;
+        private static final int SLOT_X = 80;
+        private static final int SLOT_Y = 35;
+        private static final int PLAYER_INVENTORY_START_Y = 84;
+        private static final int PLAYER_HOTBAR_Y = 142;
+
+        private final Inventory inventory;
+        private final PropertyDelegate properties;
+        private final ScarecrowBlockEntity blockEntity;
+
+        public ScarecrowScreenHandler(int syncId, PlayerInventory playerInventory, PacketByteBuf buf) {
+                this(syncId, playerInventory, getBlockEntity(playerInventory, buf.readBlockPos()));
+        }
+
+        public ScarecrowScreenHandler(int syncId, PlayerInventory playerInventory, ScarecrowBlockEntity blockEntity) {
+                this(syncId, playerInventory, blockEntity,
+                                blockEntity != null ? blockEntity.getPropertyDelegate() : new ArrayPropertyDelegate(4));
+        }
+
+        public ScarecrowScreenHandler(int syncId, PlayerInventory playerInventory, ScarecrowBlockEntity blockEntity,
+                        PropertyDelegate properties) {
+                super(ModScreenHandlers.SCARECROW_SCREEN_HANDLER, syncId);
+                this.blockEntity = blockEntity;
+                this.inventory = blockEntity != null ? blockEntity : new SimpleInventory(ScarecrowBlockEntity.INVENTORY_SIZE);
+                this.properties = properties;
+
+                checkSize(this.inventory, ScarecrowBlockEntity.INVENTORY_SIZE);
+                addProperties(properties);
+
+                this.inventory.onOpen(playerInventory.player);
+
+                this.addSlot(new Slot(this.inventory, UPGRADE_SLOT_INDEX, SLOT_X, SLOT_Y) {
+                        @Override
+                        public boolean canInsert(ItemStack stack) {
+                                if (blockEntity == null) {
+                                        return true;
+                                }
+                                return blockEntity.isValidUpgrade(stack);
+                        }
+
+                        @Override
+                        public int getMaxItemCount() {
+                                return blockEntity != null ? blockEntity.getMaxCountPerStack() : 16;
+                        }
+                });
+
+                addPlayerInventory(playerInventory);
+                addPlayerHotbar(playerInventory);
+        }
+
+        private static ScarecrowBlockEntity getBlockEntity(PlayerInventory playerInventory, BlockPos pos) {
+                if (playerInventory.player.getWorld().getBlockEntity(pos) instanceof ScarecrowBlockEntity scarecrow) {
+                        return scarecrow;
+                }
+                return null;
+        }
+
+        @Override
+        public boolean canUse(PlayerEntity player) {
+                return this.inventory.canPlayerUse(player);
+        }
+
+        @Override
+        public void onClosed(PlayerEntity player) {
+                super.onClosed(player);
+                this.inventory.onClose(player);
+        }
+
+        @Override
+        public ItemStack quickMove(PlayerEntity player, int slotIndex) {
+                ItemStack newStack = ItemStack.EMPTY;
+                Slot slot = this.slots.get(slotIndex);
+                if (slot != null && slot.hasStack()) {
+                        ItemStack original = slot.getStack();
+                        newStack = original.copy();
+                        if (slotIndex == UPGRADE_SLOT_INDEX) {
+                                if (!this.insertItem(original, ScarecrowBlockEntity.INVENTORY_SIZE, this.slots.size(), true)) {
+                                        return ItemStack.EMPTY;
+                                }
+                        } else if (!this.insertItem(original, UPGRADE_SLOT_INDEX, UPGRADE_SLOT_INDEX + 1, false)) {
+                                return ItemStack.EMPTY;
+                        }
+
+                        if (original.isEmpty()) {
+                                slot.setStack(ItemStack.EMPTY);
+                        } else {
+                                slot.markDirty();
+                        }
+                }
+                return newStack;
+        }
+
+        private void addPlayerInventory(PlayerInventory playerInventory) {
+                for (int row = 0; row < 3; ++row) {
+                        for (int column = 0; column < 9; ++column) {
+                                this.addSlot(new Slot(playerInventory, column + row * 9 + 9, 8 + column * 18,
+                                                PLAYER_INVENTORY_START_Y + row * 18));
+                        }
+                }
+        }
+
+        private void addPlayerHotbar(PlayerInventory playerInventory) {
+                for (int slot = 0; slot < 9; ++slot) {
+                        this.addSlot(new Slot(playerInventory, slot, 8 + slot * 18, PLAYER_HOTBAR_Y));
+                }
+        }
+
+        public int getDurability() {
+                return this.properties.get(0);
+        }
+
+        public int getMaxDurability() {
+                return this.properties.get(1);
+        }
+
+        public int getHorizontalRadius() {
+                return this.properties.get(2);
+        }
+
+        public int getVerticalRadius() {
+                return this.properties.get(3);
+        }
+}


### PR DESCRIPTION
## Summary
- add a scarecrow warding block, block entity, and aura component with placement checks, durability, upgrades, and aura ticking logic
- provide a scarecrow upgrade screen handler and register the block, item, block entity, and screen handler on both client and server
- implement a crow flee warding goal that reacts to scarecrow auras

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d5c76a09ec8321890f8617201a2e8e