### PR TITLE
Adjust scarecrow preview yaw

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
@@ -145,7 +145,7 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                 matrices.scale(PREVIEW_SCALE, PREVIEW_SCALE, PREVIEW_SCALE);
                 matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0F));
                 matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(pitch * 20.0F));
-                matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(yaw * 40.0F));
+                matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F + (yaw * 40.0F)));
 
                 this.renderHelper.render(matrices, immediate, 0xF000F0, OverlayTexture.DEFAULT_UV, equipment,
                                 client.world);


### PR DESCRIPTION
## Summary
- offset the scarecrow preview's yaw by 180 degrees so the model faces the viewer while retaining mouse responsiveness

## Testing
- not run (Minecraft client unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d97e7003448321ad77d735c3fef6ba