### PR TITLE
Add scarecrow pants equipment slot

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/ModItemTags.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModItemTags.java
@@ -9,6 +9,7 @@ public final class ModItemTags {
         public static final TagKey<Item> SCARECROW_HATS = of("scarecrow_hats");
         public static final TagKey<Item> SCARECROW_HEADS = of("scarecrow_heads");
         public static final TagKey<Item> SCARECROW_SHIRTS = of("scarecrow_shirts");
+        public static final TagKey<Item> SCARECROW_PANTS = of("scarecrow_pants");
         public static final TagKey<Item> SCARECROW_PITCHFORKS = of("scarecrow_pitchforks");
 
         private ModItemTags() {

--- a/src/main/java/net/jeremy/gardenkingmod/block/ward/ScarecrowBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/ward/ScarecrowBlockEntity.java
@@ -32,9 +32,10 @@ public class ScarecrowBlockEntity extends BlockEntity implements ExtendedScreenH
         public static final int SLOT_HAT = 0;
         public static final int SLOT_HEAD = 1;
         public static final int SLOT_CHEST = 2;
-        public static final int SLOT_PITCHFORK = 3;
+        public static final int SLOT_PANTS = 3;
+        public static final int SLOT_PITCHFORK = 4;
 
-        public static final int INVENTORY_SIZE = 4;
+        public static final int INVENTORY_SIZE = 5;
         public static final int MAX_DURABILITY = 64;
 
         private static final String NBT_PITCHFORK_AURA = "ScarecrowAura";
@@ -292,6 +293,10 @@ public class ScarecrowBlockEntity extends BlockEntity implements ExtendedScreenH
                 return this.inventory.get(SLOT_CHEST);
         }
 
+        public ItemStack getEquippedPants() {
+                return this.inventory.get(SLOT_PANTS);
+        }
+
         public ItemStack getEquippedPitchfork() {
                 return this.inventory.get(SLOT_PITCHFORK);
         }
@@ -320,6 +325,7 @@ public class ScarecrowBlockEntity extends BlockEntity implements ExtendedScreenH
                         case SLOT_HAT -> isValidHatItem(stack);
                         case SLOT_HEAD -> isValidHeadItem(stack);
                         case SLOT_CHEST -> isValidChestItem(stack);
+                        case SLOT_PANTS -> isValidPantsItem(stack);
                         case SLOT_PITCHFORK -> isValidPitchforkItem(stack);
                         default -> false;
                 };
