### PR TITLE
Adjust scarecrow preview alignment

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
@@ -45,8 +45,8 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
         private static final Text HAND_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.hand");
 
         private static final float PREVIEW_Z_OFFSET = 150.0F;
-        private static final int PREVIEW_CENTER_X = 56;
-        private static final int PREVIEW_CENTER_Y = 76;
+        private static final int PREVIEW_CENTER_X = 51;
+        private static final int PREVIEW_CENTER_Y = 75;
         private static final float PREVIEW_SCALE = 28.0F;
 
         private ScarecrowRenderHelper renderHelper;


### PR DESCRIPTION
## Summary
- align the scarecrow preview model next to the equipment column to mirror vanilla spacing
- tweak the preview center offsets so the pitchfork slot remains clear on the right side

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68d97aa416788321a895a2ef6c6685a9