### PR TITLE
Align market block renderer with block facing

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/render/MarketBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/MarketBlockEntityRenderer.java
@@ -1,6 +1,7 @@
 package net.jeremy.gardenkingmod.client.render;
 
 import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.block.MarketBlock;
 import net.jeremy.gardenkingmod.block.entity.MarketBlockEntity;
 import net.jeremy.gardenkingmod.client.model.MarketBlockModel;
 import net.minecraft.client.render.LightmapTextureManager;
@@ -14,6 +15,7 @@ import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.RotationAxis;
 import net.minecraft.world.World;
 
@@ -32,6 +34,19 @@ public class MarketBlockEntityRenderer implements BlockEntityRenderer<MarketBloc
                         VertexConsumerProvider vertexConsumers, int light, int overlay) {
                 matrices.push();
                 matrices.translate(0.5f, 1.5f, 0.5f);
+
+                Direction facing = entity.getCachedState() != null ? entity.getCachedState().get(MarketBlock.FACING) : null;
+                if (facing != null) {
+                        float yRotation;
+                        switch (facing) {
+                                case NORTH -> yRotation = 0.0f;
+                                case EAST -> yRotation = 90.0f;
+                                case SOUTH -> yRotation = 180.0f;
+                                case WEST -> yRotation = 270.0f;
+                                default -> yRotation = 0.0f;
+                        }
+                        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(yRotation));
+                }
                 matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
 
                 World world = entity.getWorld();


### PR DESCRIPTION
## Summary
- rotate the market block entity model around the Y axis based on the block's facing before rendering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d63cd94b2083218f1ad272996a377a