### PR TITLE
Fix scarecrow render ground translation

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
@@ -23,7 +23,7 @@ public class ScarecrowBlockEntityRenderer implements BlockEntityRenderer<Scarecr
     public void render(ScarecrowBlockEntity entity, float tickDelta, MatrixStack matrices,
             VertexConsumerProvider vertexConsumers, int light, int overlay) {
         matrices.push();
-        float groundY = ScarecrowRenderHelper.DEFAULT_RENDER_SCALE * ((24.0F - 2.0F) / 16.0F);
+        float groundY = ScarecrowRenderHelper.DEFAULT_RENDER_SCALE * (24.0F / 16.0F);
         matrices.translate(0.5f, groundY, 0.5f);
         matrices.scale(ScarecrowRenderHelper.DEFAULT_RENDER_SCALE,
                 ScarecrowRenderHelper.DEFAULT_RENDER_SCALE,


### PR DESCRIPTION
## Summary
- adjust the scarecrow block entity renderer translation so the model base sits flush with the ground after rotation

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68db5f05efe48321a924032aadcc4359