### PR TITLE
Fix scarecrow render ground offset

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
@@ -23,7 +23,8 @@ public class ScarecrowBlockEntityRenderer implements BlockEntityRenderer<Scarecr
     public void render(ScarecrowBlockEntity entity, float tickDelta, MatrixStack matrices,
             VertexConsumerProvider vertexConsumers, int light, int overlay) {
         matrices.push();
-        matrices.translate(0.5f, 1.5f, 0.5f);
+        float groundY = 1.0f + (2.0f / 16.0f) * ScarecrowRenderHelper.DEFAULT_RENDER_SCALE;
+        matrices.translate(0.5f, groundY, 0.5f);
         matrices.scale(ScarecrowRenderHelper.DEFAULT_RENDER_SCALE,
                 ScarecrowRenderHelper.DEFAULT_RENDER_SCALE,
                 ScarecrowRenderHelper.DEFAULT_RENDER_SCALE);


### PR DESCRIPTION
## Summary
- adjust the scarecrow block entity render translation to align the base with the ground

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68db0f2291148321998191488dc9248f