### PR TITLE
Render scarecrow equipment items

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
@@ -33,11 +33,11 @@ public class ScarecrowBlockEntityRenderer implements BlockEntityRenderer<Scarecr
             combinedLight = WorldRenderer.getLightmapCoordinates(world, exposedPos);
         }
 
-        this.renderHelper.setHatVisible(!entity.getEquippedHat().isEmpty());
-        this.renderHelper.setHeadVisible(!entity.getEquippedHead().isEmpty());
-        this.renderHelper.setChestVisible(!entity.getEquippedChest().isEmpty());
-        this.renderHelper.setPantsVisible(!entity.getEquippedPants().isEmpty());
-        this.renderHelper.setPitchforkVisible(!entity.getEquippedPitchfork().isEmpty());
+        this.renderHelper.setHatStack(entity.getEquippedHat());
+        this.renderHelper.setHeadStack(entity.getEquippedHead());
+        this.renderHelper.setChestStack(entity.getEquippedChest());
+        this.renderHelper.setPantsStack(entity.getEquippedPants());
+        this.renderHelper.setPitchforkStack(entity.getEquippedPitchfork());
 
         this.renderHelper.render(matrices, vertexConsumers, combinedLight, OverlayTexture.DEFAULT_UV);
 

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
@@ -8,8 +8,12 @@ import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.json.ModelTransformationMode;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.RotationAxis;
 
 public final class ScarecrowRenderHelper {
     private static final Identifier BASE_TEXTURE = new Identifier(
@@ -18,51 +22,144 @@ public final class ScarecrowRenderHelper {
     );
 
     private final ScarecrowModel baseModel;
-    private boolean hatVisible;
-    private boolean headVisible;
-    private boolean chestVisible;
-    private boolean pantsVisible;
-    private boolean pitchforkVisible;
+    private ItemStack hatStack;
+    private ItemStack headStack;
+    private ItemStack chestStack;
+    private ItemStack pantsStack;
+    private ItemStack pitchforkStack;
 
     public ScarecrowRenderHelper(ModelPart baseModelPart) {
         this.baseModel = new ScarecrowModel(baseModelPart);
-        this.hatVisible = false;
-        this.headVisible = false;
-        this.chestVisible = false;
-        this.pantsVisible = false;
-        this.pitchforkVisible = false;
+        this.hatStack = ItemStack.EMPTY;
+        this.headStack = ItemStack.EMPTY;
+        this.chestStack = ItemStack.EMPTY;
+        this.pantsStack = ItemStack.EMPTY;
+        this.pitchforkStack = ItemStack.EMPTY;
     }
 
-    public void setHatVisible(boolean visible) {
-        this.hatVisible = visible;
+    public void setHatStack(ItemStack stack) {
+        this.hatStack = stack;
     }
 
-    public void setHeadVisible(boolean visible) {
-        this.headVisible = visible;
+    public void setHeadStack(ItemStack stack) {
+        this.headStack = stack;
     }
 
-    public void setChestVisible(boolean visible) {
-        this.chestVisible = visible;
+    public void setChestStack(ItemStack stack) {
+        this.chestStack = stack;
     }
 
-    public void setPantsVisible(boolean visible) {
-        this.pantsVisible = visible;
+    public void setPantsStack(ItemStack stack) {
+        this.pantsStack = stack;
     }
 
-    public void setPitchforkVisible(boolean visible) {
-        this.pitchforkVisible = visible;
+    public void setPitchforkStack(ItemStack stack) {
+        this.pitchforkStack = stack;
     }
 
     public void render(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
         this.baseModel.setBaseVisible(true);
-        this.baseModel.setHatVisible(this.hatVisible);
-        this.baseModel.setHeadVisible(this.headVisible);
-        this.baseModel.setChestVisible(this.chestVisible);
-        this.baseModel.setPantsVisible(this.pantsVisible);
-        this.baseModel.setPitchforkVisible(this.pitchforkVisible);
+        this.baseModel.setHatVisible(false);
+        this.baseModel.setHeadVisible(false);
+        this.baseModel.setChestVisible(false);
+        this.baseModel.setPantsVisible(false);
+        this.baseModel.setPitchforkVisible(false);
 
         VertexConsumer baseConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(BASE_TEXTURE));
         this.baseModel.render(matrices, baseConsumer, light, overlay, 1.0f, 1.0f, 1.0f, 1.0f);
+
+        ItemStack hat = this.hatStack;
+        ItemStack head = this.headStack;
+        ItemStack chest = this.chestStack;
+        ItemStack pants = this.pantsStack;
+        ItemStack pitchfork = this.pitchforkStack;
+
+        this.hatStack = ItemStack.EMPTY;
+        this.headStack = ItemStack.EMPTY;
+        this.chestStack = ItemStack.EMPTY;
+        this.pantsStack = ItemStack.EMPTY;
+        this.pitchforkStack = ItemStack.EMPTY;
+
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client == null) {
+            return;
+        }
+
+        if (!hat.isEmpty()) {
+            renderHat(client, hat, matrices, vertexConsumers, light, overlay);
+        }
+        if (!head.isEmpty()) {
+            renderHead(client, head, matrices, vertexConsumers, light, overlay);
+        }
+        if (!chest.isEmpty()) {
+            renderChest(client, chest, matrices, vertexConsumers, light, overlay);
+        }
+        if (!pants.isEmpty()) {
+            renderPants(client, pants, matrices, vertexConsumers, light, overlay);
+        }
+        if (!pitchfork.isEmpty()) {
+            renderPitchfork(client, pitchfork, matrices, vertexConsumers, light, overlay);
+        }
+    }
+
+    private void renderHat(MinecraftClient client, ItemStack stack, MatrixStack matrices,
+                           VertexConsumerProvider vertexConsumers, int light, int overlay) {
+        matrices.push();
+        matrices.translate(0.0F, -2.05F, 0.0F);
+        matrices.scale(0.85F, 0.85F, 0.85F);
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
+        renderStack(client, stack, matrices, vertexConsumers, light, overlay);
+        matrices.pop();
+    }
+
+    private void renderHead(MinecraftClient client, ItemStack stack, MatrixStack matrices,
+                            VertexConsumerProvider vertexConsumers, int light, int overlay) {
+        matrices.push();
+        matrices.translate(0.0F, -1.75F, 0.0F);
+        matrices.scale(0.9F, 0.9F, 0.9F);
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
+        renderStack(client, stack, matrices, vertexConsumers, light, overlay);
+        matrices.pop();
+    }
+
+    private void renderChest(MinecraftClient client, ItemStack stack, MatrixStack matrices,
+                             VertexConsumerProvider vertexConsumers, int light, int overlay) {
+        matrices.push();
+        matrices.translate(0.0F, -1.05F, -0.2F);
+        matrices.scale(0.9F, 0.9F, 0.9F);
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
+        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(10.0F));
+        renderStack(client, stack, matrices, vertexConsumers, light, overlay);
+        matrices.pop();
+    }
+
+    private void renderPants(MinecraftClient client, ItemStack stack, MatrixStack matrices,
+                             VertexConsumerProvider vertexConsumers, int light, int overlay) {
+        matrices.push();
+        matrices.translate(0.0F, -0.45F, -0.18F);
+        matrices.scale(0.9F, 0.9F, 0.9F);
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
+        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(5.0F));
+        renderStack(client, stack, matrices, vertexConsumers, light, overlay);
+        matrices.pop();
+    }
+
+    private void renderPitchfork(MinecraftClient client, ItemStack stack, MatrixStack matrices,
+                                 VertexConsumerProvider vertexConsumers, int light, int overlay) {
+        matrices.push();
+        matrices.translate(-0.75F, -0.6F, 0.0F);
+        matrices.scale(0.85F, 0.85F, 0.85F);
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(90.0F));
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(-15.0F));
+        renderStack(client, stack, matrices, vertexConsumers, light, overlay);
+        matrices.pop();
+    }
+
+    private void renderStack(MinecraftClient client, ItemStack stack, MatrixStack matrices,
+                             VertexConsumerProvider vertexConsumers, int light, int overlay) {
+        BakedModel model = client.getItemRenderer().getModel(stack, null, null, 0);
+        client.getItemRenderer().renderItem(stack, ModelTransformationMode.FIXED, false,
+                matrices, vertexConsumers, light, overlay, model);
     }
 
     public static ScarecrowRenderHelper createDefault(BlockEntityRendererFactory.Context context) {

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/item/ScarecrowItemRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/item/ScarecrowItemRenderer.java
@@ -56,36 +56,36 @@ public class ScarecrowItemRenderer implements BuiltinItemRendererRegistry.Dynami
             this.renderHelper = ScarecrowRenderHelper.createDefault(MinecraftClient.getInstance());
         }
 
-        updateVisibilityFromItem(stack);
+        applyEquipmentFromItem(stack);
         this.renderHelper.render(matrices, vertexConsumers, light, overlay);
 
         matrices.pop();
     }
 
