### PR TITLE
Fix scissor dimensions for Garden Shop offer list

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -184,7 +184,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                 int hoveredOffer = getOfferIndexAt(mouseX, mouseY);
                 int listHeight = VISIBLE_OFFER_COUNT * OFFER_ENTRY_HEIGHT;
 
-                context.enableScissor(listLeft, listTop, listLeft + OFFER_ENTRY_WIDTH, listTop + listHeight);
+                context.enableScissor(listLeft, listTop, OFFER_ENTRY_WIDTH, listHeight);
                 for (int visibleRow = 0; visibleRow < VISIBLE_OFFER_COUNT; visibleRow++) {
                         int offerIndex = scrollOffset + visibleRow;
                         if (offerIndex >= offers.size()) {


### PR DESCRIPTION
## Summary
- update the Garden Shop offer list scissor to use the entry width and list height so content clips to the panel

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e2db7d39bc8321a627430dd8f61c4c