### PR TITLE
Fix scarecrow equipment base model inheritance

### DIFF
--- a/src/main/resources/assets/gardenkingmod/models/item/scarecrow_equipment_base.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/scarecrow_equipment_base.json
@@ -1,5 +1,4 @@
 {
-  "parent": "minecraft:builtin/entity",
   "display": {
     "gui": {
       "rotation": [30, 225, 0],


### PR DESCRIPTION
## Summary
- remove the builtin entity parent from `scarecrow_equipment_base.json`
- leave only the shared display transforms so slot-specific flags stay in child models

## Testing
- not run (manual resource reload requires a Minecraft client)


------
https://chatgpt.com/codex/tasks/task_e_68dacb8409408321a5f65e6847e7b0e3