### PR TITLE
Add custom scarecrow item renderer

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -7,6 +7,7 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
 import net.jeremy.gardenkingmod.client.model.CrowEntityModel;
@@ -15,6 +16,7 @@ import net.jeremy.gardenkingmod.client.model.ScarecrowModel;
 import net.jeremy.gardenkingmod.client.render.CrowEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.ScarecrowBlockEntityRenderer;
+import net.jeremy.gardenkingmod.client.render.item.ScarecrowItemRenderer;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.item.FortuneProvidingItem;
 import net.jeremy.gardenkingmod.network.ModPackets;
@@ -42,6 +44,7 @@ public class GardenKingModClient implements ClientModInitializer {
         BlockEntityRendererFactories.register(ModBlockEntities.MARKET_BLOCK_ENTITY, MarketBlockEntityRenderer::new);
         BlockEntityRendererFactories.register(ModBlockEntities.SCARECROW_BLOCK_ENTITY, ScarecrowBlockEntityRenderer::new);
         EntityRendererRegistry.register(ModEntities.CROW, CrowEntityRenderer::new);
+        BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.SCARECROW_BLOCK, new ScarecrowItemRenderer());
         BlockRenderLayerMap.INSTANCE.putBlock(ModBlocks.SCARECROW_BLOCK, RenderLayer.getCutout());
 
         ClientPlayNetworking.registerGlobalReceiver(ModPackets.MARKET_SALE_RESULT_PACKET,

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/item/ScarecrowItemRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/item/ScarecrowItemRenderer.java
@@ -1,0 +1,41 @@
+package net.jeremy.gardenkingmod.client.render.item;
+
+import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.client.model.ScarecrowModel;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.model.json.ModelTransformationMode;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.RotationAxis;
+
+public class ScarecrowItemRenderer implements BuiltinItemRendererRegistry.DynamicItemRenderer {
+    private static final Identifier TEXTURE = new Identifier(
+            GardenKingMod.MOD_ID,
+            "textures/entity/scarecrow/scarecrow.png"
+    );
+
+    private final ScarecrowModel model;
+
+    public ScarecrowItemRenderer() {
+        this.model = new ScarecrowModel(MinecraftClient.getInstance().getEntityModelLoader()
+                .getModelPart(ScarecrowModel.LAYER_LOCATION));
+    }
+
+    @Override
+    public void render(ItemStack stack, ModelTransformationMode mode, MatrixStack matrices,
+            VertexConsumerProvider vertexConsumers, int light, int overlay) {
+        matrices.push();
+        matrices.translate(0.5f, 1.5f, 0.5f);
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
+
+        VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));
+        this.model.render(matrices, vertexConsumer, light, overlay, 1.0f, 1.0f, 1.0f, 1.0f);
+
+        matrices.pop();
+    }
+}

--- a/src/main/resources/assets/gardenkingmod/models/item/scarecrow.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/scarecrow.json
@@ -1,3 +1,3 @@
 {
-  "parent": "gardenkingmod:block/scarecrow"
+  "parent": "minecraft:builtin/entity"
 }


### PR DESCRIPTION
## Summary
- add a ScarecrowItemRenderer that renders the scarecrow model with the block entity transforms
- register the renderer during client initialization so the scarecrow block item uses it
- point the scarecrow item model at the builtin entity parent to route through the dynamic renderer

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d69755be2c8321a80c987ea8bfc0d9