### PR TITLE
Handle null transformation mode in scarecrow renderer

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/render/item/ScarecrowItemRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/item/ScarecrowItemRenderer.java
@@ -31,36 +31,38 @@ public class ScarecrowItemRenderer implements BuiltinItemRendererRegistry.Dynami
         matrices.translate(0.5f, 1.5f, 0.5f);
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
 
-        switch (mode) {
-            case GUI:
-                matrices.scale(0.35f, 0.35f, 0.35f);
-                matrices.translate(0.0, 2.4, 0.0);
-                break;
-            case GROUND:
-                matrices.scale(0.35f, 0.35f, 0.35f);
-                matrices.translate(0.0, 0.9, 0.0);
-                break;
-            case FIXED:
-                matrices.scale(0.4f, 0.4f, 0.4f);
-                matrices.translate(0.0, 1.8, 0.0);
-                break;
-            case FIRST_PERSON_LEFT_HAND, FIRST_PERSON_RIGHT_HAND,
-                 THIRD_PERSON_LEFT_HAND, THIRD_PERSON_RIGHT_HAND:
-                matrices.scale(0.25F, 0.25F, 0.25F);
-                matrices.translate(0.0F, 2.0F, 0.0F);
-                break;
-
-            default: /* keep block-sized scale for pedestal/world */
-
-                if (this.model == null) {
-                    this.model = new ScarecrowModel(MinecraftClient.getInstance().getEntityModelLoader()
-                            .getModelPart(ScarecrowModel.LAYER_LOCATION));
-                }
-
-                VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));
-                this.model.render(matrices, vertexConsumer, light, overlay, 1.0f, 1.0f, 1.0f, 1.0f);
-
-                matrices.pop();
+        if (mode != null) {
+            switch (mode) {
+                case GUI:
+                    matrices.scale(0.35f, 0.35f, 0.35f);
+                    matrices.translate(0.0, 2.4, 0.0);
+                    break;
+                case GROUND:
+                    matrices.scale(0.35f, 0.35f, 0.35f);
+                    matrices.translate(0.0, 0.9, 0.0);
+                    break;
+                case FIXED:
+                    matrices.scale(0.4f, 0.4f, 0.4f);
+                    matrices.translate(0.0, 1.8, 0.0);
+                    break;
+                case FIRST_PERSON_LEFT_HAND, FIRST_PERSON_RIGHT_HAND,
+                     THIRD_PERSON_LEFT_HAND, THIRD_PERSON_RIGHT_HAND:
+                    matrices.scale(0.25F, 0.25F, 0.25F);
+                    matrices.translate(0.0F, 2.0F, 0.0F);
+                    break;
+                default: /* keep block-sized scale for pedestal/world */
+                    break;
+            }
         }
+
+        if (this.model == null) {
+            this.model = new ScarecrowModel(MinecraftClient.getInstance().getEntityModelLoader()
+                    .getModelPart(ScarecrowModel.LAYER_LOCATION));
+        }
+
+        VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));
+        this.model.render(matrices, vertexConsumer, light, overlay, 1.0f, 1.0f, 1.0f, 1.0f);
+
+        matrices.pop();
     }
 }


### PR DESCRIPTION
## Summary
- guard scarecrow item renderer transformations against a null transformation mode
- always execute the render path and matrix cleanup regardless of mode adjustments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6cd7619b4832199796d279f42aee5