### PR TITLE
Fix scarecrow shirt texture reference

### DIFF
--- a/src/main/resources/assets/gardenkingmod/models/item/scarecrow_shirt.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/scarecrow_shirt.json
@@ -4,8 +4,8 @@
 	"ambientocclusion": false,
 	"texture_size": [64, 64],
 	"textures": {
-		"0": "scarecrow_shirt",
-		"particle": "scarecrow_shirt"
+		"0": "gardenkingmod:item/scarecrow_shirt",
+		"particle": "gardenkingmod:item/scarecrow_shirt"
 	},
 	"elements": [
 		{


### PR DESCRIPTION
## Summary
- update the scarecrow shirt item model to use the proper namespaced texture for both the base and particle entries

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dabeb631d48321a80692fe1da2081f