### PR TITLE
Remove scarecrow pants equipment slot

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/ModItemTags.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModItemTags.java
@@ -9,7 +9,6 @@ public final class ModItemTags {
         public static final TagKey<Item> SCARECROW_HATS = of("scarecrow_hats");
         public static final TagKey<Item> SCARECROW_HEADS = of("scarecrow_heads");
         public static final TagKey<Item> SCARECROW_SHIRTS = of("scarecrow_shirts");
-        public static final TagKey<Item> SCARECROW_PANTS = of("scarecrow_pants");
         public static final TagKey<Item> SCARECROW_PITCHFORKS = of("scarecrow_pitchforks");
 
         private ModItemTags() {

--- a/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/ScarecrowModel.java
@@ -26,7 +26,6 @@ public class ScarecrowModel extends EntityModel<Entity> {
     private final ModelPart hat;
     private final ModelPart head;
     private final ModelPart chest;
-    private final ModelPart pants;
     private final ModelPart pitchfork;
 
     public ScarecrowModel(ModelPart root) {
@@ -34,14 +33,12 @@ public class ScarecrowModel extends EntityModel<Entity> {
         this.hat = root.getChild("hat");
         this.head = root.getChild("head");
         this.chest = root.getChild("chest");
-        this.pants = root.getChild("pants");
         this.pitchfork = root.getChild("pitchfork");
 
         this.base.visible = true;
         this.hat.visible = false;
         this.head.visible = false;
         this.chest.visible = false;
-        this.pants.visible = false;
         this.pitchfork.visible = false;
     }
 
@@ -57,7 +54,6 @@ public class ScarecrowModel extends EntityModel<Entity> {
         modelPartData.addChild("hat", ModelPartBuilder.create(), ModelTransform.pivot(0.0F, 24.0F, 0.0F));
         modelPartData.addChild("head", ModelPartBuilder.create(), ModelTransform.pivot(0.0F, 24.0F, 0.0F));
         modelPartData.addChild("chest", ModelPartBuilder.create(), ModelTransform.pivot(0.0F, 24.0F, 0.0F));
-        modelPartData.addChild("pants", ModelPartBuilder.create(), ModelTransform.pivot(0.0F, 24.0F, 0.0F));
         modelPartData.addChild("pitchfork", ModelPartBuilder.create(), ModelTransform.pivot(0.0F, 24.0F, 0.0F));
 
         return TexturedModelData.of(modelData, 128, 128);
@@ -78,9 +74,6 @@ public class ScarecrowModel extends EntityModel<Entity> {
         }
         if (chest.visible) {
             chest.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
-        }
-        if (pants.visible) {
-            pants.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
         }
         if (pitchfork.visible) {
             pitchfork.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
@@ -117,14 +110,6 @@ public class ScarecrowModel extends EntityModel<Entity> {
 
     public boolean isChestVisible() {
         return this.chest.visible;
-    }
-
-    public void setPantsVisible(boolean visible) {
-        this.pants.visible = visible;
-    }
-
-    public boolean isPantsVisible() {
-        return this.pants.visible;
     }
 
     public void setPitchforkVisible(boolean visible) {

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowBlockEntityRenderer.java
@@ -40,7 +40,6 @@ public class ScarecrowBlockEntityRenderer implements BlockEntityRenderer<Scarecr
         this.renderHelper.setHatStack(entity.getEquippedHat());
         this.renderHelper.setHeadStack(entity.getEquippedHead());
         this.renderHelper.setChestStack(entity.getEquippedChest());
-        this.renderHelper.setPantsStack(entity.getEquippedPants());
         this.renderHelper.setPitchforkStack(entity.getEquippedPitchfork());
 
         this.renderHelper.render(matrices, vertexConsumers, combinedLight, OverlayTexture.DEFAULT_UV);

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/ScarecrowRenderHelper.java
@@ -26,7 +26,6 @@ public final class ScarecrowRenderHelper {
     private ItemStack hatStack;
     private ItemStack headStack;
     private ItemStack chestStack;
-    private ItemStack pantsStack;
     private ItemStack pitchforkStack;
 
     public ScarecrowRenderHelper(ModelPart baseModelPart) {
@@ -34,7 +33,6 @@ public final class ScarecrowRenderHelper {
         this.hatStack = ItemStack.EMPTY;
         this.headStack = ItemStack.EMPTY;
         this.chestStack = ItemStack.EMPTY;
-        this.pantsStack = ItemStack.EMPTY;
         this.pitchforkStack = ItemStack.EMPTY;
     }
 
@@ -50,10 +48,6 @@ public final class ScarecrowRenderHelper {
         this.chestStack = stack;
     }
 
-    public void setPantsStack(ItemStack stack) {
-        this.pantsStack = stack;
-    }
-
     public void setPitchforkStack(ItemStack stack) {
         this.pitchforkStack = stack;
     }
@@ -63,7 +57,6 @@ public final class ScarecrowRenderHelper {
         this.baseModel.setHatVisible(false);
         this.baseModel.setHeadVisible(false);
         this.baseModel.setChestVisible(false);
-        this.baseModel.setPantsVisible(false);
         this.baseModel.setPitchforkVisible(false);
 
         VertexConsumer baseConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(BASE_TEXTURE));
@@ -72,13 +65,11 @@ public final class ScarecrowRenderHelper {
         ItemStack hat = this.hatStack;
         ItemStack head = this.headStack;
         ItemStack chest = this.chestStack;
-        ItemStack pants = this.pantsStack;
         ItemStack pitchfork = this.pitchforkStack;
 
         this.hatStack = ItemStack.EMPTY;
         this.headStack = ItemStack.EMPTY;
         this.chestStack = ItemStack.EMPTY;
-        this.pantsStack = ItemStack.EMPTY;
         this.pitchforkStack = ItemStack.EMPTY;
 
         MinecraftClient client = MinecraftClient.getInstance();
@@ -94,9 +85,6 @@ public final class ScarecrowRenderHelper {
         }
         if (!chest.isEmpty()) {
             renderChest(client, chest, matrices, vertexConsumers, light, overlay);
-        }
-        if (!pants.isEmpty()) {
-            renderPants(client, pants, matrices, vertexConsumers, light, overlay);
         }
         if (!pitchfork.isEmpty()) {
             renderPitchfork(client, pitchfork, matrices, vertexConsumers, light, overlay);
@@ -133,17 +121,6 @@ public final class ScarecrowRenderHelper {
         matrices.scale(1.5F, 1.1F, 1.1F);
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0F));
-        renderStack(client, stack, matrices, vertexConsumers, light, overlay);
-        matrices.pop();
-    }
-
-    private void renderPants(MinecraftClient client, ItemStack stack, MatrixStack matrices,
-                             VertexConsumerProvider vertexConsumers, int light, int overlay) {
-        matrices.push();
-        matrices.translate(0.0F, 0.55F, 0.0F);
-        matrices.scale(1.0F, 1.0F, 1.0F);
-        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
-        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180.0F));
         renderStack(client, stack, matrices, vertexConsumers, light, overlay);
         matrices.pop();
     }

--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
@@ -41,7 +41,6 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
         private static final Text HAT_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.hat");
         private static final Text HEAD_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.head");
         private static final Text CHEST_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.chest");
-        private static final Text PANTS_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.pants");
         private static final Text HAND_TOOLTIP = Text.translatable("screen.gardenkingmod.scarecrow.slot.hand");
 
         private static final float PREVIEW_Z_OFFSET = 150.0F;
@@ -85,8 +84,6 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                                 y + ScarecrowScreenHandler.HEAD_SLOT_Y - 1);
                 drawSlotOverlay(context, x + ScarecrowScreenHandler.CHEST_SLOT_X - 1,
                                 y + ScarecrowScreenHandler.CHEST_SLOT_Y - 1);
-                drawSlotOverlay(context, x + ScarecrowScreenHandler.PANTS_SLOT_X - 1,
-                                y + ScarecrowScreenHandler.PANTS_SLOT_Y - 1);
                 drawSlotOverlay(context, x + ScarecrowScreenHandler.PITCHFORK_SLOT_X - 1,
                                 y + ScarecrowScreenHandler.PITCHFORK_SLOT_Y - 1);
         }
@@ -133,13 +130,11 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                 ItemStack hat = inventory.getStack(ScarecrowBlockEntity.SLOT_HAT);
                 ItemStack head = inventory.getStack(ScarecrowBlockEntity.SLOT_HEAD);
                 ItemStack chest = inventory.getStack(ScarecrowBlockEntity.SLOT_CHEST);
-                ItemStack pants = inventory.getStack(ScarecrowBlockEntity.SLOT_PANTS);
                 ItemStack pitchfork = inventory.getStack(ScarecrowBlockEntity.SLOT_PITCHFORK);
 
                 this.renderHelper.setHatStack(hat);
                 this.renderHelper.setHeadStack(head);
                 this.renderHelper.setChestStack(chest);
-                this.renderHelper.setPantsStack(pants);
                 this.renderHelper.setPitchforkStack(pitchfork);
 
                 VertexConsumerProvider.Immediate immediate = client.getBufferBuilders().getEntityVertexConsumers();
@@ -210,7 +205,6 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                         case ScarecrowBlockEntity.SLOT_HAT -> HAT_TOOLTIP;
                         case ScarecrowBlockEntity.SLOT_HEAD -> HEAD_TOOLTIP;
                         case ScarecrowBlockEntity.SLOT_CHEST -> CHEST_TOOLTIP;
-                        case ScarecrowBlockEntity.SLOT_PANTS -> PANTS_TOOLTIP;
                         case ScarecrowBlockEntity.SLOT_PITCHFORK -> HAND_TOOLTIP;
                         default -> null;
                         };

--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreenHandler.java
@@ -24,10 +24,8 @@ public class ScarecrowScreenHandler extends ScreenHandler {
         public static final int HEAD_SLOT_Y = 26;
         public static final int CHEST_SLOT_X = 8;
         public static final int CHEST_SLOT_Y = 44;
-        public static final int PANTS_SLOT_X = 8;
-        public static final int PANTS_SLOT_Y = 62;
         public static final int PITCHFORK_SLOT_X = 8;
-        public static final int PITCHFORK_SLOT_Y = 80;
+        public static final int PITCHFORK_SLOT_Y = 62;
         public static final int PLAYER_INVENTORY_START_Y = 124;
         public static final int PLAYER_HOTBAR_Y = 182;
 
@@ -62,8 +60,6 @@ public class ScarecrowScreenHandler extends ScreenHandler {
                                 ScarecrowBlockEntity::isValidHeadItem));
                 this.addSlot(createEquipmentSlot(ScarecrowBlockEntity.SLOT_CHEST, CHEST_SLOT_X, CHEST_SLOT_Y,
                                 ScarecrowBlockEntity::isValidChestItem));
-                this.addSlot(createEquipmentSlot(ScarecrowBlockEntity.SLOT_PANTS, PANTS_SLOT_X, PANTS_SLOT_Y,
-                                ScarecrowBlockEntity::isValidPantsItem));
                 this.addSlot(createEquipmentSlot(ScarecrowBlockEntity.SLOT_PITCHFORK, PITCHFORK_SLOT_X,
                                 PITCHFORK_SLOT_Y, ScarecrowBlockEntity::isValidPitchforkItem));
 
@@ -120,8 +116,6 @@ public class ScarecrowScreenHandler extends ScreenHandler {
                                                         ScarecrowBlockEntity.SLOT_HEAD + 1, false)
                                         && !this.insertItem(original, ScarecrowBlockEntity.SLOT_CHEST,
                                                         ScarecrowBlockEntity.SLOT_CHEST + 1, false)
-                                        && !this.insertItem(original, ScarecrowBlockEntity.SLOT_PANTS,
-                                                        ScarecrowBlockEntity.SLOT_PANTS + 1, false)
                                         && !this.insertItem(original, ScarecrowBlockEntity.SLOT_PITCHFORK,
                                                         ScarecrowBlockEntity.SLOT_PITCHFORK + 1, false)) {
                                 return ItemStack.EMPTY;

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -135,7 +135,6 @@
   "screen.gardenkingmod.scarecrow.slot.hat": "Hat Slot",
   "screen.gardenkingmod.scarecrow.slot.head": "Head Slot",
   "screen.gardenkingmod.scarecrow.slot.chest": "Chest Slot",
-  "screen.gardenkingmod.scarecrow.slot.pants": "Pants Slot",
   "screen.gardenkingmod.scarecrow.slot.hand": "Hand Slot",
   "screen.gardenkingmod.scarecrow.radius.title": "Ward Radius",
   "screen.gardenkingmod.scarecrow.radius.summary": "%1$s x %2$s",

--- a/src/main/resources/data/gardenkingmod/tags/items/scarecrow_pants.json
+++ b/src/main/resources/data/gardenkingmod/tags/items/scarecrow_pants.json
@@ -1,4 +1,0 @@
-{
-  "replace": false,
-  "values": []
-}


### PR DESCRIPTION
## Summary
- collapse the scarecrow block entity inventory to four slots and migrate any legacy pitchfork data stored in the removed pants slot
- simplify the screen, handler, renderer, and item renderer so only the hat, head, chest, and pitchfork equipment slots remain
- drop the unused scarecrow pants tag and localization strings now that the slot is gone

## Testing
- not run (minecraft client not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd5050f6e08321baf024aaad8596b5