### PR TITLE
Add crow sound event registry and update crow sounds

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
@@ -7,6 +7,7 @@ import net.jeremy.gardenkingmod.crop.BonusHarvestDropManager;
 import net.jeremy.gardenkingmod.crop.CropDropModifier;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.registry.ModEntities;
+import net.jeremy.gardenkingmod.registry.ModSoundEvents;
 
 import net.minecraft.resource.ResourceType;
 
@@ -23,6 +24,7 @@ public class GardenKingMod implements ModInitializer {
                 ModBlocks.registerModBlocks();
                 ModBlockEntities.registerBlockEntities();
                 ModEntities.register();
+                ModSoundEvents.register();
                 ModScreenHandlers.registerScreenHandlers();
                 ModScoreboards.registerScoreboards();
 

--- a/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowEntity.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.jetbrains.annotations.Nullable;
 
 import net.jeremy.gardenkingmod.registry.ModEntities;
+import net.jeremy.gardenkingmod.registry.ModSoundEvents;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.CropBlock;
 import net.minecraft.entity.EntityType;
@@ -27,7 +28,6 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
-import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
@@ -180,17 +180,17 @@ public class CrowEntity extends PathAwareEntity {
 
     @Override
     protected SoundEvent getAmbientSound() {
-        return SoundEvents.ENTITY_PARROT_AMBIENT;
+        return ModSoundEvents.CROW_CAW;
     }
 
     @Override
     protected SoundEvent getHurtSound(DamageSource source) {
-        return SoundEvents.ENTITY_PARROT_HURT;
+        return ModSoundEvents.CROW_CAW;
     }
 
     @Override
     protected SoundEvent getDeathSound() {
-        return SoundEvents.ENTITY_PARROT_DEATH;
+        return ModSoundEvents.CROW_CAW;
     }
 
     @Override
@@ -321,7 +321,7 @@ public class CrowEntity extends PathAwareEntity {
 
     protected void onCropBroken(BlockState state, BlockPos pos) {
         this.resetHunger();
-        this.playSound(SoundEvents.ENTITY_PARROT_EAT, 0.9f, 0.9f + this.random.nextFloat() * 0.2f);
+        this.playSound(ModSoundEvents.CROW_CROP_BREAK, 0.9f, 0.9f + this.random.nextFloat() * 0.2f);
     }
 
     public Optional<BlockPos> findNearestWard() {

--- a/src/main/java/net/jeremy/gardenkingmod/registry/ModSoundEvents.java
+++ b/src/main/java/net/jeremy/gardenkingmod/registry/ModSoundEvents.java
@@ -1,0 +1,30 @@
+package net.jeremy.gardenkingmod.registry;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.util.Identifier;
+
+/**
+ * Registers custom sound events used throughout the mod.
+ */
+public final class ModSoundEvents {
+    public static final SoundEvent CROW_CAW = register("entity.crow.caw");
+    public static final SoundEvent CROW_CROP_BREAK = register("entity.crow.crop_break");
+    public static final SoundEvent CROW_FLAP = register("entity.crow.flap");
+    public static final SoundEvent CROW_WARDED = register("entity.crow.warded");
+
+    private ModSoundEvents() {
+    }
+
+    private static SoundEvent register(String path) {
+        Identifier id = new Identifier(GardenKingMod.MOD_ID, path);
+        return Registry.register(Registries.SOUND_EVENT, id, SoundEvent.of(id));
+    }
+
+    public static void register() {
+        GardenKingMod.LOGGER.debug("Registered sound events for Garden King Mod");
+    }
+}


### PR DESCRIPTION
## Summary
- add a ModSoundEvents helper that registers crow-specific sound events
- register the sound events during mod initialization
- update the crow entity to use the new crow sound events for ambient, hurt, death, and crop breaking

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d708b192ec8321915b12bef9d2ac8b