### PR TITLE
Refactor scarecrow rendering toggles

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
@@ -1,7 +1,6 @@
 package net.jeremy.gardenkingmod.client.render;
 
 import net.jeremy.gardenkingmod.block.ward.ScarecrowBlockEntity;
-import net.jeremy.gardenkingmod.client.render.ScarecrowRenderHelper.ScarecrowEquipment;
 import net.minecraft.client.render.LightmapTextureManager;
 import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.VertexConsumerProvider;
@@ -34,8 +33,13 @@ public class ScarecrowBlockEntityRenderer implements BlockEntityRenderer<Scarecr
             combinedLight = WorldRenderer.getLightmapCoordinates(world, exposedPos);
         }
 
-        ScarecrowEquipment equipment = ScarecrowEquipment.fromBlockEntity(entity);
-        this.renderHelper.render(matrices, vertexConsumers, combinedLight, OverlayTexture.DEFAULT_UV, equipment, world);
+        this.renderHelper.setHatVisible(!entity.getEquippedHat().isEmpty());
+        this.renderHelper.setHeadVisible(!entity.getEquippedHead().isEmpty());
+        this.renderHelper.setChestVisible(!entity.getEquippedChest().isEmpty());
+        this.renderHelper.setPantsVisible(!entity.getEquippedPants().isEmpty());
+        this.renderHelper.setPitchforkVisible(!entity.getEquippedPitchfork().isEmpty());
+
+        this.renderHelper.render(matrices, vertexConsumers, combinedLight, OverlayTexture.DEFAULT_UV);
 
         matrices.pop();
     }

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
@@ -1,12 +1,6 @@
 package net.jeremy.gardenkingmod.client.render;
 
-import java.lang.reflect.Field;
-
-import org.jetbrains.annotations.Nullable;
-
 import net.jeremy.gardenkingmod.GardenKingMod;
-import net.jeremy.gardenkingmod.ModBlocks;
-import net.jeremy.gardenkingmod.block.ward.ScarecrowBlockEntity;
 import net.jeremy.gardenkingmod.client.model.ScarecrowModel;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.model.ModelPart;
