### PR TITLE
Center radius summary text

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
@@ -98,8 +98,14 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                 Text radiusSummary = Text.translatable("screen.gardenkingmod.scarecrow.radius.summary", horizontalRadius,
                                 verticalRadius);
                 int summaryY = RADIUS_TEXT_Y + textRenderer.fontHeight + RADIUS_TEXT_SPACING;
+                int titleWidth = textRenderer.getWidth(radiusTitle);
+                int summaryWidth = textRenderer.getWidth(radiusSummary);
+                int summaryX = RADIUS_TEXT_X;
+                if (summaryWidth < titleWidth) {
+                        summaryX += (titleWidth - summaryWidth) / 2;
+                }
                 context.drawText(textRenderer, radiusTitle, RADIUS_TEXT_X, RADIUS_TEXT_Y, 0x404040, false);
-                context.drawText(textRenderer, radiusSummary, RADIUS_TEXT_X, summaryY, 0x404040, false);
+                context.drawText(textRenderer, radiusSummary, summaryX, summaryY, 0x404040, false);
         }
 
         @Override


### PR DESCRIPTION
## Summary
- center the scarecrow ward radius summary text beneath the title
- adjust the x-offset based on text widths so shorter summaries align with the header

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9abbac2288321ab08335d1288f7bf