### PR TITLE
Relax crow hunger lockout when desperate

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowAiGoals.java
+++ b/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowAiGoals.java
@@ -255,7 +255,7 @@ public final class CrowAiGoals {
 
         @Override
         public boolean canStart() {
-            if (crow.isHungry()) {
+            if (!crow.canIgnoreHungerLockout()) {
                 return false;
             }
 
@@ -269,7 +269,7 @@ public final class CrowAiGoals {
 
         @Override
         public boolean shouldContinue() {
-            return target != null && !crow.isHungry() && !crow.getNavigation().isIdle();
+            return target != null && crow.canIgnoreHungerLockout() && !crow.getNavigation().isIdle();
         }
 
         @Override
@@ -305,7 +305,7 @@ public final class CrowAiGoals {
 
         @Override
         public boolean canStart() {
-            if (crow.isHungry()) {
+            if (!crow.canIgnoreHungerLockout()) {
                 return false;
             }
 
@@ -319,7 +319,7 @@ public final class CrowAiGoals {
 
         @Override
         public boolean shouldContinue() {
-            return perchPos != null && !crow.isHungry() && perchTicks < 100;
+            return perchPos != null && crow.canIgnoreHungerLockout() && perchTicks < 100;
         }
 
         @Override

--- a/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowBalanceConfig.java
+++ b/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowBalanceConfig.java
@@ -188,6 +188,14 @@ public final class CrowBalanceConfig {
         return dropLootOnCropBreak;
     }
 
+    public int minHungerTicks() {
+        return minHungerTicks;
+    }
+
+    public int maxHungerTicks() {
+        return maxHungerTicks;
+    }
+
     public double baseHealth() {
         return baseHealth;
     }


### PR DESCRIPTION
## Summary
- add a desperation state to crow hunger tracking so crows resume roaming after prolonged crop droughts
- expose configured hunger bounds for reuse and persist the desperation flag to NBT
- update wandering and perching AI goals to consult the relaxed hunger helper while keeping crop raids top priority

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68d6e8d5cda48321ae1eadcecdb68bf7