### PR TITLE
Add configurable crow spawn parameters and registration

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/ward/ScarecrowBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/ward/ScarecrowBlockEntity.java
@@ -12,6 +12,7 @@ import net.minecraft.inventory.Inventories;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.listener.ClientPlayPacketListener;
 import net.minecraft.network.packet.Packet;

--- a/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowBalanceConfig.java
+++ b/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowBalanceConfig.java
@@ -43,6 +43,8 @@ public final class CrowBalanceConfig {
     private double flyingSpeed = 0.6;
     private double movementSpeed = 0.25;
     private int spawnWeight = 6;
+    private int minSpawnGroupSize = 1;
+    private int maxSpawnGroupSize = 3;
 
     private CrowBalanceConfig() {
     }
@@ -71,7 +73,10 @@ public final class CrowBalanceConfig {
                 GardenKingMod.LOGGER.warn("Crow config file was empty; using defaults");
                 instance = defaults;
             } else {
-                loaded.validateAndApplyDefaults(defaults);
+                boolean updated = loaded.validateAndApplyDefaults(defaults);
+                if (updated) {
+                    writeConfigFile(loaded);
+                }
                 instance = loaded;
             }
         } catch (IOException exception) {
@@ -88,58 +93,84 @@ public final class CrowBalanceConfig {
         }
     }
 
-    private void validateAndApplyDefaults(CrowBalanceConfig defaults) {
+    private boolean validateAndApplyDefaults(CrowBalanceConfig defaults) {
+        boolean changed = false;
         if (minHungerTicks <= 0) {
             minHungerTicks = defaults.minHungerTicks;
+            changed = true;
         }
 
         if (maxHungerTicks < minHungerTicks) {
             maxHungerTicks = Math.max(minHungerTicks, defaults.maxHungerTicks);
+            changed = true;
         }
 
         if (cropSearchHorizontal <= 0) {
             cropSearchHorizontal = defaults.cropSearchHorizontal;
+            changed = true;
         }
 
         if (cropSearchVertical <= 0) {
             cropSearchVertical = defaults.cropSearchVertical;
+            changed = true;
         }
 
         if (randomFlightRange <= 0.0) {
             randomFlightRange = defaults.randomFlightRange;
+            changed = true;
         }
 
         if (perchSearchRange <= 0.0) {
             perchSearchRange = defaults.perchSearchRange;
+            changed = true;
         }
 
         if (wardHorizontalRadius <= 0.0) {
             wardHorizontalRadius = defaults.wardHorizontalRadius;
+            changed = true;
         }
 
         if (wardVerticalRadius <= 0.0) {
             wardVerticalRadius = defaults.wardVerticalRadius;
+            changed = true;
         }
 
         if (wardFearRadiusMultiplier <= 0.0) {
             wardFearRadiusMultiplier = defaults.wardFearRadiusMultiplier;
+            changed = true;
         }
 
         if (baseHealth <= 0.0) {
             baseHealth = defaults.baseHealth;
+            changed = true;
         }
 
         if (flyingSpeed <= 0.0) {
             flyingSpeed = defaults.flyingSpeed;
+            changed = true;
         }
 
         if (movementSpeed <= 0.0) {
             movementSpeed = defaults.movementSpeed;
+            changed = true;
         }
 
         if (spawnWeight < 0) {
             spawnWeight = defaults.spawnWeight;
+            changed = true;
         }
+
+        if (minSpawnGroupSize <= 0) {
+            minSpawnGroupSize = defaults.minSpawnGroupSize;
+            changed = true;
+        }
+
+        if (maxSpawnGroupSize < minSpawnGroupSize) {
+            maxSpawnGroupSize = Math.max(minSpawnGroupSize, defaults.maxSpawnGroupSize);
+            changed = true;
+        }
+
+        return changed;
     }
 
     public static CrowBalanceConfig get() {
@@ -212,11 +243,19 @@ public final class CrowBalanceConfig {
         return spawnWeight;
     }
 
+    public int minSpawnGroupSize() {
+        return minSpawnGroupSize;
+    }
+
+    public int maxSpawnGroupSize() {
+        return maxSpawnGroupSize;
+    }
+
     @Override
     public String toString() {
         return String.format(Locale.ROOT,
-                "CrowBalanceConfig{hunger=%d-%d,cropRadius=%d,%d,wardRadius=%.2f/%.2f,loot=%s}",
+                "CrowBalanceConfig{hunger=%d-%d,cropRadius=%d,%d,wardRadius=%.2f/%.2f,loot=%s,spawn=%d:%d-%d}",
                 minHungerTicks, maxHungerTicks, cropSearchHorizontal, cropSearchVertical, wardHorizontalRadius,
-                wardVerticalRadius, dropLootOnCropBreak);
+                wardVerticalRadius, dropLootOnCropBreak, spawnWeight, minSpawnGroupSize, maxSpawnGroupSize);
     }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/entity/crow/CrowEntity.java
@@ -10,6 +10,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.CropBlock;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.MovementType;
+import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.ai.control.FlightMoveControl;
 import net.minecraft.entity.ai.goal.LookAroundGoal;
 import net.minecraft.entity.ai.goal.LookAtEntityGoal;
@@ -31,6 +32,9 @@ import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.ServerWorldAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldView;
 
@@ -69,6 +73,20 @@ public class CrowEntity extends PathAwareEntity {
                 .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, config.movementSpeed())
                 .add(EntityAttributes.GENERIC_FLYING_SPEED, config.flyingSpeed())
                 .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 2.0);
