### PR TITLE
Adjust scarecrow preview alignment beside equipment slots

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
@@ -45,8 +45,8 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
         private static final Text HAND_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.hand");
 
         private static final float PREVIEW_Z_OFFSET = 150.0F;
-        private static final int PREVIEW_CENTER_X = 136;
-        private static final int PREVIEW_CENTER_Y = 70;
+        private static final int PREVIEW_CENTER_X = 56;
+        private static final int PREVIEW_CENTER_Y = 76;
         private static final float PREVIEW_SCALE = 28.0F;
 
         private ScarecrowRenderHelper renderHelper;


### PR DESCRIPTION
## Summary
- move the scarecrow preview next to the hat/head/chest column to mirror vanilla layout
- tweak the vertical center to keep the model aligned with the slot overlays while leaving room for the pitchfork slot

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d978625a9c8321928b5b0bc6ade39b