@@ -14,25 +8,8 @@ import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
-import net.minecraft.client.render.entity.model.ArmorStandArmorEntityModel;
-import net.minecraft.client.render.entity.model.ArmorStandEntityModel;
-import net.minecraft.client.render.entity.model.BipedEntityModel;
-import net.minecraft.client.render.entity.model.EntityModelLayers;
-import net.minecraft.client.render.item.ItemRenderer;
-import net.minecraft.client.render.model.json.ModelTransformationMode;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.inventory.Inventories;
-import net.minecraft.item.ArmorItem;
-import net.minecraft.item.BlockItem;
-import net.minecraft.item.DyeableArmorItem;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.collection.DefaultedList;
-import net.minecraft.util.math.RotationAxis;
-import net.minecraft.world.World;
-import net.minecraft.entity.EquipmentSlot;
 
 public final class ScarecrowRenderHelper {
     private static final Identifier BASE_TEXTURE = new Identifier(
@@ -40,302 +17,61 @@ public final class ScarecrowRenderHelper {
             "textures/entity/scarecrow/scarecrow.png"
     );
 
-    private static final Field SHOULDER_STICK_FIELD = getArmorStandField("shoulderStick");
-    private static final Field BASE_PLATE_FIELD = getArmorStandField("basePlate");
-    private static final Field RIGHT_BODY_STICK_FIELD = getArmorStandField("rightBodyStick");
-    private static final Field LEFT_BODY_STICK_FIELD = getArmorStandField("leftBodyStick");
-
     private final ScarecrowModel baseModel;
-    private final ArmorStandEntityModel bodyModel;
-    private final ArmorStandArmorEntityModel innerArmorModel;
-    private final ArmorStandArmorEntityModel outerArmorModel;
+    private boolean hatVisible;
+    private boolean headVisible;
+    private boolean chestVisible;
+    private boolean pantsVisible;
+    private boolean pitchforkVisible;
 
-    public ScarecrowRenderHelper(ModelPart baseModelPart, ModelPart bodyModelPart,
-            ModelPart innerArmorModelPart, ModelPart outerArmorModelPart) {
+    public ScarecrowRenderHelper(ModelPart baseModelPart) {
         this.baseModel = new ScarecrowModel(baseModelPart);
-        this.bodyModel = new ArmorStandEntityModel(bodyModelPart);
-        this.innerArmorModel = new ArmorStandArmorEntityModel(innerArmorModelPart);
-        this.outerArmorModel = new ArmorStandArmorEntityModel(outerArmorModelPart);
+        this.hatVisible = false;
+        this.headVisible = false;
+        this.chestVisible = false;
+        this.pantsVisible = false;
+        this.pitchforkVisible = false;
     }
 
-    public void render(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay,
-            ScarecrowEquipment equipment, @Nullable World world) {
+    public void setHatVisible(boolean visible) {
+        this.hatVisible = visible;
+    }
+
+    public void setHeadVisible(boolean visible) {
+        this.headVisible = visible;
+    }
+
+    public void setChestVisible(boolean visible) {
+        this.chestVisible = visible;
+    }
+
+    public void setPantsVisible(boolean visible) {
+        this.pantsVisible = visible;
+    }
+
+    public void setPitchforkVisible(boolean visible) {
+        this.pitchforkVisible = visible;
+    }
+
+    public void render(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
+        this.baseModel.setBaseVisible(true);
+        this.baseModel.setHatVisible(this.hatVisible);
+        this.baseModel.setHeadVisible(this.headVisible);
+        this.baseModel.setChestVisible(this.chestVisible);
+        this.baseModel.setPantsVisible(this.pantsVisible);
+        this.baseModel.setPitchforkVisible(this.pitchforkVisible);
+
         VertexConsumer baseConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(BASE_TEXTURE));
         this.baseModel.render(matrices, baseConsumer, light, overlay, 1.0f, 1.0f, 1.0f, 1.0f);
-
-        renderHeadLayer(matrices, vertexConsumers, light, overlay, equipment.head(), world);
-        renderHeadLayer(matrices, vertexConsumers, light, overlay, equipment.hat(), world);
-        renderChestLayer(matrices, vertexConsumers, light, overlay, equipment.chest(), world);
-        renderLegLayer(matrices, vertexConsumers, light, overlay, equipment.pants(), world);
-        renderPitchfork(matrices, vertexConsumers, light, overlay, equipment.pitchfork());
-    }
-
-    private void renderHeadLayer(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay,
-            ItemStack stack, @Nullable World world) {
-        if (stack.isEmpty()) {
-            return;
-        }
-
-        Item item = stack.getItem();
-        if (item instanceof ArmorItem armorItem && armorItem.getSlotType() == EquipmentSlot.HEAD) {
-            renderArmor(stack, armorItem, matrices, vertexConsumers, light, overlay, world);
-            return;
-        }
-
-        matrices.push();
-        applyScarecrowPose(this.bodyModel);
-        this.bodyModel.head.rotate(matrices);
-        matrices.translate(0.0F, -0.45F, 0.0F);
-        matrices.scale(0.75F, 0.75F, 0.75F);
-        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
-        ItemRenderer itemRenderer = MinecraftClient.getInstance().getItemRenderer();
-        itemRenderer.renderItem(stack, ModelTransformationMode.HEAD,
-                light, overlay, matrices, vertexConsumers, world, 0);
-        matrices.pop();
-    }
-
-    private void renderChestLayer(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay,
-            ItemStack stack, @Nullable World world) {
-        if (stack.isEmpty()) {
-            return;
-        }
-
-        Item item = stack.getItem();
-        if (item instanceof ArmorItem armorItem && armorItem.getSlotType() == EquipmentSlot.CHEST) {
-            renderArmor(stack, armorItem, matrices, vertexConsumers, light, overlay, world);
-            return;
-        }
-
-        matrices.push();
-        applyScarecrowPose(this.bodyModel);
-        this.bodyModel.body.rotate(matrices);
-        matrices.translate(0.0F, -0.1F, -0.25F);
-        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180.0F));
-        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
-        matrices.scale(0.65F, 0.65F, 0.65F);
-        ItemRenderer itemRenderer = MinecraftClient.getInstance().getItemRenderer();
-        itemRenderer.renderItem(stack, ModelTransformationMode.FIXED,
-                light, overlay, matrices, vertexConsumers, world, 0);
-        matrices.pop();
-    }
-
-    private void renderLegLayer(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay,
-            ItemStack stack, @Nullable World world) {
-        if (stack.isEmpty()) {
-            return;
-        }
-
-        Item item = stack.getItem();
-        if (item instanceof ArmorItem armorItem && armorItem.getSlotType() == EquipmentSlot.LEGS) {
-            renderArmor(stack, armorItem, matrices, vertexConsumers, light, overlay, world);
-            return;
-        }
-
-        matrices.push();
-        applyScarecrowPose(this.bodyModel);
-        this.bodyModel.body.rotate(matrices);
-        matrices.translate(0.0F, 0.55F, -0.15F);
-        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180.0F));
-        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
-        matrices.scale(0.6F, 0.6F, 0.6F);
-        ItemRenderer itemRenderer = MinecraftClient.getInstance().getItemRenderer();
-        itemRenderer.renderItem(stack, ModelTransformationMode.FIXED,
-                light, overlay, matrices, vertexConsumers, world, 0);
-        matrices.pop();
-    }
-
-    private void renderPitchfork(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay,
-            ItemStack stack) {
-        if (stack.isEmpty()) {
-            return;
-        }
-
-        matrices.push();
-        applyScarecrowPose(this.bodyModel);
-        this.bodyModel.rightArm.rotate(matrices);
-        matrices.translate(-0.05F, 0.45F, -0.35F);
-        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90.0F));
-        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
-        matrices.scale(0.8F, 0.8F, 0.8F);
-        ItemRenderer itemRenderer = MinecraftClient.getInstance().getItemRenderer();
-        itemRenderer.renderItem(stack, ModelTransformationMode.GROUND,
-                light, overlay, matrices, vertexConsumers, null, 0);
-        matrices.pop();
-    }
-
-    private void renderArmor(ItemStack stack, ArmorItem armorItem, MatrixStack matrices,
-            VertexConsumerProvider vertexConsumers, int light, int overlay, @Nullable World world) {
-        BipedEntityModel<?> model = getModelForSlot(armorItem);
-        applyScarecrowPose(model);
-        setModelVisibility(model, armorItem);
-
-        boolean isLeggings = armorItem.getSlotType() == EquipmentSlot.LEGS;
-        Identifier armorTexture = getArmorTexture(armorItem, isLeggings, false);
-        VertexConsumer vertexConsumer = ItemRenderer.getArmorGlintConsumer(vertexConsumers,
-                RenderLayer.getArmorCutoutNoCull(armorTexture), false, stack.hasGlint());
-        float red = 1.0F;
-        float green = 1.0F;
-        float blue = 1.0F;
-        if (armorItem instanceof DyeableArmorItem dyeable) {
-            int color = dyeable.getColor(stack);
-            red = (float) (color >> 16 & 0xFF) / 255.0F;
-            green = (float) (color >> 8 & 0xFF) / 255.0F;
-            blue = (float) (color & 0xFF) / 255.0F;
-        }
-        model.render(matrices, vertexConsumer, light, overlay, red, green, blue, 1.0F);
-
-        if (armorItem instanceof DyeableArmorItem) {
-            Identifier overlayTexture = getArmorTexture(armorItem, isLeggings, true);
-            VertexConsumer overlayConsumer = ItemRenderer.getArmorGlintConsumer(vertexConsumers,
-                    RenderLayer.getArmorCutoutNoCull(overlayTexture), false, stack.hasGlint());
-            model.render(matrices, overlayConsumer, light, overlay, 1.0F, 1.0F, 1.0F, 1.0F);
-        }
-
-    }
-
-    private BipedEntityModel<?> getModelForSlot(ArmorItem armorItem) {
-        return armorItem.getSlotType() == EquipmentSlot.LEGS ? this.innerArmorModel : this.outerArmorModel;
-    }
-
-    private void setModelVisibility(BipedEntityModel<?> model, ArmorItem armorItem) {
-        model.setVisible(false);
-        if (model instanceof ArmorStandEntityModel armorStandModel) {
-            setArmorStandPartVisibility(armorStandModel, SHOULDER_STICK_FIELD, false);
-            setArmorStandPartVisibility(armorStandModel, BASE_PLATE_FIELD, false);
-            setArmorStandPartVisibility(armorStandModel, RIGHT_BODY_STICK_FIELD, false);
-            setArmorStandPartVisibility(armorStandModel, LEFT_BODY_STICK_FIELD, false);
-        }
-        EquipmentSlot slot = armorItem.getSlotType();
-        switch (slot) {
-            case HEAD -> {
-                model.head.visible = true;
-                model.hat.visible = true;
-            }
-            case CHEST -> {
-                model.body.visible = true;
-                model.rightArm.visible = true;
-                model.leftArm.visible = true;
-            }
-            case LEGS -> {
-                model.body.visible = true;
-                model.rightLeg.visible = true;
-                model.leftLeg.visible = true;
-            }
-            case FEET -> {
-                model.rightLeg.visible = true;
-                model.leftLeg.visible = true;
-            }
-            default -> {
-            }
-        }
-    }
-
-    private Identifier getArmorTexture(ArmorItem armorItem, boolean leggings, boolean overlay) {
-        String materialName = armorItem.getMaterial().getName();
-        Identifier id = new Identifier(materialName);
-        String path = String.format("textures/models/armor/%s_layer_%d%s.png",
-                id.getPath(), leggings ? 2 : 1, overlay ? "_overlay" : "");
-        return new Identifier(id.getNamespace(), path);
-    }
-
-    private static void setArmorStandPartVisibility(ArmorStandEntityModel model, @Nullable Field field,
-            boolean visible) {
-        if (field == null) {
-            return;
-        }
-        try {
-            ModelPart part = (ModelPart) field.get(model);
-            part.visible = visible;
-        } catch (IllegalAccessException exception) {
-            GardenKingMod.LOGGER.warn("Failed to update armor stand part visibility", exception);
-        }
-    }
-
-    @Nullable
-    private static Field getArmorStandField(String name) {
-        try {
-            Field field = ArmorStandEntityModel.class.getDeclaredField(name);
-            field.setAccessible(true);
-            return field;
-        } catch (NoSuchFieldException exception) {
-            GardenKingMod.LOGGER.warn("Missing armor stand field {}", name, exception);
-            return null;
-        }
-    }
-
-    private static void applyScarecrowPose(BipedEntityModel<?> model) {
-        model.head.pitch = 0.0F;
-        model.head.yaw = 0.0F;
-        model.head.roll = 0.0F;
-        model.body.pitch = 0.0F;
-        model.body.yaw = 0.0F;
-        model.body.roll = 0.0F;
-        model.rightArm.pitch = 0.0F;
-        model.rightArm.yaw = 0.0F;
-        model.rightArm.roll = (float) Math.PI / 2.0F;
-        model.leftArm.pitch = 0.0F;
-        model.leftArm.yaw = 0.0F;
-        model.leftArm.roll = -(float) Math.PI / 2.0F;
-        model.rightLeg.pitch = 0.0F;
-        model.rightLeg.yaw = 0.0F;
-        model.rightLeg.roll = 0.0F;
-        model.leftLeg.pitch = 0.0F;
-        model.leftLeg.yaw = 0.0F;
-        model.leftLeg.roll = 0.0F;
-        model.hat.copyTransform(model.head);
-    }
-
-    public record ScarecrowEquipment(ItemStack hat, ItemStack head, ItemStack chest, ItemStack pants,
-            ItemStack pitchfork) {
-        public static final ScarecrowEquipment EMPTY = new ScarecrowEquipment(ItemStack.EMPTY, ItemStack.EMPTY,
-                ItemStack.EMPTY, ItemStack.EMPTY, ItemStack.EMPTY);
-
-        public static ScarecrowEquipment fromBlockEntity(ScarecrowBlockEntity entity) {
-            return new ScarecrowEquipment(
-                    entity.getEquippedHat(),
-                    entity.getEquippedHead(),
-                    entity.getEquippedChest(),
-                    entity.getEquippedPants(),
-                    entity.getEquippedPitchfork()
-            );
-        }
-
-        public static ScarecrowEquipment fromItemStack(ItemStack stack) {
-            if (!(stack.getItem() instanceof BlockItem blockItem)) {
-                return EMPTY;
-            }
-            if (blockItem.getBlock() != ModBlocks.SCARECROW_BLOCK) {
-                return EMPTY;
-            }
-            NbtCompound nbt = BlockItem.getBlockEntityNbt(stack);
-            if (nbt == null) {
-                return EMPTY;
-            }
-            DefaultedList<ItemStack> inventory = DefaultedList.ofSize(ScarecrowBlockEntity.INVENTORY_SIZE, ItemStack.EMPTY);
-            Inventories.readNbt(nbt, inventory);
-            return new ScarecrowEquipment(
-                    inventory.get(ScarecrowBlockEntity.SLOT_HAT),
-                    inventory.get(ScarecrowBlockEntity.SLOT_HEAD),
-                    inventory.get(ScarecrowBlockEntity.SLOT_CHEST),
-                    inventory.get(ScarecrowBlockEntity.SLOT_PANTS),
-                    inventory.get(ScarecrowBlockEntity.SLOT_PITCHFORK)
-            );
-        }
     }
 
     public static ScarecrowRenderHelper createDefault(BlockEntityRendererFactory.Context context) {
         ModelPart base = context.getLayerModelPart(ScarecrowModel.LAYER_LOCATION);
-        ModelPart body = context.getLayerModelPart(EntityModelLayers.ARMOR_STAND);
-        ModelPart inner = context.getLayerModelPart(EntityModelLayers.ARMOR_STAND_INNER_ARMOR);
-        ModelPart outer = context.getLayerModelPart(EntityModelLayers.ARMOR_STAND_OUTER_ARMOR);
-        return new ScarecrowRenderHelper(base, body, inner, outer);
+        return new ScarecrowRenderHelper(base);
     }
 
     public static ScarecrowRenderHelper createDefault(MinecraftClient client) {
         ModelPart base = client.getEntityModelLoader().getModelPart(ScarecrowModel.LAYER_LOCATION);
-        ModelPart body = client.getEntityModelLoader().getModelPart(EntityModelLayers.ARMOR_STAND);
-        ModelPart inner = client.getEntityModelLoader().getModelPart(EntityModelLayers.ARMOR_STAND_INNER_ARMOR);
-        ModelPart outer = client.getEntityModelLoader().getModelPart(EntityModelLayers.ARMOR_STAND_OUTER_ARMOR);
-        return new ScarecrowRenderHelper(base, body, inner, outer);
+        return new ScarecrowRenderHelper(base);
     }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/item/ScarecrowItemRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/item/ScarecrowItemRenderer.java