-    private void updateVisibilityFromItem(ItemStack stack) {
-        boolean hatVisible = false;
-        boolean headVisible = false;
-        boolean chestVisible = false;
-        boolean pantsVisible = false;
-        boolean pitchforkVisible = false;
+    private void applyEquipmentFromItem(ItemStack stack) {
+        ItemStack hat = ItemStack.EMPTY;
+        ItemStack head = ItemStack.EMPTY;
+        ItemStack chest = ItemStack.EMPTY;
+        ItemStack pants = ItemStack.EMPTY;
+        ItemStack pitchfork = ItemStack.EMPTY;
 
         if (stack.getItem() instanceof BlockItem blockItem && blockItem.getBlock() == ModBlocks.SCARECROW_BLOCK) {
             NbtCompound nbt = BlockItem.getBlockEntityNbt(stack);
             if (nbt != null) {
                 DefaultedList<ItemStack> inventory = DefaultedList.ofSize(ScarecrowBlockEntity.INVENTORY_SIZE, ItemStack.EMPTY);
                 Inventories.readNbt(nbt, inventory);
-                hatVisible = !inventory.get(ScarecrowBlockEntity.SLOT_HAT).isEmpty();
-                headVisible = !inventory.get(ScarecrowBlockEntity.SLOT_HEAD).isEmpty();
-                chestVisible = !inventory.get(ScarecrowBlockEntity.SLOT_CHEST).isEmpty();
-                pantsVisible = !inventory.get(ScarecrowBlockEntity.SLOT_PANTS).isEmpty();
-                pitchforkVisible = !inventory.get(ScarecrowBlockEntity.SLOT_PITCHFORK).isEmpty();
+                hat = inventory.get(ScarecrowBlockEntity.SLOT_HAT);
+                head = inventory.get(ScarecrowBlockEntity.SLOT_HEAD);
+                chest = inventory.get(ScarecrowBlockEntity.SLOT_CHEST);
+                pants = inventory.get(ScarecrowBlockEntity.SLOT_PANTS);
+                pitchfork = inventory.get(ScarecrowBlockEntity.SLOT_PITCHFORK);
             }
         }
 
-        this.renderHelper.setHatVisible(hatVisible);
-        this.renderHelper.setHeadVisible(headVisible);
-        this.renderHelper.setChestVisible(chestVisible);
-        this.renderHelper.setPantsVisible(pantsVisible);
-        this.renderHelper.setPitchforkVisible(pitchforkVisible);
+        this.renderHelper.setHatStack(hat);
+        this.renderHelper.setHeadStack(head);
+        this.renderHelper.setChestStack(chest);
+        this.renderHelper.setPantsStack(pants);
+        this.renderHelper.setPitchforkStack(pitchfork);
     }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
@@ -136,11 +136,11 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                 ItemStack pants = inventory.getStack(ScarecrowBlockEntity.SLOT_PANTS);
                 ItemStack pitchfork = inventory.getStack(ScarecrowBlockEntity.SLOT_PITCHFORK);
 
-                this.renderHelper.setHatVisible(!hat.isEmpty());
-                this.renderHelper.setHeadVisible(!head.isEmpty());
-                this.renderHelper.setChestVisible(!chest.isEmpty());
-                this.renderHelper.setPantsVisible(!pants.isEmpty());
-                this.renderHelper.setPitchforkVisible(!pitchfork.isEmpty());
+                this.renderHelper.setHatStack(hat);
+                this.renderHelper.setHeadStack(head);
+                this.renderHelper.setChestStack(chest);
+                this.renderHelper.setPantsStack(pants);
+                this.renderHelper.setPitchforkStack(pitchfork);
 
                 VertexConsumerProvider.Immediate immediate = client.getBufferBuilders().getEntityVertexConsumers();
 


### PR DESCRIPTION
## Summary
- update the scarecrow render helper to store slot item stacks temporarily and render them with the item renderer
- pass actual slot stacks from the block entity, screen, and item renderer helpers instead of boolean visibility flags

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68dae9dbc1c48321be907c3c7f573828