### PR TITLE
Adjust scarecrow model proportions

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
@@ -32,10 +32,19 @@ public class ScarecrowModel extends EntityModel<Entity> {
     public static TexturedModelData getTexturedModelData() {
         ModelData modelData = new ModelData();
         ModelPartData modelPartData = modelData.getRoot();
-        ModelPartData bone = modelPartData.addChild("bone", ModelPartBuilder.create().uv(0, 0).cuboid(-6.0F, -2.0F, -6.0F, 12.0F, 2.0F, 12.0F, new Dilation(0.0F))
-                .uv(0, 14).cuboid(-4.0F, -4.0F, -4.0F, 8.0F, 2.0F, 8.0F, new Dilation(0.0F))
-                .uv(0, 28).cuboid(-1.0F, -14.0F, -1.0F, 2.0F, 10.0F, 2.0F, new Dilation(0.0F))
-                .uv(0, 24).cuboid(-8.0F, -16.0F, -1.0F, 16.0F, 2.0F, 2.0F, new Dilation(0.0F)), ModelTransform.pivot(0.0F, 24.0F, 0.0F));
+        modelPartData.addChild("bone",
+                ModelPartBuilder.create()
+                        .uv(0, 0)
+                        .cuboid(-6.0F, -2.0F, -6.0F, 12.0F, 2.0F, 12.0F, new Dilation(0.0F))
+                        .uv(0, 14)
+                        .cuboid(-4.0F, -8.0F, -4.0F, 8.0F, 4.0F, 8.0F, new Dilation(0.0F))
+                        .uv(0, 26)
+                        .cuboid(-1.0F, -24.0F, -1.0F, 2.0F, 16.0F, 2.0F, new Dilation(0.0F))
+                        .uv(0, 44)
+                        .cuboid(-8.0F, -22.0F, -1.0F, 16.0F, 2.0F, 2.0F, new Dilation(0.0F))
+                        .uv(32, 0)
+                        .cuboid(-5.0F, -30.0F, -5.0F, 10.0F, 6.0F, 10.0F, new Dilation(0.0F)),
+                ModelTransform.pivot(0.0F, 24.0F, 0.0F));
         return TexturedModelData.of(modelData, 64, 64);
     }
     @Override

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
@@ -24,7 +24,7 @@ public class ScarecrowBlockEntityRenderer implements BlockEntityRenderer<Scarecr
     public void render(ScarecrowBlockEntity entity, float tickDelta, MatrixStack matrices,
             VertexConsumerProvider vertexConsumers, int light, int overlay) {
         matrices.push();
-        matrices.translate(0.5f, 1.5f, 0.5f);
+        matrices.translate(0.5f, 1.9f, 0.5f);
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
 
         World world = entity.getWorld();

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
@@ -85,7 +85,7 @@ public final class ScarecrowRenderHelper {
         matrices.push();
         applyScarecrowPose(this.bodyModel);
         this.bodyModel.head.rotate(matrices);
-        matrices.translate(0.0F, -0.25F, 0.0F);
+        matrices.translate(0.0F, -0.45F, 0.0F);
         matrices.scale(0.75F, 0.75F, 0.75F);
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
         ItemRenderer itemRenderer = MinecraftClient.getInstance().getItemRenderer();
@@ -109,10 +109,10 @@ public final class ScarecrowRenderHelper {
         matrices.push();
         applyScarecrowPose(this.bodyModel);
         this.bodyModel.body.rotate(matrices);
-        matrices.translate(0.0F, 0.2F, -0.25F);
+        matrices.translate(0.0F, -0.1F, -0.25F);
         matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180.0F));
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
-        matrices.scale(0.6F, 0.6F, 0.6F);
+        matrices.scale(0.65F, 0.65F, 0.65F);
         ItemRenderer itemRenderer = MinecraftClient.getInstance().getItemRenderer();
         itemRenderer.renderItem(stack, ModelTransformationMode.FIXED,
                 light, overlay, matrices, vertexConsumers, world, 0);
@@ -134,10 +134,10 @@ public final class ScarecrowRenderHelper {
         matrices.push();
         applyScarecrowPose(this.bodyModel);
         this.bodyModel.body.rotate(matrices);
-        matrices.translate(0.0F, 0.95F, -0.15F);
+        matrices.translate(0.0F, 0.55F, -0.15F);
         matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180.0F));
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
-        matrices.scale(0.55F, 0.55F, 0.55F);
+        matrices.scale(0.6F, 0.6F, 0.6F);
         ItemRenderer itemRenderer = MinecraftClient.getInstance().getItemRenderer();
         itemRenderer.renderItem(stack, ModelTransformationMode.FIXED,
                 light, overlay, matrices, vertexConsumers, world, 0);


### PR DESCRIPTION
## Summary
- rebuild the scarecrow model geometry to match the taller frame
- retune the block entity origin translation for the updated height
- reposition held cosmetic items so hats, shirts, and pants align with the new pose

## Testing
- `./gradlew build`
- `./gradlew runClient` *(fails: downloadAssets could not retrieve required files in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dace1c4b8083218f526000192803e1