### PR TITLE
Adjust scarecrow base UV mapping

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
@@ -35,11 +35,11 @@ public class ScarecrowModel extends EntityModel<Entity> {
         ModelPartData modelPartData = modelData.getRoot();
         modelPartData.addChild("scarecrow_base", ModelPartBuilder.create()
                         .uv(0, 12)
-                        .cuboid(-8.0F, -4.0F, -8.0F, 16.0F, 4.0F, 16.0F, new Dilation(0.0F))
+                        .cuboid(-6.0F, -2.0F, -6.0F, 12.0F, 2.0F, 12.0F, new Dilation(0.0F))
                         .uv(0, 28)
-                        .cuboid(-1.0F, -16.0F, -1.0F, 2.0F, 12.0F, 2.0F, new Dilation(0.0F))
-                        .uv(12, 0)
-                        .cuboid(-8.0F, -18.0F, -1.0F, 16.0F, 2.0F, 2.0F, new Dilation(0.0F)),
+                        .cuboid(-1.0F, -14.0F, -1.0F, 2.0F, 12.0F, 2.0F, new Dilation(0.0F))
+                        .uv(0, 24)
+                        .cuboid(-8.0F, -16.0F, -1.0F, 16.0F, 2.0F, 2.0F, new Dilation(0.0F)),
                 ModelTransform.pivot(0.0F, 24.0F, 0.0F));
         return TexturedModelData.of(modelData, 64, 64);
     }


### PR DESCRIPTION
## Summary
- resize the scarecrow base cuboid and retarget the base, pole, and crossbar UV origins to the updated texture islands

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68da2c4dcb088321ad1282179ef2b075