### PR TITLE
Add configurable crow entity and client hooks

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
@@ -6,6 +6,7 @@ import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.jeremy.gardenkingmod.crop.BonusHarvestDropManager;
 import net.jeremy.gardenkingmod.crop.CropDropModifier;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
+import net.jeremy.gardenkingmod.registry.ModEntities;
 
 import net.minecraft.resource.ResourceType;
 
@@ -23,6 +24,7 @@ public class GardenKingMod implements ModInitializer {
                 ModBlockEntities.registerBlockEntities();
                 ModScreenHandlers.registerScreenHandlers();
                 ModScoreboards.registerScoreboards();
+                ModEntities.register();
 
                 ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(BonusHarvestDropManager.getInstance());
 

--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -7,8 +7,11 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
 import net.jeremy.gardenkingmod.client.model.MarketBlockModel;
 import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
+import net.jeremy.gardenkingmod.client.model.CrowEntityModel;
+import net.jeremy.gardenkingmod.client.render.CrowEntityRenderer;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.item.FortuneProvidingItem;
 import net.jeremy.gardenkingmod.network.ModPackets;
@@ -20,13 +23,16 @@ import net.minecraft.registry.Registries;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
+import net.jeremy.gardenkingmod.registry.ModEntities;
 
 public class GardenKingModClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         HandledScreens.register(ModScreenHandlers.MARKET_SCREEN_HANDLER, MarketScreen::new);
         EntityModelLayerRegistry.registerModelLayer(MarketBlockModel.LAYER_LOCATION, MarketBlockModel::getTexturedModelData);
+        EntityModelLayerRegistry.registerModelLayer(CrowEntityRenderer.MODEL_LAYER, CrowEntityModel::getTexturedModelData);
         BlockEntityRendererFactories.register(ModBlockEntities.MARKET_BLOCK_ENTITY, MarketBlockEntityRenderer::new);
+        EntityRendererRegistry.register(ModEntities.CROW, CrowEntityRenderer::new);
 
         ClientPlayNetworking.registerGlobalReceiver(ModPackets.MARKET_SALE_RESULT_PACKET,
                 (client, handler, buf, responseSender) -> {

--- a/src/main/java/net/jeremy/gardenkingmod/client/model/CrowEntityModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/CrowEntityModel.java
@@ -1,0 +1,92 @@
+package net.jeremy.gardenkingmod.client.model;
+
+import net.minecraft.client.model.ModelData;
+import net.minecraft.client.model.ModelPart;
+import net.minecraft.client.model.ModelPartBuilder;
+import net.minecraft.client.model.ModelPartData;
+import net.minecraft.client.model.ModelTransform;
+import net.minecraft.client.model.TexturedModelData;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.entity.model.SinglePartEntityModel;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.MathHelper;
+
+import net.jeremy.gardenkingmod.entity.crow.CrowEntity;
+
+/**
+ * Simple crow model built around a single textured cube body with animated
+ * wings. The geometry intentionally mirrors vanilla-style bird models so
+ * resource packs can reuse textures without a custom loader.
+ */
+public class CrowEntityModel extends SinglePartEntityModel<CrowEntity> {
+    private final ModelPart root;
+    private final ModelPart body;
+    private final ModelPart head;
+    private final ModelPart leftWing;
+    private final ModelPart rightWing;
+    private final ModelPart tail;
+
+    public CrowEntityModel(ModelPart root) {
+        this.root = root;
+        this.body = root.getChild("body");
+        this.head = body.getChild("head");
+        this.leftWing = body.getChild("left_wing");
+        this.rightWing = body.getChild("right_wing");
+        this.tail = body.getChild("tail");
+    }
+
+    public static TexturedModelData getTexturedModelData() {
+        ModelData modelData = new ModelData();
+        ModelPartData root = modelData.getRoot();
+
+        ModelPartData body = root.addChild("body",
+                ModelPartBuilder.create().uv(0, 0).cuboid(-3.0f, -2.0f, -4.0f, 6.0f, 4.0f, 8.0f),
+                ModelTransform.pivot(0.0f, 16.0f, 0.0f));
+
+        body.addChild("head",
+                ModelPartBuilder.create().uv(0, 12).cuboid(-2.0f, -4.0f, -3.0f, 4.0f, 4.0f, 3.0f)
+                        .uv(14, 12).cuboid(-1.0f, -2.0f, -5.0f, 2.0f, 1.0f, 2.0f),
+                ModelTransform.pivot(0.0f, -1.0f, -4.0f));
+
+        body.addChild("left_wing",
+                ModelPartBuilder.create().uv(20, 0).cuboid(0.0f, -1.0f, -4.0f, 1.0f, 3.0f, 8.0f),
+                ModelTransform.pivot(3.0f, -1.0f, 0.0f));
+
+        body.addChild("right_wing",
+                ModelPartBuilder.create().uv(20, 0).mirrored().cuboid(-1.0f, -1.0f, -4.0f, 1.0f, 3.0f, 8.0f),
+                ModelTransform.pivot(-3.0f, -1.0f, 0.0f));
+
+        body.addChild("tail",
+                ModelPartBuilder.create().uv(0, 19).cuboid(-2.0f, 0.0f, 0.0f, 4.0f, 1.0f, 4.0f),
+                ModelTransform.pivot(0.0f, 1.5f, 4.0f));
+
+        return TexturedModelData.of(modelData, 32, 32);
+    }
+
+    @Override
+    public void setAngles(CrowEntity entity, float limbAngle, float limbDistance, float animationProgress, float headYaw,
+            float headPitch) {
+        head.yaw = headYaw * (MathHelper.PI / 180.0f);
+        head.pitch = headPitch * (MathHelper.PI / 180.0f);
+
+        float flap = MathHelper.cos(animationProgress * 0.6f) * (float) Math.PI * 0.25f;
+        if (entity.isOnGround() || entity.getVelocity().lengthSquared() < 0.01f) {
+            flap = 0.05f;
+        }
+
+        leftWing.roll = flap;
+        rightWing.roll = -flap;
+        tail.pitch = -0.35f + MathHelper.cos(animationProgress * 0.2f) * 0.05f;
+    }
+
+    @Override
+    public void render(MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green,
+            float blue, float alpha) {
+        root.render(matrices, vertices, light, overlay, red, green, blue, alpha);
+    }
+
+    @Override
+    public ModelPart getPart() {
+        return root;
+    }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/CrowEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/CrowEntityRenderer.java
@@ -1,0 +1,28 @@
+package net.jeremy.gardenkingmod.client.render;
+
+import net.minecraft.client.render.entity.EntityRendererFactory.Context;
+import net.minecraft.client.render.entity.MobEntityRenderer;
+import net.minecraft.client.render.entity.model.EntityModelLayer;
+import net.minecraft.util.Identifier;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.client.model.CrowEntityModel;
+import net.jeremy.gardenkingmod.entity.crow.CrowEntity;
+
+/**
+ * Binds the crow model and texture to the renderer registry.
+ */
+public class CrowEntityRenderer extends MobEntityRenderer<CrowEntity, CrowEntityModel> {
+    public static final EntityModelLayer MODEL_LAYER = new EntityModelLayer(
+            new Identifier(GardenKingMod.MOD_ID, "crow"), "main");
+    private static final Identifier TEXTURE = new Identifier(GardenKingMod.MOD_ID, "textures/entity/crow.png");
+
+    public CrowEntityRenderer(Context context) {
+        super(context, new CrowEntityModel(context.getPart(MODEL_LAYER)), 0.3f);
+    }
+
+    @Override
+    public Identifier getTexture(CrowEntity entity) {
+        return TEXTURE;
+    }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowAiGoals.java
+++ b/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowAiGoals.java
@@ -1,0 +1,353 @@
+package net.jeremy.gardenkingmod.entity.crow;
+
+import java.util.EnumSet;
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.entity.ai.goal.Goal;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+
+import net.jeremy.gardenkingmod.registry.ModEntities;
+
+/**
+ * Collection of reusable AI goals that power the crow's behavior stack. These
+ * goals are intentionally lightweight so future hostile wildlife can reuse
+ * them.
+ */
+public final class CrowAiGoals {
+    private CrowAiGoals() {
+    }
+
+    public static class CrowFleeWardingGoal extends Goal {
+        private static final int RECALC_TICKS = 20;
+
+        private final CrowEntity crow;
+        private final double speed;
+
+        private BlockPos wardPos;
+        private Vec3d escapeTarget;
+        private int ticksUntilRecalc;
+
+        public CrowFleeWardingGoal(CrowEntity crow) {
+            this(crow, 1.5);
+        }
+
+        public CrowFleeWardingGoal(CrowEntity crow, double speed) {
+            this.crow = crow;
+            this.speed = speed;
+            setControls(EnumSet.of(Control.MOVE));
+        }
+
+        @Override
+        public boolean canStart() {
+            if (crow.isRemoved()) {
+                return false;
+            }
+
+            if (crow.getWorld().isClient) {
+                return false;
+            }
+
+            crow.findNearestWard().ifPresent(pos -> this.wardPos = pos);
+            if (wardPos == null) {
+                return false;
+            }
+
+            escapeTarget = computeEscapeTarget();
+            if (escapeTarget == null) {
+                wardPos = null;
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public boolean shouldContinue() {
+            if (crow.getWorld().isClient) {
+                return false;
+            }
+
+            Optional<BlockPos> nearest = crow.findNearestWard();
+            if (nearest.isEmpty()) {
+                return false;
+            }
+
+            wardPos = nearest.get();
+            double horizontal = CrowBalanceConfig.get().wardHorizontalRadius()
+                    * CrowBalanceConfig.get().wardFearRadiusMultiplier();
+            double horizontalSq = MathHelper.square(horizontal);
+            return crow.squaredDistanceTo(Vec3d.ofCenter(wardPos)) <= horizontalSq * 1.5;
+        }
+
+        @Override
+        public void start() {
+            ticksUntilRecalc = 0;
+            if (escapeTarget != null) {
+                crow.getNavigation().startMovingTo(escapeTarget.x, escapeTarget.y, escapeTarget.z, speed);
+            }
+        }
+
+        @Override
+        public void stop() {
+            wardPos = null;
+            escapeTarget = null;
+            crow.getNavigation().stop();
+        }
+
+        @Override
+        public void tick() {
+            if (wardPos == null) {
+                return;
+            }
+
+            if (--ticksUntilRecalc <= 0) {
+                ticksUntilRecalc = RECALC_TICKS;
+                escapeTarget = computeEscapeTarget();
+                if (escapeTarget != null) {
+                    crow.getNavigation().startMovingTo(escapeTarget.x, escapeTarget.y, escapeTarget.z, speed);
+                }
+            }
+        }
+
+        @Nullable
+        private Vec3d computeEscapeTarget() {
+            if (wardPos == null) {
+                return null;
+            }
+
+            Vec3d wardCenter = Vec3d.ofCenter(wardPos);
+            Vec3d direction = crow.getPos().subtract(wardCenter);
+            if (direction.lengthSquared() < 1.0E-4) {
+                direction = new Vec3d(crow.getRandom().nextDouble() - 0.5, 0.1,
+                        crow.getRandom().nextDouble() - 0.5);
+            }
+
+            direction = direction.normalize();
+            double horizontal = CrowBalanceConfig.get().wardHorizontalRadius()
+                    * CrowBalanceConfig.get().wardFearRadiusMultiplier() * 1.5;
+            Vec3d candidate = crow.getPos().add(direction.multiply(horizontal)).add(0.0, 1.0, 0.0);
+
+            if (!crow.getWorld().isChunkLoaded(BlockPos.ofFloored(candidate))) {
+                return null;
+            }
+
+            return candidate;
+        }
+    }
+
+    public static class CrowBreakCropGoal extends Goal {
+        private static final int BREAK_TIME = 20;
+
+        private final CrowEntity crow;
+        private final double speed;
+
+        private BlockPos targetCrop;
+        private int breakingTicks;
+
+        public CrowBreakCropGoal(CrowEntity crow) {
+            this(crow, 1.2);
+        }
+
+        public CrowBreakCropGoal(CrowEntity crow, double speed) {
+            this.crow = crow;
+            this.speed = speed;
+            setControls(EnumSet.of(Control.MOVE));
+        }
+
+        @Override
+        public boolean canStart() {
+            if (!crow.isHungry()) {
+                return false;
+            }
+
+            if (!crow.getWorld().getGameRules().getBoolean(ModEntities.CROW_GRIEFING_RULE)) {
+                return false;
+            }
+
+            targetCrop = crow.findCropTarget().orElse(null);
+            if (targetCrop == null) {
+                return false;
+            }
+
+            return crow.getWorld().isChunkLoaded(targetCrop);
+        }
+
+        @Override
+        public boolean shouldContinue() {
+            if (!crow.isHungry()) {
+                return false;
+            }
+
+            if (targetCrop == null) {
+                return false;
+            }
+
+            if (!crow.getWorld().getGameRules().getBoolean(ModEntities.CROW_GRIEFING_RULE)) {
+                return false;
+            }
+
+            return crow.getWorld().isChunkLoaded(targetCrop)
+                    && crow.getWorld().getBlockState(targetCrop).isIn(CrowTags.CROW_TARGET_CROPS);
+        }
+
+        @Override
+        public void start() {
+            breakingTicks = 0;
+            if (targetCrop != null) {
+                crow.getNavigation().startMovingTo(targetCrop.getX() + 0.5, targetCrop.getY() + 0.5,
+                        targetCrop.getZ() + 0.5, speed);
+            }
+        }
+
+        @Override
+        public void stop() {
+            crow.getNavigation().stop();
+            targetCrop = null;
+            breakingTicks = 0;
+        }
+
+        @Override
+        public void tick() {
+            if (targetCrop == null) {
+                return;
+            }
+
+            double distanceSq = crow.squaredDistanceTo(Vec3d.ofCenter(targetCrop));
+            if (distanceSq > 3.0) {
+                crow.getNavigation().startMovingTo(targetCrop.getX() + 0.5, targetCrop.getY() + 0.5,
+                        targetCrop.getZ() + 0.5, speed);
+                breakingTicks = 0;
+                return;
+            }
+
+            crow.getNavigation().stop();
+            crow.getLookControl().lookAt(targetCrop.getX() + 0.5, targetCrop.getY() + 0.5, targetCrop.getZ() + 0.5);
+            breakingTicks++;
+            if (breakingTicks >= BREAK_TIME) {
+                if (crow.tryBreakCrop(targetCrop)) {
+                    // Hunger will be reset in the crow's crop hook.
+                }
+                targetCrop = null;
+            }
+        }
+    }
+
+    public static class CrowRandomFlyGoal extends Goal {
+        private final CrowEntity crow;
+        private final double speed;
+
+        @Nullable
+        private Vec3d target;
+
+        public CrowRandomFlyGoal(CrowEntity crow) {
+            this(crow, 1.0);
+        }
+
+        public CrowRandomFlyGoal(CrowEntity crow, double speed) {
+            this.crow = crow;
+            this.speed = speed;
+            setControls(EnumSet.of(Control.MOVE));
+        }
+
+        @Override
+        public boolean canStart() {
+            if (crow.isHungry()) {
+                return false;
+            }
+
+            if (!crow.getNavigation().isIdle()) {
+                return false;
+            }
+
+            target = crow.getRandomFlightTarget();
+            return target != null;
+        }
+
+        @Override
+        public boolean shouldContinue() {
+            return target != null && !crow.isHungry() && !crow.getNavigation().isIdle();
+        }
+
+        @Override
+        public void start() {
+            if (target != null) {
+                crow.getNavigation().startMovingTo(target.x, target.y, target.z, speed);
+            }
+        }
+
+        @Override
+        public void stop() {
+            target = null;
+            crow.getNavigation().stop();
+        }
+    }
+
+    public static class CrowPerchGoal extends Goal {
+        private final CrowEntity crow;
+        private final double speed;
+
+        private BlockPos perchPos;
+        private int perchTicks;
+
+        public CrowPerchGoal(CrowEntity crow) {
+            this(crow, 1.0);
+        }
+
+        public CrowPerchGoal(CrowEntity crow, double speed) {
+            this.crow = crow;
+            this.speed = speed;
+            setControls(EnumSet.of(Control.MOVE));
+        }
+
+        @Override
+        public boolean canStart() {
+            if (crow.isHungry()) {
+                return false;
+            }
+
+            if (crow.getRandom().nextInt(5) != 0) {
+                return false;
+            }
+
+            perchPos = crow.findPerchTarget().orElse(null);
+            return perchPos != null;
+        }
+
+        @Override
+        public boolean shouldContinue() {
+            return perchPos != null && !crow.isHungry() && perchTicks < 100;
+        }
+
+        @Override
+        public void start() {
+            perchTicks = 0;
+            if (perchPos != null) {
+                crow.getNavigation().startMovingTo(perchPos.getX() + 0.5, perchPos.getY(), perchPos.getZ() + 0.5, speed);
+            }
+        }
+
+        @Override
+        public void stop() {
+            crow.getNavigation().stop();
+            perchPos = null;
+            perchTicks = 0;
+        }
+
+        @Override
+        public void tick() {
+            if (perchPos == null) {
+                return;
+            }
+
+            if (crow.getBlockPos().equals(perchPos) || crow.squaredDistanceTo(Vec3d.ofCenter(perchPos)) < 1.0) {
+                perchTicks++;
+                crow.setVelocity(Vec3d.ZERO);
+                crow.teleport(perchPos.getX() + 0.5, perchPos.getY() + 0.1, perchPos.getZ() + 0.5);
+            }
+        }
+    }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowBalanceConfig.java
+++ b/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowBalanceConfig.java
@@ -1,0 +1,214 @@
+package net.jeremy.gardenkingmod.entity.crow;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+
+/**
+ * Loads configurable balance settings for the crow entity from
+ * <code>config/gardenkingmod/crow.json</code>. The JSON file is written the
+ * first time the game runs so packs or administrators can adjust values
+ * without recompiling the mod.
+ */
+public final class CrowBalanceConfig {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final Path CONFIG_PATH = FabricLoader.getInstance().getConfigDir()
+            .resolve(GardenKingMod.MOD_ID)
+            .resolve("crow.json");
+
+    private static volatile CrowBalanceConfig instance = new CrowBalanceConfig();
+
+    private int minHungerTicks = 600;
+    private int maxHungerTicks = 1200;
+    private int cropSearchHorizontal = 12;
+    private int cropSearchVertical = 6;
+    private double randomFlightRange = 8.0;
+    private double perchSearchRange = 6.0;
+    private double wardHorizontalRadius = 12.0;
+    private double wardVerticalRadius = 8.0;
+    private double wardFearRadiusMultiplier = 1.0;
+    private boolean dropLootOnCropBreak = true;
+    private double baseHealth = 10.0;
+    private double flyingSpeed = 0.6;
+    private double movementSpeed = 0.25;
+    private int spawnWeight = 6;
+
+    private CrowBalanceConfig() {
+    }
+
+    /**
+     * Ensures the config file is written to disk and updates the cached
+     * configuration values.
+     */
+    public static void reload() {
+        CrowBalanceConfig defaults = new CrowBalanceConfig();
+        try {
+            Files.createDirectories(CONFIG_PATH.getParent());
+        } catch (IOException exception) {
+            GardenKingMod.LOGGER.warn("Failed to create crow config directory", exception);
+        }
+
+        if (Files.notExists(CONFIG_PATH)) {
+            writeConfigFile(defaults);
+            instance = defaults;
+            return;
+        }
+
+        try (BufferedReader reader = Files.newBufferedReader(CONFIG_PATH)) {
+            CrowBalanceConfig loaded = GSON.fromJson(reader, CrowBalanceConfig.class);
+            if (loaded == null) {
+                GardenKingMod.LOGGER.warn("Crow config file was empty; using defaults");
+                instance = defaults;
+            } else {
+                loaded.validateAndApplyDefaults(defaults);
+                instance = loaded;
+            }
+        } catch (IOException exception) {
+            GardenKingMod.LOGGER.warn("Failed to read crow config; falling back to defaults", exception);
+            instance = defaults;
+        }
+    }
+
+    private static void writeConfigFile(CrowBalanceConfig config) {
+        try (BufferedWriter writer = Files.newBufferedWriter(CONFIG_PATH)) {
+            GSON.toJson(config, writer);
+        } catch (IOException exception) {
+            GardenKingMod.LOGGER.warn("Failed to write default crow config", exception);
+        }
+    }
+
+    private void validateAndApplyDefaults(CrowBalanceConfig defaults) {
+        if (minHungerTicks <= 0) {
+            minHungerTicks = defaults.minHungerTicks;
+        }
+
+        if (maxHungerTicks < minHungerTicks) {
+            maxHungerTicks = Math.max(minHungerTicks, defaults.maxHungerTicks);
+        }
+
+        if (cropSearchHorizontal <= 0) {
+            cropSearchHorizontal = defaults.cropSearchHorizontal;
+        }
+
+        if (cropSearchVertical <= 0) {
+            cropSearchVertical = defaults.cropSearchVertical;
+        }
+
+        if (randomFlightRange <= 0.0) {
+            randomFlightRange = defaults.randomFlightRange;
+        }
+
+        if (perchSearchRange <= 0.0) {
+            perchSearchRange = defaults.perchSearchRange;
+        }
+
+        if (wardHorizontalRadius <= 0.0) {
+            wardHorizontalRadius = defaults.wardHorizontalRadius;
+        }
+
+        if (wardVerticalRadius <= 0.0) {
+            wardVerticalRadius = defaults.wardVerticalRadius;
+        }
+
+        if (wardFearRadiusMultiplier <= 0.0) {
+            wardFearRadiusMultiplier = defaults.wardFearRadiusMultiplier;
+        }
+
+        if (baseHealth <= 0.0) {
+            baseHealth = defaults.baseHealth;
+        }
+
+        if (flyingSpeed <= 0.0) {
+            flyingSpeed = defaults.flyingSpeed;
+        }
+
+        if (movementSpeed <= 0.0) {
+            movementSpeed = defaults.movementSpeed;
+        }
+
+        if (spawnWeight < 0) {
+            spawnWeight = defaults.spawnWeight;
+        }
+    }
+
+    public static CrowBalanceConfig get() {
+        return instance;
+    }
+
+    public int chooseHungerDuration() {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        int min = Math.min(minHungerTicks, maxHungerTicks);
+        int max = Math.max(minHungerTicks, maxHungerTicks);
+        if (min == max) {
+            return min;
+        }
+        return random.nextInt(min, max + 1);
+    }
+
+    public int cropSearchHorizontal() {
+        return cropSearchHorizontal;
+    }
+
+    public int cropSearchVertical() {
+        return cropSearchVertical;
+    }
+
+    public double randomFlightRange() {
+        return randomFlightRange;
+    }
+
+    public double perchSearchRange() {
+        return perchSearchRange;
+    }
+
+    public double wardHorizontalRadius() {
+        return wardHorizontalRadius;
+    }
+
+    public double wardVerticalRadius() {
+        return wardVerticalRadius;
+    }
+
+    public double wardFearRadiusMultiplier() {
+        return wardFearRadiusMultiplier;
+    }
+
+    public boolean dropLootOnCropBreak() {
+        return dropLootOnCropBreak;
+    }
+
+    public double baseHealth() {
+        return baseHealth;
+    }
+
+    public double flyingSpeed() {
+        return flyingSpeed;
+    }
+
+    public double movementSpeed() {
+        return movementSpeed;
+    }
+
+    public int spawnWeight() {
+        return spawnWeight;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(Locale.ROOT,
+                "CrowBalanceConfig{hunger=%d-%d,cropRadius=%d,%d,wardRadius=%.2f/%.2f,loot=%s}",
+                minHungerTicks, maxHungerTicks, cropSearchHorizontal, cropSearchVertical, wardHorizontalRadius,
+                wardVerticalRadius, dropLootOnCropBreak);
+    }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowEntity.java
@@ -1,0 +1,442 @@
+package net.jeremy.gardenkingmod.entity.crow;
+
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.CropBlock;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.ai.control.FlightMoveControl;
+import net.minecraft.entity.ai.goal.LookAroundGoal;
+import net.minecraft.entity.ai.goal.LookAtEntityGoal;
+import net.minecraft.entity.ai.pathing.BirdNavigation;
+import net.minecraft.entity.ai.pathing.EntityNavigation;
+import net.minecraft.entity.ai.pathing.PathNodeType;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.MovementType;
+import net.minecraft.entity.data.DataTracker;
+import net.minecraft.entity.data.TrackedData;
+import net.minecraft.entity.data.TrackedDataHandlerRegistry;
+import net.minecraft.entity.mob.PathAwareEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldView;
+
+import net.jeremy.gardenkingmod.registry.ModEntities;
+
+/**
+ * Server-side implementation of the crow mob. Handles configuration-driven
+ * hunger timers, crop hunting, and ward awareness.
+ */
+public class CrowEntity extends PathAwareEntity {
+    private static final TrackedData<Integer> HUNGER_TICKS = DataTracker.registerData(CrowEntity.class,
+            TrackedDataHandlerRegistry.INTEGER);
+    private static final TrackedData<Boolean> HUNGRY = DataTracker.registerData(CrowEntity.class,
+            TrackedDataHandlerRegistry.BOOLEAN);
+
+    private int timeSinceCropBreak;
+
+    public CrowEntity(EntityType<? extends CrowEntity> entityType, World world) {
+        super(entityType, world);
+        this.moveControl = new FlightMoveControl(this, 8, true);
+        this.setPathfindingPenalty(PathNodeType.DANGER_FIRE, 0.0f);
+        this.setPathfindingPenalty(PathNodeType.DAMAGE_FIRE, 0.0f);
+        this.setPathfindingPenalty(PathNodeType.WATER, -1.0f);
+        this.noClip = true;
+        this.experiencePoints = 3;
+    }
+
+    /**
+     * Defines the base attribute container using the values supplied by the
+     * configuration.
+     */
+    public static DefaultAttributeContainer.Builder createCrowAttributes() {
+        CrowBalanceConfig config = CrowBalanceConfig.get();
+        return PathAwareEntity.createMobAttributes()
+                .add(EntityAttributes.GENERIC_MAX_HEALTH, config.baseHealth())
+                .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, config.movementSpeed())
+                .add(EntityAttributes.GENERIC_FLYING_SPEED, config.flyingSpeed())
+                .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 2.0);
+    }
+
+    @Override
+    protected void initGoals() {
+        this.goalSelector.add(0, new CrowAiGoals.CrowFleeWardingGoal(this));
+        this.goalSelector.add(1, new CrowAiGoals.CrowBreakCropGoal(this));
+        this.goalSelector.add(2, new CrowAiGoals.CrowRandomFlyGoal(this));
+        this.goalSelector.add(3, new CrowAiGoals.CrowPerchGoal(this));
+        this.goalSelector.add(6, new LookAroundGoal(this));
+        this.goalSelector.add(7, new LookAtEntityGoal(this, PlayerEntity.class, 8.0f));
+    }
+
+    @Override
+    protected EntityNavigation createNavigation(World world) {
+        BirdNavigation navigation = new BirdNavigation(this, world);
+        navigation.setCanEnterOpenDoors(true);
+        navigation.setCanSwim(false);
+        return navigation;
+    }
+
+    @Override
+    protected void initDataTracker() {
+        super.initDataTracker();
+        this.dataTracker.startTracking(HUNGER_TICKS, CrowBalanceConfig.get().chooseHungerDuration());
+        this.dataTracker.startTracking(HUNGRY, false);
+    }
+
+    @Override
+    public void tickMovement() {
+        super.tickMovement();
+        if (!this.getWorld().isClient) {
+            tickHunger();
+        }
+    }
+
+    private void tickHunger() {
+        if (isHungry()) {
+            return;
+        }
+
+        int hunger = getHungerTicks();
+        if (hunger > 0) {
+            setHungerTicks(hunger - 1);
+        } else {
+            setHungry(true);
+        }
+    }
+
+    @Override
+    public void mobTick() {
+        super.mobTick();
+        if (timeSinceCropBreak < Integer.MAX_VALUE) {
+            timeSinceCropBreak++;
+        }
+    }
+
+    @Override
+    public boolean isFlappingWings() {
+        return !this.isOnGround() && this.getVelocity().lengthSquared() > 1.0E-4;
+    }
+
+    @Override
+    public void travel(Vec3d movementInput) {
+        if (this.isTouchingWater()) {
+            this.updateVelocity(0.02f, movementInput);
+            this.move(MovementType.SELF, this.getVelocity());
+            this.setVelocity(this.getVelocity().multiply(0.8f));
+            return;
+        }
+
+        if (this.isInLava()) {
+            this.updateVelocity(0.02f, movementInput);
+            this.move(MovementType.SELF, this.getVelocity());
+            this.setVelocity(this.getVelocity().multiply(0.5));
+            return;
+        }
+
+        float speed = 0.1f;
+        this.updateVelocity(speed, movementInput);
+        this.move(MovementType.SELF, this.getVelocity());
+        this.setVelocity(this.getVelocity().multiply(0.91));
+    }
+
+    @Override
+    public void setNoGravity(boolean noGravity) {
+        super.setNoGravity(true);
+    }
+
+    @Override
+    public boolean hasNoGravity() {
+        return true;
+    }
+
+    @Override
+    public boolean canSpawn(WorldView world) {
+        return world.doesNotIntersectEntities(this);
+    }
+
+    @Override
+    public void playAmbientSound() {
+        SoundEvent soundEvent = getAmbientSound();
+        if (soundEvent != null) {
+            this.getWorld().playSound(null, this.getX(), this.getY(), this.getZ(), soundEvent, SoundCategory.NEUTRAL,
+                    0.8f, 0.9f + this.random.nextFloat() * 0.2f);
+        }
+    }
+
+    @Override
+    protected SoundEvent getAmbientSound() {
+        return SoundEvents.ENTITY_PARROT_AMBIENT;
+    }
+
+    @Override
+    protected SoundEvent getHurtSound(DamageSource source) {
+        return SoundEvents.ENTITY_PARROT_HURT;
+    }
+
+    @Override
+    protected SoundEvent getDeathSound() {
+        return SoundEvents.ENTITY_PARROT_DEATH;
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource damageSource) {
+        if (damageSource == this.getDamageSources().fall()) {
+            return true;
+        }
+        return super.isInvulnerableTo(damageSource);
+    }
+
+    public int getHungerTicks() {
+        return this.dataTracker.get(HUNGER_TICKS);
+    }
+
+    public void setHungerTicks(int ticks) {
+        this.dataTracker.set(HUNGER_TICKS, Math.max(0, ticks));
+    }
+
+    public boolean isHungry() {
+        return this.dataTracker.get(HUNGRY);
+    }
+
+    public void setHungry(boolean hungry) {
+        this.dataTracker.set(HUNGRY, hungry);
+    }
+
+    public void resetHunger() {
+        setHungry(false);
+        setHungerTicks(CrowBalanceConfig.get().chooseHungerDuration());
+        timeSinceCropBreak = 0;
+    }
+
+    public int getTimeSinceCropBreak() {
+        return timeSinceCropBreak;
+    }
+
+    public Optional<BlockPos> findCropTarget() {
+        if (!(this.getWorld() instanceof ServerWorld serverWorld)) {
+            return Optional.empty();
+        }
+
+        CrowBalanceConfig config = CrowBalanceConfig.get();
+        BlockPos origin = this.getBlockPos();
+        int horizontal = config.cropSearchHorizontal();
+        int vertical = config.cropSearchVertical();
+        BlockPos.Mutable mutable = new BlockPos.Mutable();
+        BlockPos best = null;
+        double bestDistance = Double.MAX_VALUE;
+
+        for (int y = -vertical; y <= vertical; y++) {
+            int actualY = origin.getY() + y;
+            if (actualY < serverWorld.getBottomY() || actualY > serverWorld.getTopY() - 1) {
+                continue;
+            }
+
+            for (int dx = -horizontal; dx <= horizontal; dx++) {
+                for (int dz = -horizontal; dz <= horizontal; dz++) {
+                    mutable.set(origin.getX() + dx, actualY, origin.getZ() + dz);
+                    if (!serverWorld.isChunkLoaded(mutable)) {
+                        continue;
+                    }
+
+                    BlockState state = serverWorld.getBlockState(mutable);
+                    if (!state.isIn(CrowTags.CROW_TARGET_CROPS)) {
+                        continue;
+                    }
+
+                    if (!isMatureCrop(state)) {
+                        continue;
+                    }
+
+                    double distance = mutable.getSquaredDistance(origin);
+                    if (distance < bestDistance) {
+                        bestDistance = distance;
+                        best = mutable.toImmutable();
+                    }
+                }
+            }
+        }
+
+        return Optional.ofNullable(best);
+    }
+
+    public boolean isMatureCrop(BlockState state) {
+        if (state.getBlock() instanceof CropBlock cropBlock) {
+            return cropBlock.isMature(state);
+        }
+        return true;
+    }
+
+    public boolean tryBreakCrop(BlockPos pos) {
+        if (!(this.getWorld() instanceof ServerWorld serverWorld)) {
+            return false;
+        }
+
+        if (!serverWorld.getGameRules().getBoolean(ModEntities.CROW_GRIEFING_RULE)) {
+            return false;
+        }
+
+        BlockState state = serverWorld.getBlockState(pos);
+        if (!state.isIn(CrowTags.CROW_TARGET_CROPS)) {
+            return false;
+        }
+
+        if (!isMatureCrop(state)) {
+            return false;
+        }
+
+        boolean dropLoot = CrowBalanceConfig.get().dropLootOnCropBreak();
+        boolean broke = serverWorld.breakBlock(pos, dropLoot, this);
+        if (broke) {
+            onCropBroken(state, pos);
+        }
+        return broke;
+    }
+
+    protected void onCropBroken(BlockState state, BlockPos pos) {
+        this.resetHunger();
+        this.playSound(SoundEvents.ENTITY_PARROT_EAT, 0.9f, 0.9f + this.random.nextFloat() * 0.2f);
+    }
+
+    public Optional<BlockPos> findNearestWard() {
+        if (!(this.getWorld() instanceof ServerWorld serverWorld)) {
+            return Optional.empty();
+        }
+
+        CrowBalanceConfig config = CrowBalanceConfig.get();
+        double multiplier = config.wardFearRadiusMultiplier();
+        int horizontal = MathHelper.ceil(config.wardHorizontalRadius() * multiplier);
+        int vertical = MathHelper.ceil(config.wardVerticalRadius() * multiplier);
+        BlockPos origin = this.getBlockPos();
+        BlockPos.Mutable mutable = new BlockPos.Mutable();
+        BlockPos closest = null;
+        double closestDistance = Double.MAX_VALUE;
+
+        for (int y = -vertical; y <= vertical; y++) {
+            int actualY = origin.getY() + y;
+            if (actualY < serverWorld.getBottomY() || actualY > serverWorld.getTopY() - 1) {
+                continue;
+            }
+
+            for (int dx = -horizontal; dx <= horizontal; dx++) {
+                for (int dz = -horizontal; dz <= horizontal; dz++) {
+                    mutable.set(origin.getX() + dx, actualY, origin.getZ() + dz);
+                    if (!serverWorld.isChunkLoaded(mutable)) {
+                        continue;
+                    }
+
+                    BlockState state = serverWorld.getBlockState(mutable);
+                    if (!state.isIn(CrowTags.CROW_WARD_BLOCKS)) {
+                        continue;
+                    }
+
+                    double distance = mutable.getSquaredDistance(origin);
+                    if (distance < closestDistance) {
+                        closestDistance = distance;
+                        closest = mutable.toImmutable();
+                    }
+                }
+            }
+        }
+
+        return Optional.ofNullable(closest);
+    }
+
+    public Optional<BlockPos> findPerchTarget() {
+        if (!(this.getWorld() instanceof ServerWorld serverWorld)) {
+            return Optional.empty();
+        }
+
+        CrowBalanceConfig config = CrowBalanceConfig.get();
+        int range = MathHelper.ceil(config.perchSearchRange());
+        BlockPos origin = this.getBlockPos();
+        BlockPos.Mutable mutable = new BlockPos.Mutable();
+
+        for (int attempt = 0; attempt < 12; attempt++) {
+            int dx = MathHelper.nextInt(this.random, -range, range);
+            int dz = MathHelper.nextInt(this.random, -range, range);
+            int dy = MathHelper.nextInt(this.random, -2, 2);
+            mutable.set(origin.getX() + dx, origin.getY() + dy, origin.getZ() + dz);
+            if (!serverWorld.isChunkLoaded(mutable)) {
+                continue;
+            }
+
+            BlockState state = serverWorld.getBlockState(mutable);
+            if (!state.isIn(CrowTags.CROW_PERCH_BLOCKS)) {
+                continue;
+            }
+
+            BlockPos above = mutable.up();
+            if (!serverWorld.isAir(above)) {
+                continue;
+            }
+
+            return Optional.of(above);
+        }
+
+        return Optional.empty();
+    }
+
+    @Nullable
+    public Vec3d getRandomFlightTarget() {
+        CrowBalanceConfig config = CrowBalanceConfig.get();
+        Vec3d base = this.getPos();
+        Vec3d wardCenter = findNearestWard().map(Vec3d::ofCenter).orElse(null);
+        double range = Math.max(4.0, config.randomFlightRange());
+
+        for (int attempt = 0; attempt < 12; attempt++) {
+            double dx = (this.random.nextDouble() * 2.0 - 1.0) * range;
+            double dy = (this.random.nextDouble() * 0.6 - 0.3) * range;
+            double dz = (this.random.nextDouble() * 2.0 - 1.0) * range;
+            Vec3d candidate = base.add(dx, dy, dz);
+            if (wardCenter != null) {
+                double currentDistance = base.squaredDistanceTo(wardCenter);
+                double candidateDistance = candidate.squaredDistanceTo(wardCenter);
+                if (candidateDistance <= currentDistance) {
+                    continue;
+                }
+            }
+
+            if (this.getWorld().isChunkLoaded(BlockPos.ofFloored(candidate))) {
+                return candidate;
+            }
+        }
+
+        if (wardCenter != null) {
+            Vec3d direction = base.subtract(wardCenter);
+            if (direction.lengthSquared() > 1.0E-4) {
+                return base.add(direction.normalize());
+            }
+        }
+
+        return base.add(0.0, 0.5, 0.0);
+    }
+
+    @Override
+    public void writeCustomDataToNbt(NbtCompound nbt) {
+        super.writeCustomDataToNbt(nbt);
+        nbt.putInt("HungerTicks", getHungerTicks());
+        nbt.putBoolean("Hungry", isHungry());
+        nbt.putInt("TimeSinceCropBreak", timeSinceCropBreak);
+    }
+
+    @Override
+    public void readCustomDataFromNbt(NbtCompound nbt) {
+        super.readCustomDataFromNbt(nbt);
+        setHungerTicks(nbt.getInt("HungerTicks"));
+        setHungry(nbt.getBoolean("Hungry"));
+        timeSinceCropBreak = nbt.getInt("TimeSinceCropBreak");
+    }
+
+}

--- a/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowTags.java
+++ b/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowTags.java
@@ -1,0 +1,30 @@
+package net.jeremy.gardenkingmod.entity.crow;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.minecraft.block.Block;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.biome.Biome;
+
+/**
+ * Constants that expose the data-driven hooks used by the crow entity. Pack
+ * authors can refer to these keys in biome tags and block tags to control
+ * spawning and behavior without modifying Java code.
+ */
+public final class CrowTags {
+    public static final TagKey<Biome> CROW_SPAWN_BIOMES = TagKey.of(RegistryKeys.BIOME,
+            new Identifier(GardenKingMod.MOD_ID, "spawns_crows"));
+
+    public static final TagKey<Block> CROW_TARGET_CROPS = TagKey.of(RegistryKeys.BLOCK,
+            new Identifier(GardenKingMod.MOD_ID, "crow_targets"));
+
+    public static final TagKey<Block> CROW_PERCH_BLOCKS = TagKey.of(RegistryKeys.BLOCK,
+            new Identifier(GardenKingMod.MOD_ID, "crow_perches"));
+
+    public static final TagKey<Block> CROW_WARD_BLOCKS = TagKey.of(RegistryKeys.BLOCK,
+            new Identifier(GardenKingMod.MOD_ID, "crow_wards"));
+
+    private CrowTags() {
+    }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/registry/ModEntities.java
+++ b/src/main/java/net/jeremy/gardenkingmod/registry/ModEntities.java
@@ -1,0 +1,40 @@
+package net.jeremy.gardenkingmod.registry;
+
+import net.fabricmc.fabric.api.gamerule.v1.GameRuleFactory;
+import net.fabricmc.fabric.api.gamerule.v1.GameRuleRegistry;
+import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
+import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.entity.crow.CrowBalanceConfig;
+import net.jeremy.gardenkingmod.entity.crow.CrowEntity;
+
+import net.minecraft.entity.EntityDimensions;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.SpawnGroup;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.GameRules;
+
+/**
+ * Registers all custom entity types and related game rules.
+ */
+public final class ModEntities {
+    public static final GameRules.Key<GameRules.BooleanRule> CROW_GRIEFING_RULE = GameRuleRegistry.register(
+            "crowGriefing", GameRules.Category.MOBS, GameRuleFactory.createBooleanRule(true));
+
+    public static final EntityType<CrowEntity> CROW = Registry.register(Registries.ENTITY_TYPE,
+            new Identifier(GardenKingMod.MOD_ID, "crow"),
+            FabricEntityTypeBuilder.<CrowEntity>create(SpawnGroup.CREATURE, CrowEntity::new)
+                    .dimensions(EntityDimensions.changing(0.6f, 0.8f)).trackRangeBlocks(10).build());
+
+    private ModEntities() {
+    }
+
+    public static void register() {
+        CrowBalanceConfig.reload();
+        FabricDefaultAttributeRegistry.register(CROW, CrowEntity.createCrowAttributes());
+        GardenKingMod.LOGGER.info("Registered crow entity with config {}", CrowBalanceConfig.get());
+    }
+}


### PR DESCRIPTION
## Summary
- add a crow entity implementation with hunger timers, ward detection, crop hunting goals, and data tag helpers
- introduce a crow balance config loader plus a registry class that wires the entity type, attributes, and gamerule
- hook client rendering/model layers and expose the crow texture path for future art assets

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d5c6a736a883218ae312f46326eb03