### PR TITLE
Add Garden Shop screen and handler

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -24,6 +24,7 @@ import net.jeremy.gardenkingmod.client.render.item.ScarecrowItemRenderer;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.item.FortuneProvidingItem;
 import net.jeremy.gardenkingmod.network.ModPackets;
+import net.jeremy.gardenkingmod.screen.GardenShopScreen;
 import net.jeremy.gardenkingmod.screen.MarketScreen;
 import net.jeremy.gardenkingmod.screen.ScarecrowScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreens;
@@ -39,6 +40,7 @@ import net.jeremy.gardenkingmod.registry.ModEntities;
 public class GardenKingModClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
+        HandledScreens.register(ModScreenHandlers.GARDEN_SHOP_SCREEN_HANDLER, GardenShopScreen::new);
         HandledScreens.register(ModScreenHandlers.MARKET_SCREEN_HANDLER, MarketScreen::new);
         HandledScreens.register(ModScreenHandlers.SCARECROW_SCREEN_HANDLER, ScarecrowScreen::new);
         EntityModelLayerRegistry.registerModelLayer(MarketBlockModel.LAYER_LOCATION, MarketBlockModel::getTexturedModelData);

--- a/src/main/java/net/jeremy/gardenkingmod/ModScreenHandlers.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModScreenHandlers.java
@@ -1,6 +1,7 @@
 package net.jeremy.gardenkingmod;
 
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
+import net.jeremy.gardenkingmod.screen.GardenShopScreenHandler;
 import net.jeremy.gardenkingmod.screen.MarketScreenHandler;
 import net.jeremy.gardenkingmod.screen.ScarecrowScreenHandler;
 import net.minecraft.registry.Registries;
