### PR TITLE
Fix Garden Shop item visuals and localization

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -11,11 +11,14 @@ import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
 import net.jeremy.gardenkingmod.client.model.CrowEntityModel;
+import net.jeremy.gardenkingmod.client.model.GardenShopModel;
 import net.jeremy.gardenkingmod.client.model.MarketBlockModel;
 import net.jeremy.gardenkingmod.client.model.ScarecrowModel;
 import net.jeremy.gardenkingmod.client.render.CrowEntityRenderer;
+import net.jeremy.gardenkingmod.client.render.GardenShopBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.ScarecrowBlockEntityRenderer;
+import net.jeremy.gardenkingmod.client.render.item.GardenShopItemRenderer;
 import net.jeremy.gardenkingmod.client.render.item.MarketItemRenderer;
 import net.jeremy.gardenkingmod.client.render.item.ScarecrowItemRenderer;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
@@ -39,13 +42,18 @@ public class GardenKingModClient implements ClientModInitializer {
         HandledScreens.register(ModScreenHandlers.MARKET_SCREEN_HANDLER, MarketScreen::new);
         HandledScreens.register(ModScreenHandlers.SCARECROW_SCREEN_HANDLER, ScarecrowScreen::new);
         EntityModelLayerRegistry.registerModelLayer(MarketBlockModel.LAYER_LOCATION, MarketBlockModel::getTexturedModelData);
+        EntityModelLayerRegistry.registerModelLayer(GardenShopModel.LAYER_LOCATION,
+                        GardenShopModel::getTexturedModelData);
         EntityModelLayerRegistry.registerModelLayer(ScarecrowModel.LAYER_LOCATION, ScarecrowModel::getTexturedModelData);
 
         EntityModelLayerRegistry.registerModelLayer(CrowEntityModel.LAYER_LOCATION, CrowEntityModel::getTexturedModelData);
         BlockEntityRendererFactories.register(ModBlockEntities.MARKET_BLOCK_ENTITY, MarketBlockEntityRenderer::new);
+        BlockEntityRendererFactories.register(ModBlockEntities.GARDEN_SHOP_BLOCK_ENTITY,
+                        GardenShopBlockEntityRenderer::new);
         BlockEntityRendererFactories.register(ModBlockEntities.SCARECROW_BLOCK_ENTITY, ScarecrowBlockEntityRenderer::new);
         EntityRendererRegistry.register(ModEntities.CROW, CrowEntityRenderer::new);
         BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.MARKET_BLOCK, new MarketItemRenderer());
+        BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.GARDEN_SHOP_BLOCK, new GardenShopItemRenderer());
         BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.SCARECROW_BLOCK, new ScarecrowItemRenderer());
         BlockRenderLayerMap.INSTANCE.putBlock(ModBlocks.SCARECROW_BLOCK, RenderLayer.getCutout());
 

--- a/src/main/java/net/jeremy/gardenkingmod/ModBlockEntities.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModBlockEntities.java
@@ -1,6 +1,7 @@
 package net.jeremy.gardenkingmod;
 
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
+import net.jeremy.gardenkingmod.block.entity.GardenShopBlockEntity;
 import net.jeremy.gardenkingmod.block.entity.MarketBlockEntity;
 import net.jeremy.gardenkingmod.block.ward.ScarecrowBlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
