### PR TITLE
Align scarecrow arm UV with new texture

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
@@ -38,7 +38,7 @@ public class ScarecrowModel extends EntityModel<Entity> {
                         .cuboid(-8.0F, -2.0F, -8.0F, 16.0F, 2.0F, 16.0F, new Dilation(0.0F))
                         .uv(0, 18)
                         .cuboid(-1.0F, -16.0F, -1.0F, 2.0F, 14.0F, 2.0F, new Dilation(0.0F))
-                        .uv(36, 18)
+                        .uv(8, 22)
                         .cuboid(-6.0F, -18.0F, -1.0F, 12.0F, 2.0F, 2.0F, new Dilation(0.0F)),
                 ModelTransform.pivot(0.0F, 24.0F, 0.0F));
         return TexturedModelData.of(modelData, 64, 64);


### PR DESCRIPTION
## Summary
- adjust the scarecrow arm UV mapping to use the painted crossbar texture

## Testing
- not run (manual resource reload required in-game)

------
https://chatgpt.com/codex/tasks/task_e_68da2215ffc08321970af8728a0b2958