### PR TITLE
Add scarecrow shirt item registration

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/ModItems.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModItems.java
@@ -29,6 +29,8 @@ import net.minecraft.util.Identifier;
 public final class ModItems {
         public static final Item GARDEN_COIN = registerItem("garden_coin", new Item(new FabricItemSettings()));
         public static final Item RUBY = registerItem("ruby", new Item(new FabricItemSettings()));
+        public static final Item SCARECROW_SHIRT_RED = registerItem("scarecrow_shirt_red",
+                        new Item(new FabricItemSettings()));
         public static final Item RUBY_SWORD = registerItem("ruby_sword",
                         new SwordItem(RubyToolMaterial.INSTANCE, 4, -2.2F, new FabricItemSettings()));
         public static final Item RUBY_PICKAXE = registerItem("ruby_pickaxe",
@@ -113,6 +115,8 @@ public final class ModItems {
                                         entries.add(RUBY);
                                         rottenItems.forEach(entries::add);
                                 });
+                ItemGroupEvents.modifyEntriesEvent(ItemGroups.FUNCTIONAL)
+                                .register(entries -> entries.add(SCARECROW_SHIRT_RED));
                 ItemGroupEvents.modifyEntriesEvent(ItemGroups.TOOLS)
                                 .register(entries -> {
                                         entries.add(RUBY_PICKAXE);

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -10,6 +10,7 @@
   "item.gardenkingmod.ruby_chestplate": "Ruby Chestplate",
   "item.gardenkingmod.ruby_leggings": "Ruby Leggings",
   "item.gardenkingmod.ruby_boots": "Ruby Boots",
+  "item.gardenkingmod.scarecrow_shirt_red": "Red Scarecrow Shirt",
 
   "block.gardenkingmod.ruby_block": "Ruby Block",
 

--- a/src/main/resources/data/gardenkingmod/tags/items/scarecrow_shirts.json
+++ b/src/main/resources/data/gardenkingmod/tags/items/scarecrow_shirts.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "gardenkingmod:scarecrow_shirt_red"
+  ]
+}


### PR DESCRIPTION
## Summary
- register the new red scarecrow shirt item and expose it in the functional creative tab
- add localization and the scarecrow shirt item tag so the scarecrow can equip the new cosmetic

## Testing
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68d97fb2925c8321999e1dc10e42241a