@@ -1,13 +1,18 @@
 package net.jeremy.gardenkingmod.client.render.item;
 
 import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
+import net.jeremy.gardenkingmod.ModBlocks;
+import net.jeremy.gardenkingmod.block.ward.ScarecrowBlockEntity;
 import net.jeremy.gardenkingmod.client.render.ScarecrowRenderHelper;
-import net.jeremy.gardenkingmod.client.render.ScarecrowRenderHelper.ScarecrowEquipment;
+import net.minecraft.inventory.Inventories;
+import net.minecraft.item.BlockItem;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.model.json.ModelTransformationMode;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.math.RotationAxis;
 
 public class ScarecrowItemRenderer implements BuiltinItemRendererRegistry.DynamicItemRenderer {
@@ -51,10 +56,36 @@ public class ScarecrowItemRenderer implements BuiltinItemRendererRegistry.Dynami
             this.renderHelper = ScarecrowRenderHelper.createDefault(MinecraftClient.getInstance());
         }
 
-        ScarecrowEquipment equipment = ScarecrowEquipment.fromItemStack(stack);
-        this.renderHelper.render(matrices, vertexConsumers, light, overlay, equipment,
-                MinecraftClient.getInstance().world);
+        updateVisibilityFromItem(stack);
+        this.renderHelper.render(matrices, vertexConsumers, light, overlay);
 
         matrices.pop();
