### PR TITLE
Fix entity registration entrypoint

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
@@ -22,10 +22,9 @@ public class GardenKingMod implements ModInitializer {
                 ModItems.registerModItems();
                 ModBlocks.registerModBlocks();
                 ModBlockEntities.registerBlockEntities();
-                ModEntities.registerModEntities();
+                ModEntities.register();
                 ModScreenHandlers.registerScreenHandlers();
                 ModScoreboards.registerScoreboards();
-                ModEntities.register();
 
                 ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(BonusHarvestDropManager.getInstance());
 


### PR DESCRIPTION
## Summary
- replace the mod entity registration call in the entrypoint with the consolidated `ModEntities.register()`
- ensure entities are only registered once during initialization

## Testing
- `./gradlew build` *(fails: existing client model classes reference missing Minecraft types)*

------
https://chatgpt.com/codex/tasks/task_e_68d60d6000f48321ab0be5872de2aa81