### PR TITLE
Fix scarecrow model texture resolution

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
@@ -41,7 +41,7 @@ public class ScarecrowModel extends EntityModel<Entity> {
                         .uv(36, 18)
                         .cuboid(-6.0F, -18.0F, -1.0F, 12.0F, 2.0F, 2.0F, new Dilation(0.0F)),
                 ModelTransform.pivot(0.0F, 24.0F, 0.0F));
-        return TexturedModelData.of(modelData, 64, 32);
+        return TexturedModelData.of(modelData, 128, 128);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- update the scarecrow textured model data to use the 128x128 texture atlas

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68da1aa22d6c83219ae88bd8dc9f0ae3