### PR TITLE
Handle offer list updates dynamically

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -68,6 +68,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
         private float scrollAmount;
         private boolean scrollbarDragging;
         private int selectedOffer = -1;
+        private int lastOfferCount = -1;
 
         public GardenShopScreen(GardenShopScreenHandler handler, PlayerInventory inventory, Text title) {
                 super(handler, inventory, title);
@@ -83,6 +84,18 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
         protected void init() {
                 super.init();
                 updateScrollLimits();
+                lastOfferCount = handler.getOffers().size();
+        }
+
+        @Override
+        protected void handledScreenTick() {
+                super.handledScreenTick();
+
+                int currentOfferCount = handler.getOffers().size();
+                if (currentOfferCount != lastOfferCount) {
+                        updateScrollLimits();
+                        lastOfferCount = currentOfferCount;
+                }
         }
 
         @Override


### PR DESCRIPTION
## Summary
- remember the last known number of offers shown in the garden shop screen
- update the cached count during init and when the handler changes
- refresh scroll limits whenever the offer count changes so the UI stays in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d72cc418832189e579ac8815fdfd