### PR TITLE
Refactor scarecrow base geometry

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
@@ -24,90 +24,32 @@ public class ScarecrowModel extends EntityModel<Entity> {
             "main"
     );
 
-    private final ModelPart scarecrow;
+    private final ModelPart scarecrowBase;
 
     public ScarecrowModel(ModelPart root) {
-        this.scarecrow = root.getChild("scarecrow");
+        this.scarecrowBase = root.getChild("scarecrow_base");
     }
+
     public static TexturedModelData getTexturedModelData() {
         ModelData modelData = new ModelData();
         ModelPartData modelPartData = modelData.getRoot();
-        ModelPartData scarecrow = modelPartData.addChild("scarecrow", ModelPartBuilder.create().uv(0, 64).cuboid(-5.0F, -2.0F, -5.0F, 10.0F, 2.0F, 10.0F, new Dilation(0.0F))
-                .uv(40, 66).cuboid(-4.0F, -4.0F, -4.0F, 8.0F, 2.0F, 8.0F, new Dilation(0.0F))
-                .uv(0, 28).cuboid(-1.0F, -38.0F, -1.0F, 2.0F, 34.0F, 2.0F, new Dilation(0.0F))
-                .uv(0, 60).cuboid(-19.0F, -28.0F, -1.0F, 37.0F, 2.0F, 2.0F, new Dilation(0.0F))
-                .uv(16, 26).cuboid(-4.0F, -31.0F, -3.0F, 8.0F, 16.0F, 6.0F, new Dilation(0.0F))
-                .uv(16, 39).cuboid(4.0F, -31.0F, -3.0F, 9.0F, 3.0F, 6.0F, new Dilation(0.0F))
-                .uv(16, 39).cuboid(-13.0F, -31.0F, -3.0F, 9.0F, 3.0F, 6.0F, new Dilation(0.0F))
-                .uv(48, 16).cuboid(-4.0F, -39.0F, -4.0F, 8.0F, 8.0F, 8.0F, new Dilation(0.0F))
-                .uv(48, 7).cuboid(-4.0F, -40.0F, -4.0F, 8.0F, 1.0F, 8.0F, new Dilation(0.0F))
-                .uv(48, 35).cuboid(-3.0F, -42.0F, -3.0F, 6.0F, 2.0F, 6.0F, new Dilation(0.0F))
-                .uv(48, 43).cuboid(-2.0F, -43.0F, -2.0F, 4.0F, 1.0F, 4.0F, new Dilation(0.0F))
-                .uv(16, 45).cuboid(-1.0F, -15.0F, -3.0F, 2.0F, 3.0F, 0.0F, new Dilation(0.0F))
-                .uv(17, 44).cuboid(3.0F, -15.0F, -3.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F))
-                .uv(26, 39).cuboid(-4.0F, -15.0F, -3.0F, 1.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(22, 40).cuboid(4.0F, -15.0F, -3.0F, 0.0F, 2.0F, 1.0F, new Dilation(0.0F))
-                .uv(20, 38).cuboid(4.0F, -15.0F, -2.0F, 0.0F, 1.0F, 1.0F, new Dilation(0.0F))
-                .uv(28, 44).cuboid(2.0F, -15.0F, -3.0F, 1.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(24, 41).cuboid(4.0F, -15.0F, 0.0F, 0.0F, 2.0F, 1.0F, new Dilation(0.0F))
-                .uv(24, 38).cuboid(4.0F, -15.0F, 2.0F, 0.0F, 3.0F, 1.0F, new Dilation(0.0F))
-                .uv(22, 43).cuboid(3.0F, -15.0F, 3.0F, 1.0F, 1.0F, 0.0F, new Dilation(0.0F))
-                .uv(19, 37).cuboid(2.0F, -15.0F, 3.0F, 1.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(29, 37).cuboid(-1.0F, -15.0F, 3.0F, 2.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(36, 37).cuboid(-3.0F, -15.0F, 3.0F, 1.0F, 1.0F, 0.0F, new Dilation(0.0F))
-                .uv(35, 43).cuboid(-4.0F, -15.0F, 3.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F))
-                .uv(23, 43).cuboid(-4.0F, -15.0F, -3.0F, 0.0F, 1.0F, 1.0F, new Dilation(0.0F))
-                .uv(18, 42).cuboid(-4.0F, -15.0F, -1.0F, 0.0F, 3.0F, 2.0F, new Dilation(0.0F))
-                .uv(20, 41).cuboid(-4.0F, -15.0F, 2.0F, 0.0F, 2.0F, 1.0F, new Dilation(0.0F))
-                .uv(16, 17).cuboid(4.0F, -28.0F, -3.0F, 9.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(28, 45).cuboid(-13.0F, -28.0F, -3.0F, 9.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(28, 45).cuboid(-13.0F, -28.0F, 3.0F, 9.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(28, 39).cuboid(4.0F, -28.0F, 3.0F, 9.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(21, 44).cuboid(4.0F, -26.0F, -3.0F, 2.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(22, 34).cuboid(4.0F, -24.0F, -3.0F, 1.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(21, 40).cuboid(-6.0F, -26.0F, -3.0F, 2.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(21, 32).cuboid(-5.0F, -24.0F, -3.0F, 1.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(25, 42).cuboid(11.0F, -26.0F, -3.0F, 2.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(25, 38).cuboid(-13.0F, -26.0F, -3.0F, 2.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(25, 39).cuboid(-6.0F, -26.0F, 3.0F, 2.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(32, 41).cuboid(-5.0F, -24.0F, 3.0F, 1.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(35, 41).cuboid(-13.0F, -26.0F, 3.0F, 2.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(25, 41).cuboid(4.0F, -26.0F, 3.0F, 2.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(22, 43).cuboid(4.0F, -24.0F, 3.0F, 1.0F, 2.0F, 0.0F, new Dilation(0.0F))
-                .uv(25, 41).cuboid(11.0F, -26.0F, 3.0F, 2.0F, 2.0F, 0.0F, new Dilation(0.0F)), ModelTransform.pivot(0.0F, 24.0F, 0.0F));
-
-        scarecrow.addChild("cube_r1", ModelPartBuilder.create().uv(50, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(1.2929F, -36.5F, 3.1F, 0.0F, 0.0F, 2.3562F));
-
-        scarecrow.addChild("cube_r2", ModelPartBuilder.create().uv(51, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(2.0F, -35.7929F, 3.1F, 0.0F, 0.0F, 0.7854F));
-
-        scarecrow.addChild("cube_r3", ModelPartBuilder.create().uv(50, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(-2.7071F, -36.5F, 3.1F, 0.0F, 0.0F, 2.3562F));
-
-        scarecrow.addChild("cube_r4", ModelPartBuilder.create().uv(51, 18).cuboid(-1.0F, -2.0F, 1.0F, 1.0F, 3.0F, 0.0F, new Dilation(0.0F)), ModelTransform.of(-2.0F, -35.7929F, 3.1F, 0.0F, 0.0F, 0.7854F));
-
-        scarecrow.addChild("cube_r5", ModelPartBuilder.create().uv(49, 8).cuboid(-3.0F, -1.0F, -3.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
-                .uv(49, 9).cuboid(-4.0F, -1.0F, -2.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F))
-                .uv(49, 13).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(-4.0F, -39.0F, 0.0F, 0.0F, 1.5708F, 0.2182F));
-
-        scarecrow.addChild("cube_r6", ModelPartBuilder.create().uv(65, 14).cuboid(-3.0F, -1.0F, -3.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
-                .uv(62, 13).cuboid(-4.0F, -1.0F, -2.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F))
-                .uv(58, 14).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(4.0F, -39.0F, 0.0F, 0.0F, -1.5708F, -0.2182F));
-
-        scarecrow.addChild("cube_r7", ModelPartBuilder.create().uv(48, 12).cuboid(-3.0F, -1.0F, 1.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F))
-                .uv(48, 12).cuboid(-4.0F, -1.0F, 0.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F))
-                .uv(49, 11).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, 5.0F, 0.2182F, 0.0F, 0.0F));
-
-        scarecrow.addChild("cube_r8", ModelPartBuilder.create().uv(66, 13).cuboid(-3.0F, -1.0F, -1.0F, 6.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -6.0F, -0.2182F, 0.0F, 0.0F));
-
-        scarecrow.addChild("cube_r9", ModelPartBuilder.create().uv(49, 12).cuboid(-4.0F, -1.0F, -1.0F, 8.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -5.0F, -0.2182F, 0.0F, 0.0F));
-
-        scarecrow.addChild("cube_r10", ModelPartBuilder.create().uv(48, 12).cuboid(-5.0F, -1.0F, -1.0F, 10.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -39.0F, -4.0F, -0.2182F, 0.0F, 0.0F));
-        return TexturedModelData.of(modelData, 128, 128);
+        modelPartData.addChild("scarecrow_base", ModelPartBuilder.create()
+                        .uv(0, 0)
+                        .cuboid(-8.0F, -2.0F, -8.0F, 16.0F, 2.0F, 16.0F, new Dilation(0.0F))
+                        .uv(0, 18)
+                        .cuboid(-1.0F, -16.0F, -1.0F, 2.0F, 14.0F, 2.0F, new Dilation(0.0F))
+                        .uv(36, 18)
+                        .cuboid(-6.0F, -18.0F, -1.0F, 12.0F, 2.0F, 2.0F, new Dilation(0.0F)),
+                ModelTransform.pivot(0.0F, 24.0F, 0.0F));
+        return TexturedModelData.of(modelData, 64, 32);
     }
+
     @Override
     public void setAngles(Entity entity, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch) {
     }
+
     @Override
     public void render(MatrixStack matrices, VertexConsumer vertexConsumer, int light, int overlay, float red, float green, float blue, float alpha) {
-        scarecrow.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
+        scarecrowBase.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
     }
 }


### PR DESCRIPTION
## Summary
- replace the scarecrow model definition with the baseplate and post cuboids exported from Blockbench
- update the model part name, render call, and texture resolution to match the simplified geometry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da1746a63c8321b83334e2a0e857b0