### PR TITLE
Fix crow collision by disabling noclip

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowEntity.java
@@ -55,7 +55,6 @@ public class CrowEntity extends PathAwareEntity {
         this.setPathfindingPenalty(PathNodeType.DANGER_FIRE, 0.0f);
         this.setPathfindingPenalty(PathNodeType.DAMAGE_FIRE, 0.0f);
         this.setPathfindingPenalty(PathNodeType.WATER, -1.0f);
-        this.noClip = true;
         this.experiencePoints = 3;
     }
 


### PR DESCRIPTION
## Summary
- stop initializing the crow entity with noclip enabled so it collides with blocks normally

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d6f0cfe4f8832194657a80edf3e5d0