### PR TITLE
Adjust scarecrow base proportions

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
@@ -35,9 +35,9 @@ public class ScarecrowModel extends EntityModel<Entity> {
         ModelPartData modelPartData = modelData.getRoot();
         modelPartData.addChild("scarecrow_base", ModelPartBuilder.create()
                         .uv(0, 12)
-                        .cuboid(-6.0F, -2.0F, -6.0F, 12.0F, 2.0F, 12.0F, new Dilation(0.0F))
+                        .cuboid(-8.0F, -4.0F, -8.0F, 16.0F, 4.0F, 16.0F, new Dilation(0.0F))
                         .uv(0, 28)
-                        .cuboid(-1.0F, -14.0F, -1.0F, 2.0F, 12.0F, 2.0F, new Dilation(0.0F))
+                        .cuboid(-1.0F, -16.0F, -1.0F, 2.0F, 12.0F, 2.0F, new Dilation(0.0F))
                         .uv(0, 24)
                         .cuboid(-8.0F, -16.0F, -1.0F, 16.0F, 2.0F, 2.0F, new Dilation(0.0F)),
                 ModelTransform.pivot(0.0F, 24.0F, 0.0F));


### PR DESCRIPTION
## Summary
- enlarge the scarecrow base plate to the new 16×16×4 footprint
- lower the vertical post so it seats correctly on the taller base

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68da33e017248321bd96055d6f246ff3