### PR TITLE
Fix scarecrow clothing orientation

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
@@ -110,6 +110,7 @@ public final class ScarecrowRenderHelper {
         applyScarecrowPose(this.bodyModel);
         this.bodyModel.body.rotate(matrices);
         matrices.translate(0.0F, 0.2F, -0.25F);
+        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180.0F));
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
         matrices.scale(0.6F, 0.6F, 0.6F);
         ItemRenderer itemRenderer = MinecraftClient.getInstance().getItemRenderer();
@@ -134,6 +135,7 @@ public final class ScarecrowRenderHelper {
         applyScarecrowPose(this.bodyModel);
         this.bodyModel.body.rotate(matrices);
         matrices.translate(0.0F, 0.95F, -0.15F);
+        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180.0F));
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
         matrices.scale(0.55F, 0.55F, 0.55F);
         ItemRenderer itemRenderer = MinecraftClient.getInstance().getItemRenderer();


### PR DESCRIPTION
## Summary
- flip the matrix stack on the X axis when rendering scarecrow chest items so fixed items display upright
- apply the same X-axis rotation to non-armor leg items to keep them oriented correctly

## Testing
- `./gradlew runClient` *(fails: downloadAssets could not download required assets in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dabfb51c40832180643f9698dfb6c4