### PR TITLE
Remove legacy garden shop offer migration

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
@@ -58,10 +58,17 @@ public class GardenShopScreenHandler extends ScreenHandler {
                         this.offers.clear();
                         int offerCount = buf.readVarInt();
                         for (int index = 0; index < offerCount; index++) {
-                                ItemStack stack = buf.readItemStack();
-                                int price = buf.readVarInt();
-                                if (!stack.isEmpty()) {
-                                        this.offers.add(new GardenShopOffer(stack, price));
+                                ItemStack result = buf.readItemStack();
+                                int costCount = buf.readVarInt();
+                                List<ItemStack> costs = new ArrayList<>(costCount);
+                                for (int costIndex = 0; costIndex < costCount; costIndex++) {
+                                        ItemStack costStack = buf.readItemStack();
+                                        if (!costStack.isEmpty()) {
+                                                costs.add(costStack);
+                                        }
+                                }
+                                if (!result.isEmpty()) {
+                                        this.offers.add(GardenShopOffer.of(result, costs));
                                 }
                         }
                         fillInventoryFromOffers();
@@ -133,7 +140,7 @@ public class GardenShopScreenHandler extends ScreenHandler {
 
         private void fillInventoryFromOffers() {
                 for (int index = 0; index < this.inventory.size(); index++) {
-                        ItemStack stack = index < this.offers.size() ? this.offers.get(index).createDisplayStack() : ItemStack.EMPTY;
+                        ItemStack stack = index < this.offers.size() ? this.offers.get(index).copyResultStack() : ItemStack.EMPTY;
                         this.inventory.setStack(index, stack);
                 }
         }

--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenShopOffer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenShopOffer.java
@@ -1,18 +1,60 @@
 package net.jeremy.gardenkingmod.shop;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
 import net.minecraft.item.ItemStack;
 
 /**
- * Simple data holder representing a single item that the garden shop can sell
- * along with the Garden Coin price for that item.
+ * Represents a single shop offer consisting of the resulting stack and a list
+ * of ItemStacks required to purchase it.
  */
-public record GardenShopOffer(ItemStack displayStack, int price) {
+public record GardenShopOffer(ItemStack resultStack, List<ItemStack> costStacks) {
 
     public GardenShopOffer {
-        displayStack = displayStack.copy();
+        Objects.requireNonNull(resultStack, "resultStack");
+        Objects.requireNonNull(costStacks, "costStacks");
+        resultStack = resultStack.copy();
+        costStacks = toImmutableCostList(costStacks);
     }
 
-    public ItemStack createDisplayStack() {
-        return displayStack.copy();
+    public static GardenShopOffer of(ItemStack result, ItemStack... costs) {
+        return new GardenShopOffer(result, Arrays.asList(costs));
+    }
+
+    public static GardenShopOffer of(ItemStack result, List<ItemStack> costs) {
+        return new GardenShopOffer(result, costs);
+    }
+
+    private static List<ItemStack> toImmutableCostList(List<ItemStack> source) {
+        List<ItemStack> copy = new ArrayList<>(source.size());
+        for (ItemStack stack : source) {
+            copy.add(stack.copy());
+        }
+        return List.copyOf(copy);
+    }
+
+    @Override
+    public ItemStack resultStack() {
+        return this.resultStack.copy();
+    }
+
+    public ItemStack copyResultStack() {
+        return this.resultStack.copy();
+    }
+
+    @Override
+    public List<ItemStack> costStacks() {
+        return this.costStacks;
+    }
+
+    public List<ItemStack> copyCostStacks() {
+        List<ItemStack> copy = new ArrayList<>(this.costStacks.size());
+        for (ItemStack stack : this.costStacks) {
+            copy.add(stack.copy());
+        }
+        return copy;
     }
 }


### PR DESCRIPTION
## Summary
- drop the legacy item/price migration logic when reading garden shop offers
- keep only the new multi-cost offer format in persistence logic while continuing to sync inventory

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e2ea21a5c08321b0f7768848e25d9e