+    }
+
+    private void updateVisibilityFromItem(ItemStack stack) {
+        boolean hatVisible = false;
+        boolean headVisible = false;
+        boolean chestVisible = false;
+        boolean pantsVisible = false;
+        boolean pitchforkVisible = false;
+
+        if (stack.getItem() instanceof BlockItem blockItem && blockItem.getBlock() == ModBlocks.SCARECROW_BLOCK) {
+            NbtCompound nbt = BlockItem.getBlockEntityNbt(stack);
+            if (nbt != null) {
+                DefaultedList<ItemStack> inventory = DefaultedList.ofSize(ScarecrowBlockEntity.INVENTORY_SIZE, ItemStack.EMPTY);
+                Inventories.readNbt(nbt, inventory);
+                hatVisible = !inventory.get(ScarecrowBlockEntity.SLOT_HAT).isEmpty();
+                headVisible = !inventory.get(ScarecrowBlockEntity.SLOT_HEAD).isEmpty();
+                chestVisible = !inventory.get(ScarecrowBlockEntity.SLOT_CHEST).isEmpty();
+                pantsVisible = !inventory.get(ScarecrowBlockEntity.SLOT_PANTS).isEmpty();
+                pitchforkVisible = !inventory.get(ScarecrowBlockEntity.SLOT_PITCHFORK).isEmpty();
+            }
+        }
+
+        this.renderHelper.setHatVisible(hatVisible);
+        this.renderHelper.setHeadVisible(headVisible);
+        this.renderHelper.setChestVisible(chestVisible);
+        this.renderHelper.setPantsVisible(pantsVisible);
+        this.renderHelper.setPitchforkVisible(pitchforkVisible);
     }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