@@ -9,6 +10,10 @@ import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.util.Identifier;
 
 public final class ModScreenHandlers {
+        public static final ScreenHandlerType<GardenShopScreenHandler> GARDEN_SHOP_SCREEN_HANDLER = Registry.register(
+                        Registries.SCREEN_HANDLER, new Identifier(GardenKingMod.MOD_ID, "garden_shop"),
+                        new ExtendedScreenHandlerType<>(GardenShopScreenHandler::new));
+
         public static final ScreenHandlerType<MarketScreenHandler> MARKET_SCREEN_HANDLER = Registry.register(
                         Registries.SCREEN_HANDLER, new Identifier(GardenKingMod.MOD_ID, "market"),
                         new ExtendedScreenHandlerType<>(MarketScreenHandler::new));

--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/GardenShopBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/GardenShopBlockEntity.java
@@ -2,6 +2,7 @@ package net.jeremy.gardenkingmod.block.entity;
 
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
 import net.jeremy.gardenkingmod.ModBlockEntities;
+import net.jeremy.gardenkingmod.screen.GardenShopScreenHandler;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
@@ -40,7 +41,7 @@ public class GardenShopBlockEntity extends BlockEntity implements ExtendedScreen
 
         @Override
         public ScreenHandler createMenu(int syncId, PlayerInventory playerInventory, PlayerEntity player) {
-                return null;
+                return new GardenShopScreenHandler(syncId, playerInventory, this);
         }
 
         @Override

--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -1,0 +1,42 @@
+package net.jeremy.gardenkingmod.screen;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
+        private static final Identifier TEXTURE = new Identifier(GardenKingMod.MOD_ID,
+                        "textures/gui/container/garden_shop_gui.png");
+
+        private static final int BACKGROUND_WIDTH = 274;
+        private static final int BACKGROUND_HEIGHT = 198;
+        private static final int PLAYER_INVENTORY_LABEL_Y = BACKGROUND_HEIGHT - 94;
+        private static final int TITLE_X = 8;
+        private static final int TITLE_Y = 6;
+
+        public GardenShopScreen(GardenShopScreenHandler handler, PlayerInventory inventory, Text title) {
+                super(handler, inventory, title);
+                this.backgroundWidth = BACKGROUND_WIDTH;
+                this.backgroundHeight = BACKGROUND_HEIGHT;
+                this.playerInventoryTitleY = PLAYER_INVENTORY_LABEL_Y;
+                this.titleX = TITLE_X;
+                this.titleY = TITLE_Y;
+        }
+
+        @Override
+        protected void drawBackground(DrawContext context, float delta, int mouseX, int mouseY) {
+                int x = (width - backgroundWidth) / 2;
+                int y = (height - backgroundHeight) / 2;
+                context.drawTexture(TEXTURE, x, y, 0, 0, backgroundWidth, backgroundHeight);
+        }
+
+        @Override
+        public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+                renderBackground(context);
+                super.render(context, mouseX, mouseY, delta);
+                drawMouseoverTooltip(context, mouseX, mouseY);
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
@@ -1,0 +1,129 @@
+package net.jeremy.gardenkingmod.screen;
+
+import net.jeremy.gardenkingmod.ModScreenHandlers;
+import net.jeremy.gardenkingmod.block.entity.GardenShopBlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.util.math.BlockPos;
+
+public class GardenShopScreenHandler extends ScreenHandler {
+        private static final int HOTBAR_SLOT_COUNT = 9;
+        private static final int PLAYER_INVENTORY_ROW_COUNT = 3;
+        private static final int PLAYER_INVENTORY_COLUMN_COUNT = 9;
+        private static final int SHOP_SLOTS_PER_ROW = 9;
+        private static final int SLOT_SIZE = 18;
+        private static final int SHOP_SLOT_START_X = 8;
+        private static final int SHOP_SLOT_START_Y = 18;
+        private static final int PLAYER_INVENTORY_START_Y = 84;
+        private static final int PLAYER_HOTBAR_Y = 142;
+
+        private final Inventory inventory;
+        private final GardenShopBlockEntity blockEntity;
+
+        public GardenShopScreenHandler(int syncId, PlayerInventory playerInventory, PacketByteBuf buf) {
+                this(syncId, playerInventory, getBlockEntity(playerInventory, buf.readBlockPos()));
+        }
+
+        public GardenShopScreenHandler(int syncId, PlayerInventory playerInventory, GardenShopBlockEntity blockEntity) {
+                super(ModScreenHandlers.GARDEN_SHOP_SCREEN_HANDLER, syncId);
+                this.blockEntity = blockEntity;
+                this.inventory = blockEntity != null ? blockEntity : new SimpleInventory(GardenShopBlockEntity.INVENTORY_SIZE);
+
+                checkSize(this.inventory, GardenShopBlockEntity.INVENTORY_SIZE);
+                this.inventory.onOpen(playerInventory.player);
+
+                addGardenShopInventory();
+                addPlayerInventory(playerInventory);
+                addPlayerHotbar(playerInventory);
+        }
+
+        private void addGardenShopInventory() {
+                for (int slotIndex = 0; slotIndex < GardenShopBlockEntity.INVENTORY_SIZE; ++slotIndex) {
+                        int column = slotIndex % SHOP_SLOTS_PER_ROW;
+                        int row = slotIndex / SHOP_SLOTS_PER_ROW;
+                        int x = SHOP_SLOT_START_X + column * SLOT_SIZE;
+                        int y = SHOP_SLOT_START_Y + row * SLOT_SIZE;
+                        this.addSlot(new Slot(this.inventory, slotIndex, x, y));
+                }
+        }
+
+        private static GardenShopBlockEntity getBlockEntity(PlayerInventory playerInventory, BlockPos pos) {
+                if (playerInventory.player.getWorld().getBlockEntity(pos) instanceof GardenShopBlockEntity shopBlockEntity) {
+                        return shopBlockEntity;
+                }
+
+                return null;
+        }
+
+        @Override
+        public boolean canUse(PlayerEntity player) {
+                if (this.blockEntity != null) {
+                        return this.blockEntity.canPlayerUse(player);
+                }
+
+                return this.inventory.canPlayerUse(player);
+        }
+
+        @Override
+        public void onClosed(PlayerEntity player) {
+                super.onClosed(player);
+                if (this.blockEntity != null) {
+                        this.blockEntity.onClose(player);
+                } else {
+                        this.inventory.onClose(player);
+                }
+        }
+
+        @Override
+        public ItemStack quickMove(PlayerEntity player, int index) {
+                ItemStack newStack = ItemStack.EMPTY;
+                Slot slot = this.slots.get(index);
+                if (slot != null && slot.hasStack()) {
+                        ItemStack originalStack = slot.getStack();
+                        newStack = originalStack.copy();
+                        if (index < GardenShopBlockEntity.INVENTORY_SIZE) {
+                                if (!this.insertItem(originalStack, GardenShopBlockEntity.INVENTORY_SIZE, this.slots.size(), true)) {
+                                        return ItemStack.EMPTY;
+                                }
+                        } else if (!this.insertItem(originalStack, 0, GardenShopBlockEntity.INVENTORY_SIZE, false)) {
+                                return ItemStack.EMPTY;
+                        }
+
+                        if (originalStack.isEmpty()) {
+                                slot.setStack(ItemStack.EMPTY);
+                        } else {
+                                slot.markDirty();
+                        }
+                }
+
+                return newStack;
+        }
+
+        public Inventory getInventory() {
+                return this.inventory;
+        }
+
+        private void addPlayerInventory(PlayerInventory playerInventory) {
+                for (int row = 0; row < PLAYER_INVENTORY_ROW_COUNT; ++row) {
+                        for (int column = 0; column < PLAYER_INVENTORY_COLUMN_COUNT; ++column) {
+                                int x = SHOP_SLOT_START_X + column * SLOT_SIZE;
+                                int y = PLAYER_INVENTORY_START_Y + row * SLOT_SIZE;
+                                this.addSlot(new Slot(playerInventory, column + row * PLAYER_INVENTORY_COLUMN_COUNT + HOTBAR_SLOT_COUNT,
+                                                x, y));
+                        }
+                }
+        }
+
+        private void addPlayerHotbar(PlayerInventory playerInventory) {
+                for (int slot = 0; slot < HOTBAR_SLOT_COUNT; ++slot) {
+                        int x = SHOP_SLOT_START_X + slot * SLOT_SIZE;
+                        this.addSlot(new Slot(playerInventory, slot, x, PLAYER_HOTBAR_Y));
+                }
+        }
+}


### PR DESCRIPTION
## Summary
- add a Garden Shop screen handler and register it on both sides
- implement the Garden Shop client screen drawing the dedicated UI texture
- hook the Garden Shop block entity up to the new handler factory

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e0adbf01d4832199999dc8d43f525b