### PR TITLE
Limit garden shop visible offers to fit background

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -36,7 +36,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
         private static final int OFFER_LIST_Y = 17;
         private static final int OFFER_ENTRY_WIDTH = 88;
         private static final int OFFER_ENTRY_HEIGHT = 20;
-        private static final int VISIBLE_OFFER_COUNT = 12;
+        private static final int VISIBLE_OFFER_COUNT = 9;
         private static final int OFFER_ITEM_OFFSET_Y = 2;
         private static final int OFFER_COST_ITEM_OFFSET_X = 6;
         private static final int OFFER_RESULT_ITEM_OFFSET_X = 68;


### PR DESCRIPTION
## Summary
- reduce the number of simultaneously rendered offers in the garden shop GUI so the list stays within the background texture

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e2d30d68808321a4e00efff362460f