### PR TITLE
Render market block item with custom renderer

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -16,6 +16,7 @@ import net.jeremy.gardenkingmod.client.model.ScarecrowModel;
 import net.jeremy.gardenkingmod.client.render.CrowEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.ScarecrowBlockEntityRenderer;
+import net.jeremy.gardenkingmod.client.render.item.MarketItemRenderer;
 import net.jeremy.gardenkingmod.client.render.item.ScarecrowItemRenderer;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.item.FortuneProvidingItem;
@@ -44,6 +45,7 @@ public class GardenKingModClient implements ClientModInitializer {
         BlockEntityRendererFactories.register(ModBlockEntities.MARKET_BLOCK_ENTITY, MarketBlockEntityRenderer::new);
         BlockEntityRendererFactories.register(ModBlockEntities.SCARECROW_BLOCK_ENTITY, ScarecrowBlockEntityRenderer::new);
         EntityRendererRegistry.register(ModEntities.CROW, CrowEntityRenderer::new);
+        BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.MARKET_BLOCK, new MarketItemRenderer());
         BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.SCARECROW_BLOCK, new ScarecrowItemRenderer());
         BlockRenderLayerMap.INSTANCE.putBlock(ModBlocks.SCARECROW_BLOCK, RenderLayer.getCutout());
 

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/item/MarketItemRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/item/MarketItemRenderer.java
@@ -1,0 +1,68 @@
+package net.jeremy.gardenkingmod.client.render.item;
+
+import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.client.model.MarketBlockModel;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.model.json.ModelTransformationMode;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.RotationAxis;
+
+public class MarketItemRenderer implements BuiltinItemRendererRegistry.DynamicItemRenderer {
+    private static final Identifier TEXTURE = new Identifier(
+            GardenKingMod.MOD_ID,
+            "textures/entity/market/market.png"
+    );
+
+    private MarketBlockModel model;
+
+    public MarketItemRenderer() {
+    }
+
+    @Override
+    public void render(ItemStack stack, ModelTransformationMode mode, MatrixStack matrices,
+                       VertexConsumerProvider vertexConsumers, int light, int overlay) {
+        matrices.push();
+        matrices.translate(0.5f, 1.5f, 0.5f);
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
+
+        if (mode != null) {
+            switch (mode) {
+                case GUI -> {
+                    matrices.scale(0.16f, 0.16f, 0.16f);
+                    matrices.translate(0.0, 4.4, 0.0);
+                }
+                case GROUND -> {
+                    matrices.scale(0.18f, 0.18f, 0.18f);
+                    matrices.translate(0.0, 2.8, 0.0);
+                }
+                case FIXED -> {
+                    matrices.scale(0.18f, 0.18f, 0.18f);
+                    matrices.translate(0.0, 3.0, 0.0);
+                }
+                case FIRST_PERSON_LEFT_HAND, FIRST_PERSON_RIGHT_HAND,
+                        THIRD_PERSON_LEFT_HAND, THIRD_PERSON_RIGHT_HAND -> {
+                    matrices.scale(0.14f, 0.14f, 0.14f);
+                    matrices.translate(0.0f, 3.2f, 0.0f);
+                }
+                default -> {
+                }
+            }
+        }
+
+        if (this.model == null) {
+            this.model = new MarketBlockModel(MinecraftClient.getInstance().getEntityModelLoader()
+                    .getModelPart(MarketBlockModel.LAYER_LOCATION));
+        }
+
+        VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));
+        this.model.render(matrices, vertexConsumer, light, overlay, 1.0f, 1.0f, 1.0f, 1.0f);
+
+        matrices.pop();
+    }
+}

--- a/src/main/resources/assets/gardenkingmod/models/item/market_block.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/market_block.json
@@ -1,3 +1,3 @@
 {
-  "parent": "gardenkingmod:block/market_block"
+  "parent": "minecraft:builtin/entity"
 }


### PR DESCRIPTION
## Summary
- add a dedicated `MarketItemRenderer` so the market block item renders with the full entity texture in all transform modes
- register the market item renderer on the client and point the item model at the builtin entity renderer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e2a54fe4832187f761f5550663e5