### PR TITLE
Configure garden shop trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,26 @@ Crow spawning is configured with two JSON files so that designers can keep biome
 
 Crow models, textures, and other assets follow the same conventions as the rest of the project. Keep any `.png` textures for the crow entity under `assets/gardenkingmod/textures/entity/` so that they are picked up automatically at runtime.
 
+## Garden shop trades
+
+The garden shop's default trades are defined in [`GardenShopBlockEntity`](src/main/java/net/jeremy/gardenkingmod/block/entity/GardenShopBlockEntity.java).
+When the block entity is opened, its `ensureOffers` method populates the offers list with preconfigured `GardenShopOffer`
+instances. Each offer specifies the result `ItemStack` followed by one or more cost stacks that players must provide to
+complete the trade. The current configuration supplies two trades:
+
+1. One Minecraft milk bucket plus one Croptopia butter yields one Croptopia cheese.
+2. Thirty-two Garden King rubies yield one Minecraft elytra.
+
+### Adding more trades
+
+1. Open `GardenShopBlockEntity` and locate the `ensureOffers` method.
+2. Use `createStack(new Identifier("namespace", "item"), count)` for third-party mod items, or `new ItemStack(Items.*)` and
+   `new ItemStack(ModItems.*)` for vanilla and Garden King items.
+3. Call `offers.add(GardenShopOffer.of(resultStack, costStacks...))` to register the new trade before the method invokes
+   `syncItemsFromOffers()`.
+4. Save the file and rebuild or reload the mod. If the trade produces a brand-new item, place its `.png` texture in
+   `assets/gardenkingmod/textures/item/` so Fabric can find it.
+
 ## Fortune levels and loot drops
 
 The Fortune effect rolls for extra items whenever a block or crop is flagged as "fortune affected" in its loot table. For ore-style drops (diamonds, coal, emeralds, etc.) the final stack size equals `1 + random(0, level)`, so higher levels guarantee more bonus items on average. The table below shows how this plays out in practice:

--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/GardenShopBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/GardenShopBlockEntity.java
@@ -17,24 +17,27 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventories;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.collection.DefaultedList;
+import net.minecraft.registry.Registries;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
+import net.minecraft.util.Identifier;
 
 public class GardenShopBlockEntity extends BlockEntity implements ExtendedScreenHandlerFactory, Inventory {
     public static final int INVENTORY_SIZE = 27;
     private static final String OFFERS_KEY = "Offers";
     private static final String OFFER_RESULT_KEY = "Result";
     private static final String OFFER_COSTS_KEY = "Costs";
-    private static final int TEST_OFFER_COUNT = 18;
-    private static final int TEST_PRICE_PER_ITEM = 64;
+    private static final Identifier CROPTOPIA_BUTTER_ID = new Identifier("croptopia", "butter");
+    private static final Identifier CROPTOPIA_CHEESE_ID = new Identifier("croptopia", "cheese");
 
     private DefaultedList<ItemStack> items = DefaultedList.ofSize(INVENTORY_SIZE, ItemStack.EMPTY);
     private final List<GardenShopOffer> offers = new ArrayList<>();
@@ -220,9 +223,16 @@ public class GardenShopBlockEntity extends BlockEntity implements ExtendedScreen
         }
 
         offers.clear();
-        for (int index = 0; index < Math.min(TEST_OFFER_COUNT, INVENTORY_SIZE); index++) {
-            ItemStack stack = new ItemStack(ModItems.RUBY_CHESTPLATE);
-            offers.add(GardenShopOffer.of(stack, new ItemStack(ModItems.GARDEN_COIN, TEST_PRICE_PER_ITEM)));
+        ItemStack cheese = createStack(CROPTOPIA_CHEESE_ID, 1);
+        ItemStack butter = createStack(CROPTOPIA_BUTTER_ID, 1);
+        if (!cheese.isEmpty() && !butter.isEmpty()) {
+            offers.add(GardenShopOffer.of(cheese, new ItemStack(Items.MILK_BUCKET), butter));
+        }
+
+        ItemStack elytra = new ItemStack(Items.ELYTRA);
+        ItemStack rubies = new ItemStack(ModItems.RUBY, 32);
+        if (!elytra.isEmpty() && !rubies.isEmpty()) {
+            offers.add(GardenShopOffer.of(elytra, rubies));
         }
         syncItemsFromOffers();
         markDirty();
@@ -235,5 +245,11 @@ public class GardenShopBlockEntity extends BlockEntity implements ExtendedScreen
         for (int index = 0; index < offers.size() && index < items.size(); index++) {
             items.set(index, offers.get(index).copyResultStack());
         }
+    }
+
+    private ItemStack createStack(Identifier itemId, int count) {
+        return Registries.ITEM.getOrEmpty(itemId)
+                .map(item -> new ItemStack(item, count))
+                .orElse(ItemStack.EMPTY);
     }
 }


### PR DESCRIPTION
## Summary
- replace the placeholder garden shop test offers with milk/butter for cheese and ruby-for-elytra trades that load through the item registry
- document where garden shop trades live and how to add more entries in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2f2fd55988321b6dc916d6913943e