### PR TITLE
Align scarecrow equipment slots with vanilla layout

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreenHandler.java
@@ -18,14 +18,14 @@ import net.minecraft.util.math.BlockPos;
 
 public class ScarecrowScreenHandler extends ScreenHandler {
         public static final int EQUIPMENT_SLOT_COUNT = ScarecrowBlockEntity.INVENTORY_SIZE;
-        public static final int HAT_SLOT_X = 44;
-        public static final int HAT_SLOT_Y = 28;
-        public static final int HEAD_SLOT_X = 98;
-        public static final int HEAD_SLOT_Y = 28;
-        public static final int CHEST_SLOT_X = 44;
-        public static final int CHEST_SLOT_Y = 82;
-        public static final int PITCHFORK_SLOT_X = 98;
-        public static final int PITCHFORK_SLOT_Y = 82;
+        public static final int HAT_SLOT_X = 8;
+        public static final int HAT_SLOT_Y = 8;
+        public static final int HEAD_SLOT_X = 8;
+        public static final int HEAD_SLOT_Y = 26;
+        public static final int CHEST_SLOT_X = 8;
+        public static final int CHEST_SLOT_Y = 44;
+        public static final int PITCHFORK_SLOT_X = 77;
+        public static final int PITCHFORK_SLOT_Y = 62;
         public static final int PLAYER_INVENTORY_START_Y = 118;
         public static final int PLAYER_HOTBAR_Y = 176;
 


### PR DESCRIPTION
## Summary
- update scarecrow equipment slot constants to match vanilla layout positions
- verified the scarecrow GUI texture aligns with the updated slot coordinates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d974f6c2508321b1bf99a9a5ef6681