@@ -340,6 +346,10 @@ public class ScarecrowBlockEntity extends BlockEntity implements ExtendedScreenH
 
         public static boolean isValidChestItem(ItemStack stack) {
                 return stack.isIn(ModItemTags.SCARECROW_SHIRTS);
+        }
+
+        public static boolean isValidPantsItem(ItemStack stack) {
+                return stack.isIn(ModItemTags.SCARECROW_PANTS);
         }
 
         public static boolean isValidPitchforkItem(ItemStack stack) {

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
@@ -57,6 +57,7 @@ public final class ScarecrowRenderHelper {
         renderHeadLayer(matrices, vertexConsumers, light, overlay, equipment.head(), world);
         renderHeadLayer(matrices, vertexConsumers, light, overlay, equipment.hat(), world);
         renderChestLayer(matrices, vertexConsumers, light, overlay, equipment.chest(), world);
+        renderLegLayer(matrices, vertexConsumers, light, overlay, equipment.pants(), world);
         renderPitchfork(matrices, vertexConsumers, light, overlay, equipment.pitchfork());
     }
 
@@ -102,6 +103,30 @@ public final class ScarecrowRenderHelper {
         matrices.translate(0.0F, 0.2F, -0.25F);
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
         matrices.scale(0.6F, 0.6F, 0.6F);
+        ItemRenderer itemRenderer = MinecraftClient.getInstance().getItemRenderer();
+        itemRenderer.renderItem(stack, ModelTransformationMode.FIXED,
+                light, overlay, matrices, vertexConsumers, world, 0);
+        matrices.pop();
+    }
+
+    private void renderLegLayer(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay,
+            ItemStack stack, @Nullable World world) {
+        if (stack.isEmpty()) {
+            return;
+        }
+
+        Item item = stack.getItem();
+        if (item instanceof ArmorItem armorItem && armorItem.getSlotType() == EquipmentSlot.LEGS) {
+            renderArmor(stack, armorItem, matrices, vertexConsumers, light, overlay, world);
+            return;
+        }
+
+        matrices.push();
+        applyScarecrowPose(this.bodyModel);
+        this.bodyModel.body.rotate(matrices);
+        matrices.translate(0.0F, 0.95F, -0.15F);
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
+        matrices.scale(0.55F, 0.55F, 0.55F);
         ItemRenderer itemRenderer = MinecraftClient.getInstance().getItemRenderer();
         itemRenderer.renderItem(stack, ModelTransformationMode.FIXED,
                 light, overlay, matrices, vertexConsumers, world, 0);
@@ -218,15 +243,17 @@ public final class ScarecrowRenderHelper {
         model.hat.copyTransform(model.head);
     }
 
-    public record ScarecrowEquipment(ItemStack hat, ItemStack head, ItemStack chest, ItemStack pitchfork) {
+    public record ScarecrowEquipment(ItemStack hat, ItemStack head, ItemStack chest, ItemStack pants,
+            ItemStack pitchfork) {
         public static final ScarecrowEquipment EMPTY = new ScarecrowEquipment(ItemStack.EMPTY, ItemStack.EMPTY,
-                ItemStack.EMPTY, ItemStack.EMPTY);
+                ItemStack.EMPTY, ItemStack.EMPTY, ItemStack.EMPTY);
 
         public static ScarecrowEquipment fromBlockEntity(ScarecrowBlockEntity entity) {
             return new ScarecrowEquipment(
                     entity.getEquippedHat(),
                     entity.getEquippedHead(),
                     entity.getEquippedChest(),
+                    entity.getEquippedPants(),
                     entity.getEquippedPitchfork()
             );
         }
@@ -248,6 +275,7 @@ public final class ScarecrowRenderHelper {
                     inventory.get(ScarecrowBlockEntity.SLOT_HAT),
                     inventory.get(ScarecrowBlockEntity.SLOT_HEAD),
                     inventory.get(ScarecrowBlockEntity.SLOT_CHEST),
+                    inventory.get(ScarecrowBlockEntity.SLOT_PANTS),
                     inventory.get(ScarecrowBlockEntity.SLOT_PITCHFORK)
             );
         }

--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
@@ -42,6 +42,7 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
         private static final Text HAT_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.hat");
         private static final Text HEAD_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.head");
         private static final Text CHEST_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.chest");
+        private static final Text PANTS_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.pants");
         private static final Text HAND_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.hand");
 
         private static final float PREVIEW_Z_OFFSET = 150.0F;
@@ -85,6 +86,8 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                                 y + ScarecrowScreenHandler.HEAD_SLOT_Y - 1);
                 drawSlotOverlay(context, x + ScarecrowScreenHandler.CHEST_SLOT_X - 1,
                                 y + ScarecrowScreenHandler.CHEST_SLOT_Y - 1);
+                drawSlotOverlay(context, x + ScarecrowScreenHandler.PANTS_SLOT_X - 1,
+                                y + ScarecrowScreenHandler.PANTS_SLOT_Y - 1);
                 drawSlotOverlay(context, x + ScarecrowScreenHandler.PITCHFORK_SLOT_X - 1,
                                 y + ScarecrowScreenHandler.PITCHFORK_SLOT_Y - 1);
         }
@@ -131,8 +134,9 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                 ItemStack hat = inventory.getStack(ScarecrowBlockEntity.SLOT_HAT);
                 ItemStack head = inventory.getStack(ScarecrowBlockEntity.SLOT_HEAD);
                 ItemStack chest = inventory.getStack(ScarecrowBlockEntity.SLOT_CHEST);
+                ItemStack pants = inventory.getStack(ScarecrowBlockEntity.SLOT_PANTS);
                 ItemStack pitchfork = inventory.getStack(ScarecrowBlockEntity.SLOT_PITCHFORK);
-                ScarecrowEquipment equipment = new ScarecrowEquipment(hat, head, chest, pitchfork);
+                ScarecrowEquipment equipment = new ScarecrowEquipment(hat, head, chest, pants, pitchfork);
 
                 VertexConsumerProvider.Immediate immediate = client.getBufferBuilders().getEntityVertexConsumers();
 
