### PR TITLE
Add cutout render type to scarecrow model

### DIFF
--- a/src/main/resources/assets/gardenkingmod/models/block/scarecrow.json
+++ b/src/main/resources/assets/gardenkingmod/models/block/scarecrow.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "textures": {
     "particle": "gardenkingmod:block/scarecrow",
     "all": "gardenkingmod:block/scarecrow"


### PR DESCRIPTION
## Summary
- add a cutout render type entry to the scarecrow block model so the baked model uses the correct layer

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d62d1823a48321a34e0c788da45685