### PR TITLE
Revamp scarecrow GUI layout and tooltips

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
@@ -1,41 +1,139 @@
 package net.jeremy.gardenkingmod.screen;
 
-import com.mojang.blaze3d.systems.RenderSystem;
+import java.util.ArrayList;
+import java.util.List;
 
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.block.ward.ScarecrowBlockEntity;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
-import net.minecraft.client.render.GameRenderer;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
-        private static final Identifier TEXTURE = new Identifier("minecraft", "textures/gui/container/hopper.png");
+        private static final Identifier TEXTURE = new Identifier(GardenKingMod.MOD_ID,
+                        "textures/gui/container/scarecrow.png");
         private static final int BACKGROUND_WIDTH = 176;
-        private static final int BACKGROUND_HEIGHT = 133;
-        private static final int PLAYER_LABEL_Y = 40;
+        private static final int BACKGROUND_HEIGHT = 206;
+        private static final int PLAYER_LABEL_Y = 108;
+        private static final int TITLE_X = 8;
+        private static final int TITLE_Y = 8;
+        private static final int OVERLAY_SIZE = 18;
+        private static final int SLOT_OVERLAY_U = 176;
+        private static final int SLOT_OVERLAY_V = 0;
+        private static final int RADIUS_TEXT_X = 8;
+        private static final int RADIUS_TEXT_Y = 28;
+        private static final int RADIUS_INFO_X = 8;
+        private static final int RADIUS_INFO_Y = 24;
+        private static final int RADIUS_INFO_WIDTH = 160;
+        private static final int RADIUS_INFO_HEIGHT = 14;
+
+        private static final Text HAT_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.hat");
+        private static final Text HEAD_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.head");
+        private static final Text CHEST_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.chest");
+        private static final Text HAND_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.hand");
 
         public ScarecrowScreen(ScarecrowScreenHandler handler, PlayerInventory inventory, Text title) {
                 super(handler, inventory, title);
                 this.backgroundWidth = BACKGROUND_WIDTH;
                 this.backgroundHeight = BACKGROUND_HEIGHT;
                 this.playerInventoryTitleY = PLAYER_LABEL_Y;
+                this.titleX = TITLE_X;
+                this.titleY = TITLE_Y;
+        }
+
+        @Override
+        protected void init() {
+                super.init();
+                this.titleX = TITLE_X;
+                this.titleY = TITLE_Y;
         }
 
         @Override
         protected void drawBackground(DrawContext context, float delta, int mouseX, int mouseY) {
-                RenderSystem.setShader(GameRenderer::getPositionTexProgram);
-                RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-                RenderSystem.setShaderTexture(0, TEXTURE);
                 int x = (width - backgroundWidth) / 2;
                 int y = (height - backgroundHeight) / 2;
                 context.drawTexture(TEXTURE, x, y, 0, 0, backgroundWidth, backgroundHeight);
+
+                drawSlotOverlay(context, x + ScarecrowScreenHandler.HAT_SLOT_X - 1,
+                                y + ScarecrowScreenHandler.HAT_SLOT_Y - 1);
+                drawSlotOverlay(context, x + ScarecrowScreenHandler.HEAD_SLOT_X - 1,
+                                y + ScarecrowScreenHandler.HEAD_SLOT_Y - 1);
+                drawSlotOverlay(context, x + ScarecrowScreenHandler.CHEST_SLOT_X - 1,
+                                y + ScarecrowScreenHandler.CHEST_SLOT_Y - 1);
+                drawSlotOverlay(context, x + ScarecrowScreenHandler.PITCHFORK_SLOT_X - 1,
+                                y + ScarecrowScreenHandler.PITCHFORK_SLOT_Y - 1);
+        }
+
+        @Override
+        protected void drawForeground(DrawContext context, int mouseX, int mouseY) {
+                super.drawForeground(context, mouseX, mouseY);
+                int horizontalRadius = handler.getHorizontalRadius();
+                int verticalRadius = handler.getVerticalRadius();
+                Text radiusSummary = Text.translatable("screen.gardenkingmod.scarecrow.radius.summary",
+                                horizontalRadius, verticalRadius);
+                context.drawText(textRenderer, radiusSummary, RADIUS_TEXT_X, RADIUS_TEXT_Y, 0x404040, false);
         }
 
         @Override
         public void render(DrawContext context, int mouseX, int mouseY, float delta) {
                 renderBackground(context);
                 super.render(context, mouseX, mouseY, delta);
+                drawCustomTooltips(context, mouseX, mouseY);
                 drawMouseoverTooltip(context, mouseX, mouseY);
+        }
+
+        private void drawSlotOverlay(DrawContext context, int x, int y) {
+                context.drawTexture(TEXTURE, x, y, SLOT_OVERLAY_U, SLOT_OVERLAY_V, OVERLAY_SIZE, OVERLAY_SIZE);
+        }
+
+        private void drawCustomTooltips(DrawContext context, int mouseX, int mouseY) {
+                Slot hoveredSlot = findHoveredEquipmentSlot(mouseX, mouseY);
+                if (hoveredSlot != null && !hoveredSlot.hasStack()) {
+                        Text tooltip = getEquipmentTooltip(hoveredSlot);
+                        if (tooltip != null) {
+                                context.drawTooltip(textRenderer, tooltip, mouseX, mouseY);
+                                return;
+                        }
+                }
+
+                if (isPointWithinBounds(RADIUS_INFO_X, RADIUS_INFO_Y, RADIUS_INFO_WIDTH, RADIUS_INFO_HEIGHT, mouseX,
+                                mouseY)) {
+                        int horizontalRadius = handler.getHorizontalRadius();
+                        int verticalRadius = handler.getVerticalRadius();
+                        List<Text> radiusTooltip = new ArrayList<>();
+                        radiusTooltip.add(Text.translatable("screen.gardenkingmod.scarecrow.radius.horizontal",
+                                        horizontalRadius));
+                        radiusTooltip.add(Text.translatable("screen.gardenkingmod.scarecrow.radius.vertical",
+                                        verticalRadius));
+                        radiusTooltip.add(Text.translatable("tooltip.gardenkingmod.scarecrow.ward_radius",
+                                        Math.max(horizontalRadius, verticalRadius)));
+                        context.drawTooltip(textRenderer, radiusTooltip, mouseX, mouseY);
+                }
+        }
+
+        private Text getEquipmentTooltip(Slot slot) {
+                if (slot.inventory == handler.getInventory()) {
+                        return switch (slot.getIndex()) {
+                        case ScarecrowBlockEntity.SLOT_HAT -> HAT_TOOLTIP;
+                        case ScarecrowBlockEntity.SLOT_HEAD -> HEAD_TOOLTIP;
+                        case ScarecrowBlockEntity.SLOT_CHEST -> CHEST_TOOLTIP;
+                        case ScarecrowBlockEntity.SLOT_PITCHFORK -> HAND_TOOLTIP;
+                        default -> null;
+                        };
+                }
+                return null;
+        }
+
+        private Slot findHoveredEquipmentSlot(int mouseX, int mouseY) {
+                for (Slot slot : handler.slots) {
+                        if (slot.inventory == handler.getInventory()
+                                        && isPointWithinBounds(slot.x, slot.y, 16, 16, mouseX, mouseY)) {
+                                return slot;
+                        }
+                }
+                return null;
         }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreenHandler.java
