### PR TITLE
Replace scarecrow shirt red item with base variant

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/ModItems.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModItems.java
@@ -29,8 +29,6 @@ import net.minecraft.util.Identifier;
 public final class ModItems {
         public static final Item GARDEN_COIN = registerItem("garden_coin", new Item(new FabricItemSettings()));
         public static final Item RUBY = registerItem("ruby", new Item(new FabricItemSettings()));
-        public static final Item SCARECROW_SHIRT_RED = registerItem("scarecrow_shirt_red",
-                        new Item(new FabricItemSettings()));
         public static final Item SCARECROW_SHIRT = registerItem("scarecrow_shirt",
                         new Item(new FabricItemSettings()));
         public static final Item RUBY_SWORD = registerItem("ruby_sword",
@@ -118,7 +116,7 @@ public final class ModItems {
                                         rottenItems.forEach(entries::add);
                                 });
                 ItemGroupEvents.modifyEntriesEvent(ItemGroups.FUNCTIONAL)
-                                .register(entries -> entries.add(SCARECROW_SHIRT_RED));
+                                .register(entries -> entries.add(SCARECROW_SHIRT));
                 ItemGroupEvents.modifyEntriesEvent(ItemGroups.TOOLS)
                                 .register(entries -> {
                                         entries.add(RUBY_PICKAXE);

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -10,7 +10,7 @@
   "item.gardenkingmod.ruby_chestplate": "Ruby Chestplate",
   "item.gardenkingmod.ruby_leggings": "Ruby Leggings",
   "item.gardenkingmod.ruby_boots": "Ruby Boots",
-  "item.gardenkingmod.scarecrow_shirt_red": "Red Scarecrow Shirt",
+  "item.gardenkingmod.scarecrow_shirt": "Scarecrow Shirt",
 
   "block.gardenkingmod.ruby_block": "Ruby Block",
 

--- a/src/main/resources/data/gardenkingmod/tags/items/scarecrow_shirts.json
+++ b/src/main/resources/data/gardenkingmod/tags/items/scarecrow_shirts.json
@@ -1,7 +1,6 @@
 {
   "replace": false,
   "values": [
-    "gardenkingmod:scarecrow_shirt_red",
     "gardenkingmod:scarecrow_shirt"
   ]
 }


### PR DESCRIPTION
## Summary
- register the scarecrow shirt item under a single shared constant
- update the functional item group and scarecrow shirt tag to reference the unified item
- refresh the English localization to match the new scarecrow shirt identifier

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab84bbbec83218ceaee6679720cec