### PR TITLE
Adjust scarecrow radius display layout

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
@@ -34,10 +34,10 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
         private static final int SLOT_OVERLAY_V = 0;
         private static final int RADIUS_TEXT_X = 104;
         private static final int RADIUS_TEXT_Y = 62;
+        private static final int RADIUS_TEXT_SPACING = 2;
         private static final int RADIUS_INFO_X = 104;
         private static final int RADIUS_INFO_Y = 62;
         private static final int RADIUS_INFO_WIDTH = 160;
-        private static final int RADIUS_INFO_HEIGHT = 14;
 
         private static final Text HAT_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.hat");
         private static final Text HEAD_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.head");
@@ -94,9 +94,12 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                 super.drawForeground(context, mouseX, mouseY);
                 int horizontalRadius = handler.getHorizontalRadius();
                 int verticalRadius = handler.getVerticalRadius();
-                Text radiusSummary = Text.translatable("screen.gardenkingmod.scarecrow.radius.summary",
-                                horizontalRadius, verticalRadius);
-                context.drawText(textRenderer, radiusSummary, RADIUS_TEXT_X, RADIUS_TEXT_Y, 0x404040, false);
+                Text radiusTitle = Text.translatable("screen.gardenkingmod.scarecrow.radius.title");
+                Text radiusSummary = Text.translatable("screen.gardenkingmod.scarecrow.radius.summary", horizontalRadius,
+                                verticalRadius);
+                int summaryY = RADIUS_TEXT_Y + textRenderer.fontHeight + RADIUS_TEXT_SPACING;
+                context.drawText(textRenderer, radiusTitle, RADIUS_TEXT_X, RADIUS_TEXT_Y, 0x404040, false);
+                context.drawText(textRenderer, radiusSummary, RADIUS_TEXT_X, summaryY, 0x404040, false);
         }
 
         @Override
@@ -158,6 +161,10 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                 context.drawTexture(TEXTURE, x, y, SLOT_OVERLAY_U, SLOT_OVERLAY_V, OVERLAY_SIZE, OVERLAY_SIZE);
         }
 
+        private int getRadiusInfoHeight() {
+                return textRenderer.fontHeight * 2 + RADIUS_TEXT_SPACING;
+        }
+
         private void drawCustomTooltips(DrawContext context, int mouseX, int mouseY) {
                 Slot hoveredSlot = findHoveredEquipmentSlot(mouseX, mouseY);
                 if (hoveredSlot != null && !hoveredSlot.hasStack()) {
@@ -168,7 +175,8 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                         }
                 }
 
-                if (isPointWithinBounds(RADIUS_INFO_X, RADIUS_INFO_Y, RADIUS_INFO_WIDTH, RADIUS_INFO_HEIGHT, mouseX,
+                int radiusInfoHeight = getRadiusInfoHeight();
+                if (isPointWithinBounds(RADIUS_INFO_X, RADIUS_INFO_Y, RADIUS_INFO_WIDTH, radiusInfoHeight, mouseX,
                                 mouseY)) {
                         int horizontalRadius = handler.getHorizontalRadius();
                         int verticalRadius = handler.getVerticalRadius();

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -132,7 +132,8 @@
   "screen.gardenkingmod.scarecrow.slot.head": "Head Slot",
   "screen.gardenkingmod.scarecrow.slot.chest": "Chest Slot",
   "screen.gardenkingmod.scarecrow.slot.hand": "Hand Slot",
-  "screen.gardenkingmod.scarecrow.radius.summary": "Ward Radius: %1$s x %2$s",
+  "screen.gardenkingmod.scarecrow.radius.title": "Ward Radius",
+  "screen.gardenkingmod.scarecrow.radius.summary": "%1$s x %2$s",
   "screen.gardenkingmod.scarecrow.radius.horizontal": "Horizontal radius: %s blocks",
   "screen.gardenkingmod.scarecrow.radius.vertical": "Vertical radius: %s blocks",
 


### PR DESCRIPTION
## Summary
- draw the scarecrow radius label and numeric value on separate lines with consistent spacing
- expand the scarecrow radius tooltip hitbox to cover both lines of text
- add a translation for the new ward radius label and update the summary string to show only numbers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a91cbf308321a0c391ed60b8c02b