### PR TITLE
Add scarecrow container localization

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/datagen/RottenLanguageProvider.java
+++ b/src/main/java/net/jeremy/gardenkingmod/datagen/RottenLanguageProvider.java
@@ -23,6 +23,7 @@ public final class RottenLanguageProvider extends FabricLanguageProvider {
                 translationBuilder.add("block.gardenkingmod.market_block", "Garden Market");
                 translationBuilder.add("item.gardenkingmod.garden_coin", "Garden Coin");
                 translationBuilder.add("container.gardenkingmod.market", "Garden Market");
+                translationBuilder.add("container.gardenkingmod.scarecrow", "Field Scarecrow");
                 translationBuilder.add("screen.gardenkingmod.market.sell", "Sell");
                 translationBuilder.add("screen.gardenkingmod.market.sale_result",
                                 "You sold %1$s crops and earned %2$s garden coins.");

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -15,6 +15,7 @@
 
   "block.gardenkingmod.market_block": "Garden Market",
   "container.gardenkingmod.market": "Garden Market",
+  "container.gardenkingmod.scarecrow": "Field Scarecrow",
   "item.gardenkingmod.garden_coin": "Garden Coin",
   "message.gardenkingmod.market.empty": "There are no crops to sell.",
   "message.gardenkingmod.market.invalid": "Only Crops and Food can be sold here!",


### PR DESCRIPTION
## Summary
- add a scarecrow container translation to the en_us locale
- include the scarecrow container title in language datagen output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9a92548f083219a36a38381014cdf