### PR TITLE
Fix garden shop scissor bounds

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -184,7 +184,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                 int hoveredOffer = getOfferIndexAt(mouseX, mouseY);
                 int listHeight = VISIBLE_OFFER_COUNT * OFFER_ENTRY_HEIGHT;
 
-                context.enableScissor(listLeft, listTop, OFFER_ENTRY_WIDTH, listHeight);
+                context.enableScissor(listLeft, listTop, listLeft + OFFER_ENTRY_WIDTH, listTop + listHeight);
                 for (int visibleRow = 0; visibleRow < VISIBLE_OFFER_COUNT; visibleRow++) {
                         int offerIndex = scrollOffset + visibleRow;
                         if (offerIndex >= offers.size()) {


### PR DESCRIPTION
## Summary
- adjust the garden shop offer list scissor rectangle to use the full panel bounds so entries clip correctly

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e2ddaab24883218b06a11b8be0d962