@@ -203,6 +207,7 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                         case ScarecrowBlockEntity.SLOT_HAT -> HAT_TOOLTIP;
                         case ScarecrowBlockEntity.SLOT_HEAD -> HEAD_TOOLTIP;
                         case ScarecrowBlockEntity.SLOT_CHEST -> CHEST_TOOLTIP;
+                        case ScarecrowBlockEntity.SLOT_PANTS -> PANTS_TOOLTIP;
                         case ScarecrowBlockEntity.SLOT_PITCHFORK -> HAND_TOOLTIP;
                         default -> null;
                         };

--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreenHandler.java
@@ -24,6 +24,8 @@ public class ScarecrowScreenHandler extends ScreenHandler {
         public static final int HEAD_SLOT_Y = 26;
         public static final int CHEST_SLOT_X = 8;
         public static final int CHEST_SLOT_Y = 44;
+        public static final int PANTS_SLOT_X = 8;
+        public static final int PANTS_SLOT_Y = 62;
         public static final int PITCHFORK_SLOT_X = 8;
         public static final int PITCHFORK_SLOT_Y = 80;
         public static final int PLAYER_INVENTORY_START_Y = 124;
@@ -60,6 +62,8 @@ public class ScarecrowScreenHandler extends ScreenHandler {
                                 ScarecrowBlockEntity::isValidHeadItem));
                 this.addSlot(createEquipmentSlot(ScarecrowBlockEntity.SLOT_CHEST, CHEST_SLOT_X, CHEST_SLOT_Y,
                                 ScarecrowBlockEntity::isValidChestItem));
+                this.addSlot(createEquipmentSlot(ScarecrowBlockEntity.SLOT_PANTS, PANTS_SLOT_X, PANTS_SLOT_Y,
+                                ScarecrowBlockEntity::isValidPantsItem));
                 this.addSlot(createEquipmentSlot(ScarecrowBlockEntity.SLOT_PITCHFORK, PITCHFORK_SLOT_X,
                                 PITCHFORK_SLOT_Y, ScarecrowBlockEntity::isValidPitchforkItem));
 
@@ -116,6 +120,8 @@ public class ScarecrowScreenHandler extends ScreenHandler {
                                                         ScarecrowBlockEntity.SLOT_HEAD + 1, false)
                                         && !this.insertItem(original, ScarecrowBlockEntity.SLOT_CHEST,
                                                         ScarecrowBlockEntity.SLOT_CHEST + 1, false)
+                                        && !this.insertItem(original, ScarecrowBlockEntity.SLOT_PANTS,
+                                                        ScarecrowBlockEntity.SLOT_PANTS + 1, false)
                                         && !this.insertItem(original, ScarecrowBlockEntity.SLOT_PITCHFORK,
                                                         ScarecrowBlockEntity.SLOT_PITCHFORK + 1, false)) {
                                 return ItemStack.EMPTY;

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -132,6 +132,7 @@
   "screen.gardenkingmod.scarecrow.slot.hat": "Hat Slot",
   "screen.gardenkingmod.scarecrow.slot.head": "Head Slot",
   "screen.gardenkingmod.scarecrow.slot.chest": "Chest Slot",
+  "screen.gardenkingmod.scarecrow.slot.pants": "Pants Slot",
   "screen.gardenkingmod.scarecrow.slot.hand": "Hand Slot",
   "screen.gardenkingmod.scarecrow.radius.title": "Ward Radius",
   "screen.gardenkingmod.scarecrow.radius.summary": "%1$s x %2$s",

--- a/src/main/resources/data/gardenkingmod/tags/items/scarecrow_pants.json
+++ b/src/main/resources/data/gardenkingmod/tags/items/scarecrow_pants.json
@@ -1,0 +1,4 @@
+{
+  "replace": false,
+  "values": []
+}


### PR DESCRIPTION
## Summary
- add a pants equipment slot to the scarecrow interface and screen handler
- expand the scarecrow block entity inventory and validation for pants items
- update rendering, localization, and item tag definitions for the new pants slot

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d9b1ec1b508321800e91ce72f16ea1