@@ -17,17 +17,17 @@ import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.math.BlockPos;
 
 public class ScarecrowScreenHandler extends ScreenHandler {
-        private static final int EQUIPMENT_SLOT_COUNT = ScarecrowBlockEntity.INVENTORY_SIZE;
-        private static final int HAT_SLOT_X = 80;
-        private static final int HAT_SLOT_Y = 17;
-        private static final int HEAD_SLOT_X = 80;
-        private static final int HEAD_SLOT_Y = 35;
-        private static final int CHEST_SLOT_X = 80;
-        private static final int CHEST_SLOT_Y = 53;
-        private static final int PITCHFORK_SLOT_X = 104;
-        private static final int PITCHFORK_SLOT_Y = 35;
-        private static final int PLAYER_INVENTORY_START_Y = 84;
-        private static final int PLAYER_HOTBAR_Y = 142;
+        public static final int EQUIPMENT_SLOT_COUNT = ScarecrowBlockEntity.INVENTORY_SIZE;
+        public static final int HAT_SLOT_X = 44;
+        public static final int HAT_SLOT_Y = 28;
+        public static final int HEAD_SLOT_X = 98;
+        public static final int HEAD_SLOT_Y = 28;
+        public static final int CHEST_SLOT_X = 44;
+        public static final int CHEST_SLOT_Y = 82;
+        public static final int PITCHFORK_SLOT_X = 98;
+        public static final int PITCHFORK_SLOT_Y = 82;
+        public static final int PLAYER_INVENTORY_START_Y = 118;
+        public static final int PLAYER_HOTBAR_Y = 176;
 
         private final Inventory inventory;
         private final PropertyDelegate properties;
@@ -128,6 +128,10 @@ public class ScarecrowScreenHandler extends ScreenHandler {
                         }
                 }
                 return newStack;
+        }
+
+        public Inventory getInventory() {
+                return inventory;
         }
 
         private void addPlayerInventory(PlayerInventory playerInventory) {

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -128,6 +128,13 @@
   "item.gardenkingmod.crow_spawn_egg": "Crow Spawn Egg",
 
   "tooltip.gardenkingmod.scarecrow.ward_radius": "Wards crows within %s blocks.",
+  "screen.gardenkingmod.scarecrow.slot.hat": "Hat Slot",
+  "screen.gardenkingmod.scarecrow.slot.head": "Head Slot",
+  "screen.gardenkingmod.scarecrow.slot.chest": "Chest Slot",
+  "screen.gardenkingmod.scarecrow.slot.hand": "Hand Slot",
+  "screen.gardenkingmod.scarecrow.radius.summary": "Ward Radius: %1$s x %2$s",
+  "screen.gardenkingmod.scarecrow.radius.horizontal": "Horizontal radius: %s blocks",
+  "screen.gardenkingmod.scarecrow.radius.vertical": "Vertical radius: %s blocks",
 
   "subtitles.gardenkingmod.entity.crow.caw": "Crow caws",
   "subtitles.gardenkingmod.entity.crow.flap": "Crow wings flap",


### PR DESCRIPTION
## Summary
- point the scarecrow screen at a dedicated GUI texture and draw slot overlays for the new equipment grid
- reposition equipment and player inventory slots so the expanded background layout lines up correctly
- add localized tooltips and ward radius details to the scarecrow interface

## Testing
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68d93e92285c83218e119ae5f69309a5