### PR TITLE
Update scarecrow model root part name

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
@@ -24,14 +24,15 @@ public class ScarecrowModel extends EntityModel<Entity> {
             "main"
     );
 
-    private final ModelPart bb_main;
+    private final ModelPart scarecrow;
+
     public ScarecrowModel(ModelPart root) {
-        this.bb_main = root.getChild("bb_main");
+        this.scarecrow = root.getChild("scarecrow");
     }
     public static TexturedModelData getTexturedModelData() {
         ModelData modelData = new ModelData();
         ModelPartData modelPartData = modelData.getRoot();
-        ModelPartData bb_main = modelPartData.addChild("bb_main", ModelPartBuilder.create().uv(0, 64).cuboid(-5.0F, -2.0F, -5.0F, 10.0F, 2.0F, 10.0F, new Dilation(0.0F))
+        ModelPartData scarecrow = modelPartData.addChild("scarecrow", ModelPartBuilder.create().uv(0, 64).cuboid(-5.0F, -2.0F, -5.0F, 10.0F, 2.0F, 10.0F, new Dilation(0.0F))
                 .uv(40, 66).cuboid(-4.0F, -4.0F, -4.0F, 8.0F, 2.0F, 8.0F, new Dilation(0.0F))
                 .uv(0, 28).cuboid(-1.0F, -38.0F, -1.0F, 2.0F, 34.0F, 2.0F, new Dilation(0.0F))
                 .uv(0, 60).cuboid(-19.0F, -28.0F, -1.0F, 37.0F, 2.0F, 2.0F, new Dilation(0.0F))
@@ -75,31 +76,31 @@ public class ScarecrowModel extends EntityModel<Entity> {
                 .uv(22, 43).cuboid(4.0F, -24.0F, 3.0F, 1.0F, 2.0F, 0.0F, new Dilation(0.0F))
                 .uv(25, 41).cuboid(11.0F, -26.0F, 3.0F, 2.0F, 2.0F, 0.0F, new Dilation(0.0F)), ModelTransform.pivot(0.0F, 24.0F, 0.0F));
 
-        bb_main.addChild("cube_r1", ModelPartBuilder.create().uv(50, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(1.2929F, -36.5F, 3.1F, 0.0F, 0.0F, 2.3562F));
+        scarecrow.addChild("cube_r1", ModelPartBuilder.create().uv(50, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(1.2929F, -36.5F, 3.1F, 0.0F, 0.0F, 2.3562F));
 
-        bb_main.addChild("cube_r2", ModelPartBuilder.create().uv(51, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(2.0F, -35.7929F, 3.1F, 0.0F, 0.0F, 0.7854F));
+        scarecrow.addChild("cube_r2", ModelPartBuilder.create().uv(51, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(2.0F, -35.7929F, 3.1F, 0.0F, 0.0F, 0.7854F));
 
-        bb_main.addChild("cube_r3", ModelPartBuilder.create().uv(50, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(-2.7071F, -36.5F, 3.1F, 0.0F, 0.0F, 2.3562F));
+        scarecrow.addChild("cube_r3", ModelPartBuilder.create().uv(50, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(-2.7071F, -36.5F, 3.1F, 0.0F, 0.0F, 2.3562F));
 
-        bb_main.addChild("cube_r4", ModelPartBuilder.create().uv(51, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(-2.0F, -35.7929F, 3.1F, 0.0F, 0.0F, 0.7854F));
+        scarecrow.addChild("cube_r4", ModelPartBuilder.create().uv(51, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(-2.0F, -35.7929F, 3.1F, 0.0F, 0.0F, 0.7854F));
 
-        bb_main.addChild("cube_r5", ModelPartBuilder.create().uv(49, 8).cuboid(-3.0F, -1.0F, -3.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
+        scarecrow.addChild("cube_r5", ModelPartBuilder.create().uv(49, 8).cuboid(-3.0F, -1.0F, -3.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
                 .uv(49, 9).cuboid(-4.0F, -1.0F, -2.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F))
                 .uv(49, 13).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(-4.0F, -39.0F, 0.0F, 0.0F, 1.5708F, 0.2182F));
 
-        bb_main.addChild("cube_r6", ModelPartBuilder.create().uv(65, 14).cuboid(-3.0F, -1.0F, -3.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
+        scarecrow.addChild("cube_r6", ModelPartBuilder.create().uv(65, 14).cuboid(-3.0F, -1.0F, -3.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
                 .uv(62, 13).cuboid(-4.0F, -1.0F, -2.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F))
                 .uv(58, 14).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(4.0F, -39.0F, 0.0F, 0.0F, -1.5708F, -0.2182F));
 
-        bb_main.addChild("cube_r7", ModelPartBuilder.create().uv(48, 12).cuboid(-3.0F, -1.0F, 1.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
+        scarecrow.addChild("cube_r7", ModelPartBuilder.create().uv(48, 12).cuboid(-3.0F, -1.0F, 1.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
                 .uv(48, 12).cuboid(-4.0F, -1.0F, 0.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F))
                 .uv(49, 11).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, 5.0F, 0.2182F, 0.0F, 0.0F));
 
-        bb_main.addChild("cube_r8", ModelPartBuilder.create().uv(66, 13).cuboid(-3.0F, -1.0F, -1.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -6.0F, -0.2182F, 0.0F, 0.0F));
+        scarecrow.addChild("cube_r8", ModelPartBuilder.create().uv(66, 13).cuboid(-3.0F, -1.0F, -1.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -6.0F, -0.2182F, 0.0F, 0.0F));
 
-        bb_main.addChild("cube_r9", ModelPartBuilder.create().uv(49, 12).cuboid(-4.0F, -1.0F, -1.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -5.0F, -0.2182F, 0.0F, 0.0F));
+        scarecrow.addChild("cube_r9", ModelPartBuilder.create().uv(49, 12).cuboid(-4.0F, -1.0F, -1.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -5.0F, -0.2182F, 0.0F, 0.0F));
 
-        bb_main.addChild("cube_r10", ModelPartBuilder.create().uv(48, 12).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -4.0F, -0.2182F, 0.0F, 0.0F));
+        scarecrow.addChild("cube_r10", ModelPartBuilder.create().uv(48, 12).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -4.0F, -0.2182F, 0.0F, 0.0F));
         return TexturedModelData.of(modelData, 128, 128);
     }
     @Override
@@ -107,6 +108,6 @@ public class ScarecrowModel extends EntityModel<Entity> {
     }
     @Override
     public void render(MatrixStack matrices, VertexConsumer vertexConsumer, int light, int overlay, float red, float green, float blue, float alpha) {
-        bb_main.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
+        scarecrow.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
     }
 }


### PR DESCRIPTION
## Summary
- rename the scarecrow model's root part to match the latest Blockbench export
- update textured model data and rendering to use the new root part identifier

## Testing
- `./gradlew runClient` *(fails: asset download requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_68da147a52b88321936241a6433d7761