@@ -6,7 +6,6 @@ import java.util.List;
 import net.jeremy.gardenkingmod.GardenKingMod;
 import net.jeremy.gardenkingmod.block.ward.ScarecrowBlockEntity;
 import net.jeremy.gardenkingmod.client.render.ScarecrowRenderHelper;
-import net.jeremy.gardenkingmod.client.render.ScarecrowRenderHelper.ScarecrowEquipment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
@@ -136,7 +135,12 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                 ItemStack chest = inventory.getStack(ScarecrowBlockEntity.SLOT_CHEST);
                 ItemStack pants = inventory.getStack(ScarecrowBlockEntity.SLOT_PANTS);
                 ItemStack pitchfork = inventory.getStack(ScarecrowBlockEntity.SLOT_PITCHFORK);
-                ScarecrowEquipment equipment = new ScarecrowEquipment(hat, head, chest, pants, pitchfork);
+
+                this.renderHelper.setHatVisible(!hat.isEmpty());
+                this.renderHelper.setHeadVisible(!head.isEmpty());
+                this.renderHelper.setChestVisible(!chest.isEmpty());
+                this.renderHelper.setPantsVisible(!pants.isEmpty());
+                this.renderHelper.setPitchforkVisible(!pitchfork.isEmpty());
 
                 VertexConsumerProvider.Immediate immediate = client.getBufferBuilders().getEntityVertexConsumers();
 
@@ -160,8 +164,7 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                 matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(pitch * 20.0F));
                 matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(yaw * 40.0F));
 
-                this.renderHelper.render(matrices, immediate, 0xF000F0, OverlayTexture.DEFAULT_UV, equipment,
-                                client.world);
+                this.renderHelper.render(matrices, immediate, 0xF000F0, OverlayTexture.DEFAULT_UV);
 
                 matrices.pop();
                 immediate.draw();


### PR DESCRIPTION
## Summary
- simplify `ScarecrowRenderHelper` to use baked scarecrow parts with explicit visibility toggles and a single render path
- update block renderer, item renderer, and GUI preview to set part visibility directly based on scarecrow equipment state

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68dae39fba488321888f81d58538d790