### PR TITLE
Adjust scarecrow renderer ground offset

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
@@ -23,7 +23,7 @@ public class ScarecrowBlockEntityRenderer implements BlockEntityRenderer<Scarecr
     public void render(ScarecrowBlockEntity entity, float tickDelta, MatrixStack matrices,
             VertexConsumerProvider vertexConsumers, int light, int overlay) {
         matrices.push();
-        float groundY = 1.0f + (2.0f / 16.0f) * ScarecrowRenderHelper.DEFAULT_RENDER_SCALE;
+        float groundY = ScarecrowRenderHelper.DEFAULT_RENDER_SCALE * ((24.0F - 2.0F) / 16.0F);
         matrices.translate(0.5f, groundY, 0.5f);
         matrices.scale(ScarecrowRenderHelper.DEFAULT_RENDER_SCALE,
                 ScarecrowRenderHelper.DEFAULT_RENDER_SCALE,


### PR DESCRIPTION
## Summary
- adjust the scarecrow renderer ground offset so the flipped pivot accounts for the base thickness

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68db137ec9008321bf9a9114a04c69fa