### PR TITLE
Adjust scarecrow render scale and orientation

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
@@ -23,7 +23,10 @@ public class ScarecrowBlockEntityRenderer implements BlockEntityRenderer<Scarecr
     public void render(ScarecrowBlockEntity entity, float tickDelta, MatrixStack matrices,
             VertexConsumerProvider vertexConsumers, int light, int overlay) {
         matrices.push();
-        matrices.translate(0.5f, 1.9f, 0.5f);
+        matrices.translate(0.5f, 1.5f, 0.5f);
+        matrices.scale(ScarecrowRenderHelper.DEFAULT_RENDER_SCALE,
+                ScarecrowRenderHelper.DEFAULT_RENDER_SCALE,
+                ScarecrowRenderHelper.DEFAULT_RENDER_SCALE);
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
 
         World world = entity.getWorld();

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
@@ -16,6 +16,7 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.RotationAxis;
 
 public final class ScarecrowRenderHelper {
+    public static final float DEFAULT_RENDER_SCALE = 0.9F;
     private static final Identifier BASE_TEXTURE = new Identifier(
             GardenKingMod.MOD_ID,
             "textures/entity/scarecrow/scarecrow.png"
@@ -128,6 +129,7 @@ public final class ScarecrowRenderHelper {
         matrices.translate(0.0F, -1.05F, -0.2F);
         matrices.scale(0.9F, 0.9F, 0.9F);
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0F));
         matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(10.0F));
         renderStack(client, stack, matrices, vertexConsumers, light, overlay);
         matrices.pop();

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/item/ScarecrowItemRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/item/ScarecrowItemRenderer.java
@@ -26,6 +26,9 @@ public class ScarecrowItemRenderer implements BuiltinItemRendererRegistry.Dynami
                        VertexConsumerProvider vertexConsumers, int light, int overlay) {
         matrices.push();
         matrices.translate(0.5f, 1.5f, 0.5f);
+        matrices.scale(ScarecrowRenderHelper.DEFAULT_RENDER_SCALE,
+                ScarecrowRenderHelper.DEFAULT_RENDER_SCALE,
+                ScarecrowRenderHelper.DEFAULT_RENDER_SCALE);
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
 
         if (mode != null) {


### PR DESCRIPTION
## Summary
- lower and uniformly scale the scarecrow when rendered as a block entity so it rests on the ground and appears smaller
- apply the same scale when rendering the scarecrow item to keep visuals consistent
- rotate the equipped chest item around the Z axis to stop the shirt from appearing upside down

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db09c2fb288321a73c342e92df9c4d