### PR TITLE
Adjust scarecrow UVs for updated geometry

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
@@ -34,12 +34,12 @@ public class ScarecrowModel extends EntityModel<Entity> {
         ModelData modelData = new ModelData();
         ModelPartData modelPartData = modelData.getRoot();
         modelPartData.addChild("scarecrow_base", ModelPartBuilder.create()
-                        .uv(0, 0)
-                        .cuboid(-8.0F, -2.0F, -8.0F, 16.0F, 2.0F, 16.0F, new Dilation(0.0F))
-                        .uv(0, 18)
-                        .cuboid(-1.0F, -16.0F, -1.0F, 2.0F, 14.0F, 2.0F, new Dilation(0.0F))
-                        .uv(8, 22)
-                        .cuboid(-6.0F, -18.0F, -1.0F, 12.0F, 2.0F, 2.0F, new Dilation(0.0F)),
+                        .uv(0, 12)
+                        .cuboid(-8.0F, -4.0F, -8.0F, 16.0F, 4.0F, 16.0F, new Dilation(0.0F))
+                        .uv(0, 28)
+                        .cuboid(-1.0F, -16.0F, -1.0F, 2.0F, 12.0F, 2.0F, new Dilation(0.0F))
+                        .uv(12, 0)
+                        .cuboid(-8.0F, -18.0F, -1.0F, 16.0F, 2.0F, 2.0F, new Dilation(0.0F)),
                 ModelTransform.pivot(0.0F, 24.0F, 0.0F));
         return TexturedModelData.of(modelData, 64, 64);
     }


### PR DESCRIPTION
## Summary
- expand the scarecrow base plate to the authored 4px height and stretch the crossbar to the full 16px span
- retarget the scarecrow model UVs to the updated texture locations for the base, post, and arm

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68da2555f3388321841f1d55f9247bdf