### PR TITLE
Add scarecrow block entity renderer

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -9,10 +9,12 @@ import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
-import net.jeremy.gardenkingmod.client.model.MarketBlockModel;
-import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.model.CrowEntityModel;
+import net.jeremy.gardenkingmod.client.model.MarketBlockModel;
+import net.jeremy.gardenkingmod.client.model.ScarecrowModel;
 import net.jeremy.gardenkingmod.client.render.CrowEntityRenderer;
+import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
+import net.jeremy.gardenkingmod.client.render.ScarecrowBlockEntityRenderer;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.item.FortuneProvidingItem;
 import net.jeremy.gardenkingmod.network.ModPackets;
@@ -34,9 +36,11 @@ public class GardenKingModClient implements ClientModInitializer {
         HandledScreens.register(ModScreenHandlers.MARKET_SCREEN_HANDLER, MarketScreen::new);
         HandledScreens.register(ModScreenHandlers.SCARECROW_SCREEN_HANDLER, ScarecrowScreen::new);
         EntityModelLayerRegistry.registerModelLayer(MarketBlockModel.LAYER_LOCATION, MarketBlockModel::getTexturedModelData);
+        EntityModelLayerRegistry.registerModelLayer(ScarecrowModel.LAYER_LOCATION, ScarecrowModel::getTexturedModelData);
 
         EntityModelLayerRegistry.registerModelLayer(CrowEntityModel.LAYER_LOCATION, CrowEntityModel::getTexturedModelData);
         BlockEntityRendererFactories.register(ModBlockEntities.MARKET_BLOCK_ENTITY, MarketBlockEntityRenderer::new);
+        BlockEntityRendererFactories.register(ModBlockEntities.SCARECROW_BLOCK_ENTITY, ScarecrowBlockEntityRenderer::new);
         EntityRendererRegistry.register(ModEntities.CROW, CrowEntityRenderer::new);
         BlockRenderLayerMap.INSTANCE.putBlock(ModBlocks.SCARECROW_BLOCK, RenderLayer.getCutout());
 

--- a/src/main/java/net/jeremy/gardenkingmod/block/ward/ScarecrowBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/ward/ScarecrowBlock.java
@@ -51,7 +51,7 @@ public class ScarecrowBlock extends BlockWithEntity {
 
         @Override
         public BlockRenderType getRenderType(BlockState state) {
-                return BlockRenderType.MODEL;
+                return BlockRenderType.ENTITYBLOCK_ANIMATED;
         }
 
         @Override

--- a/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
@@ -1,5 +1,6 @@
 package net.jeremy.gardenkingmod.client.model;
 
+import net.jeremy.gardenkingmod.GardenKingMod;
 import net.minecraft.client.model.Dilation;
 import net.minecraft.client.model.ModelData;
 import net.minecraft.client.model.ModelPart;
@@ -9,13 +10,20 @@ import net.minecraft.client.model.ModelTransform;
 import net.minecraft.client.model.TexturedModelData;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.model.EntityModel;
+import net.minecraft.client.render.entity.model.EntityModelLayer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
+import net.minecraft.util.Identifier;
 
 // Made with Blockbench 4.12.6
 // Exported for Minecraft version 1.17+ for Yarn
 // Paste this class into your mod and generate all required imports
 public class ScarecrowModel extends EntityModel<Entity> {
+    public static final EntityModelLayer LAYER_LOCATION = new EntityModelLayer(
+            new Identifier(GardenKingMod.MOD_ID, "scarecrow"),
+            "main"
+    );
+
     private final ModelPart bb_main;
     public ScarecrowModel(ModelPart root) {
         this.bb_main = root.getChild("bb_main");

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
@@ -1,0 +1,51 @@
+package net.jeremy.gardenkingmod.client.render;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.block.ward.ScarecrowBlockEntity;
+import net.jeremy.gardenkingmod.client.model.ScarecrowModel;
+import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.render.OverlayTexture;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.client.render.block.entity.BlockEntityRenderer;
+import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RotationAxis;
+import net.minecraft.world.World;
+
+public class ScarecrowBlockEntityRenderer implements BlockEntityRenderer<ScarecrowBlockEntity> {
+    private static final Identifier TEXTURE = new Identifier(
+            GardenKingMod.MOD_ID,
+            "textures/entity/scarecrow/scarecrow.png"
+    );
+
+    private final ScarecrowModel model;
+
+    public ScarecrowBlockEntityRenderer(BlockEntityRendererFactory.Context context) {
+        this.model = new ScarecrowModel(context.getLayerModelPart(ScarecrowModel.LAYER_LOCATION));
+    }
+
+    @Override
+    public void render(ScarecrowBlockEntity entity, float tickDelta, MatrixStack matrices,
+            VertexConsumerProvider vertexConsumers, int light, int overlay) {
+        matrices.push();
+        matrices.translate(0.5f, 1.5f, 0.5f);
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
+
+        World world = entity.getWorld();
+        int combinedLight = LightmapTextureManager.MAX_LIGHT_COORDINATE;
+        if (world != null) {
+            BlockPos exposedPos = entity.getPos().up();
+            combinedLight = WorldRenderer.getLightmapCoordinates(world, exposedPos);
+        }
+
+        VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));
+        this.model.render(matrices, vertexConsumer, combinedLight, OverlayTexture.DEFAULT_UV, 1.0f, 1.0f, 1.0f, 1.0f);
+
+        matrices.pop();
+    }
+}


### PR DESCRIPTION
## Summary
- add a model layer constant to ScarecrowModel so baked parts can be fetched during rendering
- implement a dedicated scarecrow block entity renderer that positions the model and uses the scarecrow texture
- register the scarecrow model layer and renderer on the client and switch the block to ENTITYBLOCK_ANIMATED rendering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d68c4a1678832182aab4aabc40284b