### PR TITLE
Expand scarecrow block model

### DIFF
--- a/src/main/resources/assets/gardenkingmod/models/block/scarecrow.json
+++ b/src/main/resources/assets/gardenkingmod/models/block/scarecrow.json
@@ -1,6 +1,638 @@
 {
-  "parent": "minecraft:block/cube_all",
+  "parent": "minecraft:block/block",
   "textures": {
-    "all": "gardenkingmod:block/scarecrow"
+    "particle": "gardenkingmod:block/scarecrow",
+    "scarecrow": "gardenkingmod:block/scarecrow"
+  },
+  "elements": [
+    {
+      "name": "base",
+      "from": [
+        2.0,
+        0.0,
+        2.0
+      ],
+      "to": [
+        14.0,
+        2.0,
+        14.0
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            0.0,
+            96.0,
+            24.0,
+            112.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "east": {
+          "uv": [
+            24.0,
+            96.0,
+            48.0,
+            112.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "south": {
+          "uv": [
+            48.0,
+            96.0,
+            72.0,
+            112.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "west": {
+          "uv": [
+            72.0,
+            96.0,
+            96.0,
+            112.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "up": {
+          "uv": [
+            0.0,
+            112.0,
+            24.0,
+            128.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "down": {
+          "uv": [
+            24.0,
+            112.0,
+            48.0,
+            128.0
+          ],
+          "texture": "#scarecrow"
+        }
+      }
+    },
+    {
+      "name": "post",
+      "from": [
+        7.0,
+        2.0,
+        7.0
+      ],
+      "to": [
+        9.0,
+        38.0,
+        9.0
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            96.0,
+            0.0,
+            104.0,
+            128.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "east": {
+          "uv": [
+            104.0,
+            0.0,
+            112.0,
+            128.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "south": {
+          "uv": [
+            112.0,
+            0.0,
+            120.0,
+            128.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "west": {
+          "uv": [
+            120.0,
+            0.0,
+            128.0,
+            128.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "up": {
+          "uv": [
+            96.0,
+            120.0,
+            104.0,
+            128.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "down": {
+          "uv": [
+            104.0,
+            120.0,
+            112.0,
+            128.0
+          ],
+          "texture": "#scarecrow"
+        }
+      }
+    },
+    {
+      "name": "torso",
+      "from": [
+        4.0,
+        22.0,
+        4.0
+      ],
+      "to": [
+        12.0,
+        34.0,
+        12.0
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            32.0,
+            64.0,
+            48.0,
+            96.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "east": {
+          "uv": [
+            48.0,
+            64.0,
+            64.0,
+            96.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "south": {
+          "uv": [
+            64.0,
+            64.0,
+            80.0,
+            96.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "west": {
+          "uv": [
+            80.0,
+            64.0,
+            96.0,
+            96.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "up": {
+          "uv": [
+            32.0,
+            96.0,
+            48.0,
+            112.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "down": {
+          "uv": [
+            48.0,
+            96.0,
+            64.0,
+            112.0
+          ],
+          "texture": "#scarecrow"
+        }
+      }
+    },
+    {
+      "name": "left_arm",
+      "from": [
+        12.0,
+        26.0,
+        5.5
+      ],
+      "to": [
+        20.0,
+        30.0,
+        10.5
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            0.0,
+            64.0,
+            16.0,
+            80.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "east": {
+          "uv": [
+            16.0,
+            64.0,
+            24.0,
+            80.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "south": {
+          "uv": [
+            24.0,
+            64.0,
+            40.0,
+            80.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "west": {
+          "uv": [
+            40.0,
+            64.0,
+            48.0,
+            80.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "up": {
+          "uv": [
+            0.0,
+            80.0,
+            16.0,
+            88.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "down": {
+          "uv": [
+            16.0,
+            80.0,
+            32.0,
+            88.0
+          ],
+          "texture": "#scarecrow"
+        }
+      }
+    },
+    {
+      "name": "right_arm",
+      "from": [
+        -4.0,
+        26.0,
+        5.5
+      ],
+      "to": [
+        4.0,
+        30.0,
+        10.5
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            0.0,
+            80.0,
+            16.0,
+            96.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "east": {
+          "uv": [
+            16.0,
+            80.0,
+            24.0,
+            96.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "south": {
+          "uv": [
+            24.0,
+            80.0,
+            40.0,
+            96.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "west": {
+          "uv": [
+            40.0,
+            80.0,
+            48.0,
+            96.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "up": {
+          "uv": [
+            0.0,
+            96.0,
+            16.0,
+            104.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "down": {
+          "uv": [
+            16.0,
+            96.0,
+            32.0,
+            104.0
+          ],
+          "texture": "#scarecrow"
+        }
+      }
+    },
+    {
+      "name": "head",
+      "from": [
+        5.0,
+        34.0,
+        5.0
+      ],
+      "to": [
+        11.0,
+        42.0,
+        11.0
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            0.0,
+            32.0,
+            12.0,
+            48.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "east": {
+          "uv": [
+            12.0,
+            32.0,
+            24.0,
+            48.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "south": {
+          "uv": [
+            24.0,
+            32.0,
+            36.0,
+            48.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "west": {
+          "uv": [
+            36.0,
+            32.0,
+            48.0,
+            48.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "up": {
+          "uv": [
+            48.0,
+            32.0,
+            60.0,
+            44.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "down": {
+          "uv": [
+            60.0,
+            32.0,
+            72.0,
+            44.0
+          ],
+          "texture": "#scarecrow"
+        }
+      }
+    },
+    {
+      "name": "hat_brim",
+      "from": [
+        4.0,
+        42.0,
+        4.0
+      ],
+      "to": [
+        12.0,
+        44.0,
+        12.0
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            72.0,
+            32.0,
+            88.0,
+            40.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "east": {
+          "uv": [
+            88.0,
+            32.0,
+            104.0,
+            40.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "south": {
+          "uv": [
+            104.0,
+            32.0,
+            120.0,
+            40.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "west": {
+          "uv": [
+            120.0,
+            32.0,
+            128.0,
+            40.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "up": {
+          "uv": [
+            72.0,
+            40.0,
+            88.0,
+            56.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "down": {
+          "uv": [
+            88.0,
+            40.0,
+            104.0,
+            56.0
+          ],
+          "texture": "#scarecrow"
+        }
+      }
+    },
+    {
+      "name": "hat_crown",
+      "from": [
+        5.0,
+        44.0,
+        5.0
+      ],
+      "to": [
+        11.0,
+        48.0,
+        11.0
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            0.0,
+            16.0,
+            12.0,
+            32.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "east": {
+          "uv": [
+            12.0,
+            16.0,
+            24.0,
+            32.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "south": {
+          "uv": [
+            24.0,
+            16.0,
+            36.0,
+            32.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "west": {
+          "uv": [
+            36.0,
+            16.0,
+            48.0,
+            32.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "up": {
+          "uv": [
+            48.0,
+            16.0,
+            60.0,
+            28.0
+          ],
+          "texture": "#scarecrow"
+        },
+        "down": {
+          "uv": [
+            60.0,
+            16.0,
+            72.0,
+            28.0
+          ],
+          "texture": "#scarecrow"
+        }
+      }
+    }
+  ],
+  "display": {
+    "gui": {
+      "rotation": [
+        30,
+        225,
+        0
+      ],
+      "translation": [
+        0,
+        0,
+        0
+      ],
+      "scale": [
+        0.8,
+        0.8,
+        0.8
+      ]
+    },
+    "ground": {
+      "translation": [
+        0,
+        3,
+        0
+      ],
+      "scale": [
+        0.6,
+        0.6,
+        0.6
+      ]
+    },
+    "fixed": {
+      "rotation": [
+        0,
+        90,
+        0
+      ],
+      "scale": [
+        0.8,
+        0.8,
+        0.8
+      ]
+    },
+    "thirdperson_righthand": {
+      "rotation": [
+        75,
+        45,
+        0
+      ],
+      "translation": [
+        0,
+        2.5,
+        0
+      ],
+      "scale": [
+        0.55,
+        0.55,
+        0.55
+      ]
+    },
+    "firstperson_righthand": {
+      "rotation": [
+        0,
+        45,
+        0
+      ],
+      "translation": [
+        0,
+        4,
+        0
+      ],
+      "scale": [
+        0.6,
+        0.6,
+        0.6
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- replace the scarecrow block model with a multi-part 3-block-tall geometry aligned to the 128x128 texture atlas
- keep the held item model inheriting from the updated block model so it reuses the corrected UVs

## Testing
- not run (data-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d6769578b48321899bf2624715c7b5