### PR TITLE
Fix crow model import package

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/CrowEntityModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/CrowEntityModel.java
@@ -8,10 +8,10 @@ import net.minecraft.client.model.ModelPart;
 import net.minecraft.client.model.ModelPartBuilder;
 import net.minecraft.client.model.ModelPartData;
 import net.minecraft.client.model.ModelTransform;
-import net.minecraft.client.model.SinglePartEntityModel;
 import net.minecraft.client.model.TexturedModelData;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.model.EntityModelLayer;
+import net.minecraft.client.render.entity.model.SinglePartEntityModel;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 

--- a/src/main/java/net/jeremy/gardenkingmod/client/model/scarecrow.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/scarecrow.java
@@ -1,5 +1,17 @@
 package net.jeremy.gardenkingmod.client.model;
 
+import net.minecraft.client.model.Dilation;
+import net.minecraft.client.model.ModelData;
+import net.minecraft.client.model.ModelPart;
+import net.minecraft.client.model.ModelPartBuilder;
+import net.minecraft.client.model.ModelPartData;
+import net.minecraft.client.model.ModelTransform;
+import net.minecraft.client.model.TexturedModelData;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.entity.model.EntityModel;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.Entity;
+
 // Made with Blockbench 4.12.6
 // Exported for Minecraft version 1.17+ for Yarn
 // Paste this class into your mod and generate all required imports


### PR DESCRIPTION
## Summary
- fix the crow entity model to use the render package SinglePartEntityModel class
- add the missing Minecraft client/model imports to the scarecrow model stub so it compiles

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68d60e083810832183237064a719cd8b