@@ -12,6 +13,10 @@ public final class ModBlockEntities {
         public static final BlockEntityType<MarketBlockEntity> MARKET_BLOCK_ENTITY = Registry.register(
                         Registries.BLOCK_ENTITY_TYPE, new Identifier(GardenKingMod.MOD_ID, "market_block"),
                         FabricBlockEntityTypeBuilder.create(MarketBlockEntity::new, ModBlocks.MARKET_BLOCK).build());
+
+        public static final BlockEntityType<GardenShopBlockEntity> GARDEN_SHOP_BLOCK_ENTITY = Registry.register(
+                        Registries.BLOCK_ENTITY_TYPE, new Identifier(GardenKingMod.MOD_ID, "garden_shop_block"),
+                        FabricBlockEntityTypeBuilder.create(GardenShopBlockEntity::new, ModBlocks.GARDEN_SHOP_BLOCK).build());
 
         public static final BlockEntityType<ScarecrowBlockEntity> SCARECROW_BLOCK_ENTITY = Registry.register(
                         Registries.BLOCK_ENTITY_TYPE, new Identifier(GardenKingMod.MOD_ID, "scarecrow"),

--- a/src/main/java/net/jeremy/gardenkingmod/ModBlocks.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModBlocks.java
@@ -3,6 +3,8 @@ package net.jeremy.gardenkingmod;
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.jeremy.gardenkingmod.block.GardenShopBlock;
+import net.jeremy.gardenkingmod.block.GardenShopBlockPart;
 import net.jeremy.gardenkingmod.block.MarketBlock;
 import net.jeremy.gardenkingmod.block.MarketBlockPart;
 import net.jeremy.gardenkingmod.block.ward.ScarecrowBlock;
@@ -20,6 +22,10 @@ public final class ModBlocks {
                         new MarketBlock(
                                         FabricBlockSettings.copyOf(Blocks.OAK_PLANKS).strength(2.5f).nonOpaque()));
 
+        public static final Block GARDEN_SHOP_BLOCK = registerBlock("garden_shop_block",
+                        new GardenShopBlock(
+                                        FabricBlockSettings.copyOf(Blocks.SPRUCE_PLANKS).strength(2.5f).nonOpaque()));
+
         public static final Block SCARECROW_BLOCK = registerBlock("scarecrow",
                         new ScarecrowBlock(FabricBlockSettings.copyOf(Blocks.HAY_BLOCK).strength(1.5f).nonOpaque()));
 
@@ -28,6 +34,10 @@ public final class ModBlocks {
 
         public static final Block MARKET_BLOCK_PART = registerBlockWithoutItem("market_block_part",
                         new MarketBlockPart(FabricBlockSettings.copyOf(Blocks.OAK_PLANKS).dropsNothing().nonOpaque()));
+
+        public static final Block GARDEN_SHOP_BLOCK_PART = registerBlockWithoutItem("garden_shop_block_part",
+                        new GardenShopBlockPart(
+                                        FabricBlockSettings.copyOf(Blocks.SPRUCE_PLANKS).dropsNothing().nonOpaque()));
 
         private ModBlocks() {
         }
@@ -49,6 +59,7 @@ public final class ModBlocks {
                 GardenKingMod.LOGGER.info("Registering mod blocks for {}", GardenKingMod.MOD_ID);
                 ItemGroupEvents.modifyEntriesEvent(ItemGroups.FUNCTIONAL).register(entries -> {
                         entries.add(MARKET_BLOCK);
+                        entries.add(GARDEN_SHOP_BLOCK);
                         entries.add(SCARECROW_BLOCK);
                 });
                 ItemGroupEvents.modifyEntriesEvent(ItemGroups.BUILDING_BLOCKS).register(entries -> entries.add(RUBY_BLOCK));

--- a/src/main/java/net/jeremy/gardenkingmod/block/GardenShopBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/GardenShopBlock.java
@@ -1,0 +1,164 @@
+package net.jeremy.gardenkingmod.block;
+
+import net.jeremy.gardenkingmod.ModBlocks;
+import net.jeremy.gardenkingmod.block.entity.GardenShopBlockEntity;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRenderType;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.BlockWithEntity;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemPlacementContext;
+import net.minecraft.item.ItemStack;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.DirectionProperty;
+import net.minecraft.state.property.Properties;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.ItemScatterer;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldView;
+
+public class GardenShopBlock extends BlockWithEntity {
+        public static final DirectionProperty FACING = Properties.HORIZONTAL_FACING;
+
+        public GardenShopBlock(Settings settings) {
+                super(settings);
+                this.setDefaultState(getStateManager().getDefaultState().with(FACING, Direction.NORTH));
+        }
+
+        @Override
+        protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+                builder.add(FACING);
+        }
+
+        @Override
+        public BlockState getPlacementState(ItemPlacementContext ctx) {
+                Direction facing = ctx.getHorizontalPlayerFacing().getOpposite();
+                BlockPos origin = ctx.getBlockPos();
+                WorldView worldView = ctx.getWorld();
+
+                for (GardenShopBlockPart.Part part : GardenShopBlockPart.Part.values()) {
+                        if (part == GardenShopBlockPart.Part.CENTER) {
+                                continue;
+                        }
+
+                        BlockPos targetPos = origin.add(part.getOffset(facing));
+                        if (!worldView.isAir(targetPos)) {
+                                return null;
+                        }
+                }
+
+                return getDefaultState().with(FACING, facing);
+        }
+
+        @Override
+        public void onPlaced(World world, BlockPos pos, BlockState state, LivingEntity placer, ItemStack itemStack) {
+                super.onPlaced(world, pos, state, placer, itemStack);
+
+                if (world.isClient) {
+                        return;
+                }
+
+                Direction facing = state.get(FACING);
+                for (GardenShopBlockPart.Part part : GardenShopBlockPart.Part.values()) {
+                        if (part == GardenShopBlockPart.Part.CENTER) {
+                                continue;
+                        }
+
+                        BlockPos targetPos = pos.add(part.getOffset(facing));
+                        BlockState partState = ModBlocks.GARDEN_SHOP_BLOCK_PART.getDefaultState()
+                                        .with(GardenShopBlockPart.FACING, facing)
+                                        .with(GardenShopBlockPart.PART, part);
+                        world.setBlockState(targetPos, partState, Block.NOTIFY_ALL | Block.FORCE_STATE);
+                }
+        }
+
+        @Override
+        public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+                return GardenShopBlockPart.getShape(GardenShopBlockPart.Part.CENTER, state.get(FACING));
+        }
+
+        @Override
+        public VoxelShape getCollisionShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+                return GardenShopBlockPart.getShape(GardenShopBlockPart.Part.CENTER, state.get(FACING));
+        }
+
+        @Override
+        public float getAmbientOcclusionLightLevel(BlockState state, BlockView world, BlockPos pos) {
+                return 1.0F;
+        }
+
+        @Override
+        public BlockRenderType getRenderType(BlockState state) {
+                return BlockRenderType.ENTITYBLOCK_ANIMATED;
+        }
+
+        @Override
+        public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand,
+                        BlockHitResult hit) {
+                if (!world.isClient) {
+                        BlockEntity blockEntity = world.getBlockEntity(pos);
+                        if (blockEntity instanceof GardenShopBlockEntity gardenShopBlockEntity) {
+                                player.openHandledScreen(gardenShopBlockEntity);
+                        }
+                }
+
+                return ActionResult.SUCCESS;
+        }
+
+        @Override
+        public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
+                if (state.getBlock() != newState.getBlock()) {
+                        if (!world.isClient) {
+                                removePartBlocks(world, pos, state.get(FACING));
+                        }
+
+                        BlockEntity blockEntity = world.getBlockEntity(pos);
+                        if (blockEntity instanceof Inventory inventory) {
+                                ItemScatterer.spawn(world, pos, inventory);
+                                world.updateComparators(pos, this);
+                        }
+
+                        super.onStateReplaced(state, world, pos, newState, moved);
+                }
+        }
+
+        private void removePartBlocks(World world, BlockPos origin, Direction facing) {
+                for (GardenShopBlockPart.Part part : GardenShopBlockPart.Part.values()) {
+                        if (part == GardenShopBlockPart.Part.CENTER) {
+                                continue;
+                        }
+
+                        BlockPos targetPos = origin.add(part.getOffset(facing));
+                        BlockState targetState = world.getBlockState(targetPos);
+                        if (targetState.getBlock() instanceof GardenShopBlockPart) {
+                                world.removeBlock(targetPos, false);
+                        }
+                }
+        }
+
+        @Override
+        public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
+                return new GardenShopBlockEntity(pos, state);
+        }
+
+        @Override
+        public boolean hasComparatorOutput(BlockState state) {
+                return true;
+        }
+
+        @Override
+        public int getComparatorOutput(BlockState state, World world, BlockPos pos) {
+                return ScreenHandler.calculateComparatorOutput(world.getBlockEntity(pos));
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/block/GardenShopBlockPart.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/GardenShopBlockPart.java
@@ -1,0 +1,162 @@
+package net.jeremy.gardenkingmod.block;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRenderType;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.loot.context.LootContextParameterSet;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.DirectionProperty;
+import net.minecraft.state.property.EnumProperty;
+import net.minecraft.state.property.Properties;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.StringIdentifiable;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.BlockRotation;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+
+public class GardenShopBlockPart extends Block {
+        public static final DirectionProperty FACING = Properties.HORIZONTAL_FACING;
+        public static final EnumProperty<Part> PART = EnumProperty.of("part", Part.class);
+
+        private static final Map<Part, VoxelShape> BASE_SHAPES = createBaseShapes();
+
+        public GardenShopBlockPart(Settings settings) {
+                super(settings);
+                this.setDefaultState(getStateManager().getDefaultState().with(FACING, Direction.NORTH).with(PART,
+                                Part.CENTER));
+        }
+
+        private static Map<Part, VoxelShape> createBaseShapes() {
+                EnumMap<Part, VoxelShape> shapes = new EnumMap<>(Part.class);
+                for (Part part : Part.values()) {
+                        shapes.put(part, VoxelShapes.fullCube());
+                }
+                return shapes;
+        }
+
+        public static VoxelShape getShape(Part part, Direction facing) {
+                return BASE_SHAPES.getOrDefault(part, VoxelShapes.fullCube());
+        }
+
+        @Override
+        protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+                builder.add(FACING, PART);
+        }
+
+        @Override
+        public BlockRenderType getRenderType(BlockState state) {
+                return BlockRenderType.INVISIBLE;
+        }
+
+        public static BlockPos getOrigin(BlockPos partPos, BlockState state) {
+                BlockPos offset = state.get(PART).getOffset(state.get(FACING));
+                return partPos.subtract(offset);
+        }
+
+        @Override
+        public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand,
+                        BlockHitResult hit) {
+                BlockPos origin = getOrigin(pos, state);
+                BlockState originState = world.getBlockState(origin);
+                if (!(originState.getBlock() instanceof GardenShopBlock)) {
+                        return ActionResult.PASS;
+                }
+
+                BlockHitResult translatedHit = new BlockHitResult(hit.getPos(), hit.getSide(), origin,
+                                hit.isInsideBlock());
+                return originState.onUse(world, player, hand, translatedHit);
+        }
+
+        @Override
+        public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
+                if (state.getBlock() != newState.getBlock()) {
+                        if (!world.isClient) {
+                                BlockPos origin = getOrigin(pos, state);
+                                BlockState originState = world.getBlockState(origin);
+                                if (originState.getBlock() instanceof GardenShopBlock) {
+                                        world.breakBlock(origin, true);
+                                }
+                        }
+
+                        super.onStateReplaced(state, world, pos, newState, moved);
+                }
+        }
+
+        @Override
+        public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+                return getShape(state.get(PART), state.get(FACING));
+        }
+
+        @Override
+        public VoxelShape getCollisionShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+                return getShape(state.get(PART), state.get(FACING));
+        }
+
+        @Override
+        public float getAmbientOcclusionLightLevel(BlockState state, BlockView world, BlockPos pos) {
+                return 1.0F;
+        }
+
+        @Override
+        public ItemStack getPickStack(BlockView world, BlockPos pos, BlockState state) {
+                return ItemStack.EMPTY;
+        }
+
+        @Override
+        public List<ItemStack> getDroppedStacks(BlockState state, LootContextParameterSet.Builder builder) {
+                return Collections.emptyList();
+        }
+
+        public enum Part implements StringIdentifiable {
+                NORTH_WEST("north_west", new BlockPos(-1, 0, -1)),
+                NORTH("north", new BlockPos(0, 0, -1)),
+                NORTH_EAST("north_east", new BlockPos(1, 0, -1)),
+                WEST("west", new BlockPos(-1, 0, 0)),
+                CENTER("center", BlockPos.ORIGIN),
+                EAST("east", new BlockPos(1, 0, 0)),
+                SOUTH_WEST("south_west", new BlockPos(-1, 0, 1)),
+                SOUTH("south", new BlockPos(0, 0, 1)),
+                SOUTH_EAST("south_east", new BlockPos(1, 0, 1));
+
+                private final String name;
+                private final BlockPos offset;
+
+                Part(String name, BlockPos offset) {
+                        this.name = name;
+                        this.offset = offset;
+                }
+
+                public BlockPos getOffset(Direction facing) {
+                        return offset.rotate(rotationFromFacing(facing));
+                }
+
+                @Override
+                public String asString() {
+                        return name;
+                }
+        }
+
+        private static BlockRotation rotationFromFacing(Direction facing) {
+                return switch (facing) {
+                        case NORTH -> BlockRotation.NONE;
+                        case SOUTH -> BlockRotation.CLOCKWISE_180;
+                        case WEST -> BlockRotation.COUNTERCLOCKWISE_90;
+                        case EAST -> BlockRotation.CLOCKWISE_90;
+                        default -> BlockRotation.NONE;
+                };
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/GardenShopBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/GardenShopBlockEntity.java
@@ -1,0 +1,155 @@
+package net.jeremy.gardenkingmod.block.entity;
+
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
+import net.jeremy.gardenkingmod.ModBlockEntities;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.Inventories;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.collection.DefaultedList;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class GardenShopBlockEntity extends BlockEntity implements ExtendedScreenHandlerFactory, Inventory {
+        public static final int INVENTORY_SIZE = 27;
+
+        private DefaultedList<ItemStack> items = DefaultedList.ofSize(INVENTORY_SIZE, ItemStack.EMPTY);
+
+        public GardenShopBlockEntity(BlockPos pos, BlockState state) {
+                super(ModBlockEntities.GARDEN_SHOP_BLOCK_ENTITY, pos, state);
+        }
+
+        @Override
+        public void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf) {
+                buf.writeBlockPos(getPos());
+        }
+
+        @Override
+        public Text getDisplayName() {
+                return Text.translatable("container.gardenkingmod.garden_shop");
+        }
+
+        @Override
+        public ScreenHandler createMenu(int syncId, PlayerInventory playerInventory, PlayerEntity player) {
+                return null;
+        }
+
+        @Override
+        public int size() {
+                return items.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+                for (ItemStack stack : items) {
+                        if (!stack.isEmpty()) {
+                                return false;
+                        }
+                }
+
+                return true;
+        }
+
+        @Override
+        public ItemStack getStack(int slot) {
+                return items.get(slot);
+        }
+
+        @Override
+        public ItemStack removeStack(int slot, int amount) {
+                ItemStack stack = Inventories.splitStack(items, slot, amount);
+                if (!stack.isEmpty()) {
+                        markDirty();
+                }
+                return stack;
+        }
+
+        @Override
+        public ItemStack removeStack(int slot) {
+                ItemStack stack = Inventories.removeStack(items, slot);
+                if (!stack.isEmpty()) {
+                        markDirty();
+                }
+                return stack;
+        }
+
+        @Override
+        public void setStack(int slot, ItemStack stack) {
+                items.set(slot, stack);
+                if (stack.getCount() > getMaxCountPerStack()) {
+                        stack.setCount(getMaxCountPerStack());
+                }
+                markDirty();
+        }
+
+        @Override
+        public boolean canPlayerUse(PlayerEntity player) {
+                if (world == null || world.getBlockEntity(pos) != this) {
+                        return false;
+                }
+
+                return player.squaredDistanceTo((double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D,
+                                (double) pos.getZ() + 0.5D) <= 64.0D;
+        }
+
+        @Override
+        public boolean isValid(int slot, ItemStack stack) {
+                return true;
+        }
+
+        @Override
+        public void clear() {
+                for (int slot = 0; slot < items.size(); slot++) {
+                        items.set(slot, ItemStack.EMPTY);
+                }
+        }
+
+        @Override
+        public void onClose(PlayerEntity player) {
+                Inventory.super.onClose(player);
+                if (!(player instanceof ServerPlayerEntity serverPlayer)) {
+                        return;
+                }
+
+                for (int slot = 0; slot < size(); slot++) {
+                        ItemStack remainingStack = removeStack(slot);
+                        if (!remainingStack.isEmpty()) {
+                                if (!serverPlayer.getInventory().insertStack(remainingStack)) {
+                                        serverPlayer.dropItem(remainingStack, false);
+                                }
+                        }
+                }
+        }
+
+        @Override
+        public void markDirty() {
+                super.markDirty();
+                World world = getWorld();
+                if (world != null) {
+                        world.updateListeners(pos, getCachedState(), getCachedState(), Block.NOTIFY_ALL);
+                        world.updateComparators(pos, getCachedState().getBlock());
+                }
+        }
+
+        @Override
+        protected void writeNbt(NbtCompound nbt) {
+                super.writeNbt(nbt);
+                Inventories.writeNbt(nbt, items);
+        }
+
+        @Override
+        public void readNbt(NbtCompound nbt) {
+                super.readNbt(nbt);
+                items = DefaultedList.ofSize(INVENTORY_SIZE, ItemStack.EMPTY);
+                Inventories.readNbt(nbt, items);
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/client/model/GardenShopModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/GardenShopModel.java
@@ -1,9 +1,26 @@
 package net.jeremy.gardenkingmod.client.model;
 
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.minecraft.client.model.Dilation;
+import net.minecraft.client.model.ModelData;
+import net.minecraft.client.model.ModelPart;
+import net.minecraft.client.model.ModelPartBuilder;
+import net.minecraft.client.model.ModelPartData;
+import net.minecraft.client.model.ModelTransform;
+import net.minecraft.client.model.TexturedModelData;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.entity.model.EntityModel;
+import net.minecraft.client.render.entity.model.EntityModelLayer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.Identifier;
+
 // Made with Blockbench 4.12.6
 // Exported for Minecraft version 1.17+ for Yarn
-// Paste this class into your mod and generate all required imports
 public class GardenShopModel extends EntityModel<Entity> {
+        public static final EntityModelLayer LAYER_LOCATION = new EntityModelLayer(
+                        new Identifier(GardenKingMod.MOD_ID, "garden_shop"),
+                        "main");
 	private final ModelPart fencegate1;
 	private final ModelPart fencegate2;
 	private final ModelPart fencegate3;

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/GardenShopBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/GardenShopBlockEntityRenderer.java
@@ -1,0 +1,63 @@
+package net.jeremy.gardenkingmod.client.render;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.block.GardenShopBlock;
+import net.jeremy.gardenkingmod.block.entity.GardenShopBlockEntity;
+import net.jeremy.gardenkingmod.client.model.GardenShopModel;
+import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.render.OverlayTexture;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.client.render.block.entity.BlockEntityRenderer;
+import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.RotationAxis;
+import net.minecraft.world.World;
+
+public class GardenShopBlockEntityRenderer implements BlockEntityRenderer<GardenShopBlockEntity> {
+        private static final Identifier TEXTURE = new Identifier(GardenKingMod.MOD_ID,
+                        "textures/entity/shop/garden_shop.png");
+
+        private final GardenShopModel model;
+
+        public GardenShopBlockEntityRenderer(BlockEntityRendererFactory.Context context) {
+                this.model = new GardenShopModel(context.getLayerModelPart(GardenShopModel.LAYER_LOCATION));
+        }
+
+        @Override
+        public void render(GardenShopBlockEntity entity, float tickDelta, MatrixStack matrices,
+                        VertexConsumerProvider vertexConsumers, int light, int overlay) {
+                matrices.push();
+                matrices.translate(0.5f, 1.5f, 0.5f);
+
+                Direction facing = entity.getCachedState() != null ? entity.getCachedState().get(GardenShopBlock.FACING) : null;
+                if (facing != null) {
+                        float yRotation = switch (facing) {
+                                case NORTH -> 0.0f;
+                                case EAST -> 90.0f;
+                                case SOUTH -> 180.0f;
+                                case WEST -> 270.0f;
+                                default -> 0.0f;
+                        };
+                        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(yRotation));
+                }
+                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
+
+                World world = entity.getWorld();
+                int combinedLight = LightmapTextureManager.MAX_LIGHT_COORDINATE;
+                if (world != null) {
+                        BlockPos exposedPos = entity.getPos().up();
+                        combinedLight = WorldRenderer.getLightmapCoordinates(world, exposedPos);
+                }
+
+                VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));
+                this.model.render(matrices, vertexConsumer, combinedLight, OverlayTexture.DEFAULT_UV, 1.0f, 1.0f, 1.0f, 1.0f);
+
+                matrices.pop();
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/item/GardenShopItemRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/item/GardenShopItemRenderer.java
@@ -1,0 +1,66 @@
+package net.jeremy.gardenkingmod.client.render.item;
+
+import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.client.model.GardenShopModel;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.model.json.ModelTransformationMode;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.RotationAxis;
+
+public class GardenShopItemRenderer implements BuiltinItemRendererRegistry.DynamicItemRenderer {
+        private static final Identifier TEXTURE = new Identifier(GardenKingMod.MOD_ID,
+                        "textures/entity/shop/garden_shop.png");
+
+        private GardenShopModel model;
+
+        public GardenShopItemRenderer() {
+        }
+
+        @Override
+        public void render(ItemStack stack, ModelTransformationMode mode, MatrixStack matrices,
+                        VertexConsumerProvider vertexConsumers, int light, int overlay) {
+                matrices.push();
+                matrices.translate(0.5f, 1.5f, 0.5f);
+                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
+
+                if (mode != null) {
+                        switch (mode) {
+                                case GUI -> {
+                                        matrices.scale(0.16f, 0.16f, 0.16f);
+                                        matrices.translate(0.0f, 4.4f, 0.0f);
+                                }
+                                case GROUND -> {
+                                        matrices.scale(0.18f, 0.18f, 0.18f);
+                                        matrices.translate(0.0f, 2.8f, 0.0f);
+                                }
+                                case FIXED -> {
+                                        matrices.scale(0.18f, 0.18f, 0.18f);
+                                        matrices.translate(0.0f, 3.0f, 0.0f);
+                                }
+                                case FIRST_PERSON_LEFT_HAND, FIRST_PERSON_RIGHT_HAND,
+                                                THIRD_PERSON_LEFT_HAND, THIRD_PERSON_RIGHT_HAND -> {
+                                        matrices.scale(0.14f, 0.14f, 0.14f);
+                                        matrices.translate(0.0f, 3.2f, 0.0f);
+                                }
+                                default -> {
+                                }
+                        }
+                }
+
+                if (this.model == null) {
+                        this.model = new GardenShopModel(MinecraftClient.getInstance().getEntityModelLoader()
+                                        .getModelPart(GardenShopModel.LAYER_LOCATION));
+                }
+
+                VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));
+                this.model.render(matrices, vertexConsumer, light, overlay, 1.0f, 1.0f, 1.0f, 1.0f);
+
+                matrices.pop();
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/datagen/RottenLanguageProvider.java
+++ b/src/main/java/net/jeremy/gardenkingmod/datagen/RottenLanguageProvider.java
@@ -19,10 +19,12 @@ public final class RottenLanguageProvider extends FabricLanguageProvider {
         }
 
     @Override
-    public void generateTranslations(TranslationBuilder translationBuilder) {
+        public void generateTranslations(TranslationBuilder translationBuilder) {
                 translationBuilder.add("block.gardenkingmod.market_block", "Garden Market");
+                translationBuilder.add("block.gardenkingmod.garden_shop_block", "Garden Shop");
                 translationBuilder.add("item.gardenkingmod.garden_coin", "Garden Coin");
                 translationBuilder.add("container.gardenkingmod.market", "Garden Market");
+                translationBuilder.add("container.gardenkingmod.garden_shop", "Garden Shop");
                 translationBuilder.add("container.gardenkingmod.scarecrow", "Field Scarecrow");
                 translationBuilder.add("screen.gardenkingmod.market.sell", "Sell");
                 translationBuilder.add("screen.gardenkingmod.market.sale_result",

--- a/src/main/resources/assets/gardenkingmod/blockstates/garden_shop_block.json
+++ b/src/main/resources/assets/gardenkingmod/blockstates/garden_shop_block.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": { "model": "minecraft:block/air" }
+  }
+}

--- a/src/main/resources/assets/gardenkingmod/blockstates/garden_shop_block_part.json
+++ b/src/main/resources/assets/gardenkingmod/blockstates/garden_shop_block_part.json
@@ -1,0 +1,9 @@
+{
+  "multipart": [
+    {
+      "apply": {
+        "model": "minecraft:block/air"
+      }
+    }
+  ]
+}

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -17,7 +17,9 @@
   "block.gardenkingmod.ruby_block": "Ruby Block",
 
   "block.gardenkingmod.market_block": "Garden Market",
+  "block.gardenkingmod.garden_shop_block": "Garden Shop",
   "container.gardenkingmod.market": "Garden Market",
+  "container.gardenkingmod.garden_shop": "Garden Shop",
   "container.gardenkingmod.scarecrow": "Scarecrow",
   "item.gardenkingmod.garden_coin": "Garden Coin",
   "message.gardenkingmod.market.empty": "There are no crops to sell.",

--- a/src/main/resources/assets/gardenkingmod/models/item/garden_shop_block.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/garden_shop_block.json
@@ -1,0 +1,3 @@
+{
+  "parent": "minecraft:builtin/entity"
+}


### PR DESCRIPTION
## Summary
- add Garden Shop multiblock, block entity, and collision-forwarding part blocks mirroring the Garden Market
- integrate the exported GardenShop model with item and block-entity renderers and register associated client assets
- register new blocks, block entities, and localization entries for the Garden Shop structure
- ensure the Garden Shop block/item use builtin entity models and add the missing English translation entries

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68e03f6c005c83218687fc38ebc87299