+    }
+
+    public static boolean canSpawn(EntityType<CrowEntity> type, ServerWorldAccess world, SpawnReason reason, BlockPos pos,
+            Random random) {
+        if (reason != SpawnReason.NATURAL && reason != SpawnReason.CHUNK_GENERATION) {
+            return true;
+        }
+
+        int surfaceY = world.getTopY(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, pos.getX(), pos.getZ());
+        if (pos.getY() < surfaceY) {
+            return false;
+        }
+
+        return world.getBaseLightLevel(pos, 0) > 7;
     }
 
     @Override

--- a/src/main/java/net/jeremy/gardenkingmod/registry/ModEntities.java
+++ b/src/main/java/net/jeremy/gardenkingmod/registry/ModEntities.java
@@ -1,5 +1,7 @@
 package net.jeremy.gardenkingmod.registry;
 
+import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
+import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleFactory;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleRegistry;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
@@ -8,14 +10,17 @@ import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
 import net.jeremy.gardenkingmod.GardenKingMod;
 import net.jeremy.gardenkingmod.entity.crow.CrowBalanceConfig;
 import net.jeremy.gardenkingmod.entity.crow.CrowEntity;
+import net.jeremy.gardenkingmod.entity.crow.CrowTags;
 
 import net.minecraft.entity.EntityDimensions;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnGroup;
+import net.minecraft.entity.SpawnRestriction;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.GameRules;
+import net.minecraft.world.Heightmap;
 
 /**
  * Registers all custom entity types and related game rules.
@@ -34,7 +39,13 @@ public final class ModEntities {
 
     public static void register() {
         CrowBalanceConfig.reload();
+        CrowBalanceConfig config = CrowBalanceConfig.get();
         FabricDefaultAttributeRegistry.register(CROW, CrowEntity.createCrowAttributes());
-        GardenKingMod.LOGGER.info("Registered crow entity with config {}", CrowBalanceConfig.get());
+        SpawnRestriction.register(CROW, SpawnRestriction.Location.ON_GROUND, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
+                CrowEntity::canSpawn);
+        // Datapacks can edit data/gardenkingmod/tags/worldgen/biome/spawns_crows.json to change where crows spawn.
+        BiomeModifications.addSpawn(BiomeSelectors.tag(CrowTags.CROW_SPAWN_BIOMES), SpawnGroup.CREATURE, CROW,
+                config.spawnWeight(), config.minSpawnGroupSize(), config.maxSpawnGroupSize());
+        GardenKingMod.LOGGER.info("Registered crow entity with config {}", config);
     }
 }


### PR DESCRIPTION
## Summary
- add spawn group size options to the crow balance config with validation and serialization updates
- expose a CrowEntity::canSpawn helper and register the crow spawn restriction and biome spawn entry using the reloaded config
- fix ScarecrowBlockEntity imports so the project continues to compile after the new build run

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68de270afda48321b6869761e8661bd5