### PR TITLE
Remove unused ModelPartData references in scarecrow model

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
@@ -75,31 +75,31 @@ public class ScarecrowModel extends EntityModel<Entity> {
                 .uv(22, 43).cuboid(4.0F, -24.0F, 3.0F, 1.0F, 2.0F, 0.0F, new Dilation(0.0F))
                 .uv(25, 41).cuboid(11.0F, -26.0F, 3.0F, 2.0F, 2.0F, 0.0F, new Dilation(0.0F)), ModelTransform.pivot(0.0F, 24.0F, 0.0F));
 
-        ModelPartData cube_r1 = bb_main.addChild("cube_r1", ModelPartBuilder.create().uv(50, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(1.2929F, -36.5F, 3.1F, 0.0F, 0.0F, 2.3562F));
+        bb_main.addChild("cube_r1", ModelPartBuilder.create().uv(50, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(1.2929F, -36.5F, 3.1F, 0.0F, 0.0F, 2.3562F));
 
-        ModelPartData cube_r2 = bb_main.addChild("cube_r2", ModelPartBuilder.create().uv(51, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(2.0F, -35.7929F, 3.1F, 0.0F, 0.0F, 0.7854F));
+        bb_main.addChild("cube_r2", ModelPartBuilder.create().uv(51, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(2.0F, -35.7929F, 3.1F, 0.0F, 0.0F, 0.7854F));
 
-        ModelPartData cube_r3 = bb_main.addChild("cube_r3", ModelPartBuilder.create().uv(50, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(-2.7071F, -36.5F, 3.1F, 0.0F, 0.0F, 2.3562F));
+        bb_main.addChild("cube_r3", ModelPartBuilder.create().uv(50, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(-2.7071F, -36.5F, 3.1F, 0.0F, 0.0F, 2.3562F));
 
-        ModelPartData cube_r4 = bb_main.addChild("cube_r4", ModelPartBuilder.create().uv(51, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(-2.0F, -35.7929F, 3.1F, 0.0F, 0.0F, 0.7854F));
+        bb_main.addChild("cube_r4", ModelPartBuilder.create().uv(51, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(-2.0F, -35.7929F, 3.1F, 0.0F, 0.0F, 0.7854F));
 
-        ModelPartData cube_r5 = bb_main.addChild("cube_r5", ModelPartBuilder.create().uv(49, 8).cuboid(-3.0F, -1.0F, -3.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
+        bb_main.addChild("cube_r5", ModelPartBuilder.create().uv(49, 8).cuboid(-3.0F, -1.0F, -3.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
                 .uv(49, 9).cuboid(-4.0F, -1.0F, -2.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F))
                 .uv(49, 13).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(-4.0F, -39.0F, 0.0F, 0.0F, 1.5708F, 0.2182F));
 
-        ModelPartData cube_r6 = bb_main.addChild("cube_r6", ModelPartBuilder.create().uv(65, 14).cuboid(-3.0F, -1.0F, -3.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
+        bb_main.addChild("cube_r6", ModelPartBuilder.create().uv(65, 14).cuboid(-3.0F, -1.0F, -3.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
                 .uv(62, 13).cuboid(-4.0F, -1.0F, -2.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F))
                 .uv(58, 14).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(4.0F, -39.0F, 0.0F, 0.0F, -1.5708F, -0.2182F));
 
-        ModelPartData cube_r7 = bb_main.addChild("cube_r7", ModelPartBuilder.create().uv(48, 12).cuboid(-3.0F, -1.0F, 1.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
+        bb_main.addChild("cube_r7", ModelPartBuilder.create().uv(48, 12).cuboid(-3.0F, -1.0F, 1.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
                 .uv(48, 12).cuboid(-4.0F, -1.0F, 0.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F))
                 .uv(49, 11).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, 5.0F, 0.2182F, 0.0F, 0.0F));
 
-        ModelPartData cube_r8 = bb_main.addChild("cube_r8", ModelPartBuilder.create().uv(66, 13).cuboid(-3.0F, -1.0F, -1.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -6.0F, -0.2182F, 0.0F, 0.0F));
+        bb_main.addChild("cube_r8", ModelPartBuilder.create().uv(66, 13).cuboid(-3.0F, -1.0F, -1.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -6.0F, -0.2182F, 0.0F, 0.0F));
 
-        ModelPartData cube_r9 = bb_main.addChild("cube_r9", ModelPartBuilder.create().uv(49, 12).cuboid(-4.0F, -1.0F, -1.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -5.0F, -0.2182F, 0.0F, 0.0F));
+        bb_main.addChild("cube_r9", ModelPartBuilder.create().uv(49, 12).cuboid(-4.0F, -1.0F, -1.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -5.0F, -0.2182F, 0.0F, 0.0F));
 
-        ModelPartData cube_r10 = bb_main.addChild("cube_r10", ModelPartBuilder.create().uv(48, 12).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -4.0F, -0.2182F, 0.0F, 0.0F));
+        bb_main.addChild("cube_r10", ModelPartBuilder.create().uv(48, 12).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -4.0F, -0.2182F, 0.0F, 0.0F));
         return TexturedModelData.of(modelData, 128, 128);
     }
     @Override


### PR DESCRIPTION
## Summary
- remove the temporary `ModelPartData` variables when adding child cubes in the scarecrow model to avoid unused-variable warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d99f3106c48321a670ab81f60d589e