### PR TITLE
Load garden shop offers from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,42 @@ Crow spawning is configured with two JSON files so that designers can keep biome
 
 Crow models, textures, and other assets follow the same conventions as the rest of the project. Keep any `.png` textures for the crow entity under `assets/gardenkingmod/textures/entity/` so that they are picked up automatically at runtime.
 
+## Garden shop trades
+
+The garden shop's inventory is now data-driven. All default trades live in
+[`data/gardenkingmod/garden_shop_offers.json`](src/main/resources/data/gardenkingmod/garden_shop_offers.json), so you can add
+new entries without touching Java code. Each entry follows a simple "offer / price" layout:
+
+```json
+{
+  "offer": "minecraft:elytra",
+  "price": "gardenkingmod:ruby*32"
+}
+```
+
+* `offer` is the item the shop will sell. You can provide it as a plain string (`"namespace:item"`) or as an object with
+  explicit fields:
+
+  ```json
+  { "item": "croptopia:cheese", "count": 2 }
+  ```
+
+* `price` accepts either a single string/object or an array if you want multiple inputs. To specify stack sizes inline, append
+  `*<count>` to the identifier (for example, `"gardenkingmod:ruby*32"`).
+
+The current configuration supplies two trades:
+
+1. One Minecraft milk bucket plus one Croptopia butter yields one Croptopia cheese.
+2. Thirty-two Garden King rubies yield one Minecraft elytra.
+
+### Adding more trades
+
+1. Open [`garden_shop_offers.json`](src/main/resources/data/gardenkingmod/garden_shop_offers.json).
+2. Add a new JSON object to the `offers` array using the format above (one `offer`, one `price`).
+3. Save the file and reload your data packs (or restart the game/server) so Fabric's resource loader picks up the change.
+4. If the trade produces a brand-new item, place its `.png` texture inside `assets/gardenkingmod/textures/item/` so Fabric can
+   find it at runtime.
+
 ## Fortune levels and loot drops
 
 The Fortune effect rolls for extra items whenever a block or crop is flagged as "fortune affected" in its loot table. For ore-style drops (diamonds, coal, emeralds, etc.) the final stack size equals `1 + random(0, level)`, so higher levels guarantee more bonus items on average. The table below shows how this plays out in practice:

--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
@@ -9,6 +9,7 @@ import net.jeremy.gardenkingmod.crop.CropDropModifier;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.registry.ModEntities;
 import net.jeremy.gardenkingmod.registry.ModSoundEvents;
+import net.jeremy.gardenkingmod.shop.GardenShopOfferManager;
 
 import net.minecraft.resource.ResourceType;
 
@@ -31,6 +32,7 @@ public class GardenKingMod implements ModInitializer {
                 ModArmorSetEffects.register();
 
                 ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(BonusHarvestDropManager.getInstance());
+                ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(GardenShopOfferManager.getInstance());
 
                 CropTierRegistry.init();
                 CropDropModifier.register();

--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/GardenShopBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/GardenShopBlockEntity.java
@@ -6,9 +6,9 @@ import java.util.Collections;
 import java.util.List;
 
 import net.jeremy.gardenkingmod.ModBlockEntities;
-import net.jeremy.gardenkingmod.ModItems;
 import net.jeremy.gardenkingmod.screen.GardenShopScreenHandler;
 import net.jeremy.gardenkingmod.shop.GardenShopOffer;
+import net.jeremy.gardenkingmod.shop.GardenShopOfferManager;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
@@ -33,9 +33,6 @@ public class GardenShopBlockEntity extends BlockEntity implements ExtendedScreen
     private static final String OFFERS_KEY = "Offers";
     private static final String OFFER_RESULT_KEY = "Result";
     private static final String OFFER_COSTS_KEY = "Costs";
-    private static final int TEST_OFFER_COUNT = 18;
-    private static final int TEST_PRICE_PER_ITEM = 64;
-
     private DefaultedList<ItemStack> items = DefaultedList.ofSize(INVENTORY_SIZE, ItemStack.EMPTY);
     private final List<GardenShopOffer> offers = new ArrayList<>();
 
@@ -214,16 +211,14 @@ public class GardenShopBlockEntity extends BlockEntity implements ExtendedScreen
     }
 
     public void ensureOffers() {
-        if (!offers.isEmpty()) {
+        List<GardenShopOffer> configuredOffers = GardenShopOfferManager.getInstance().getOffers();
+        if (offers.equals(configuredOffers)) {
             syncItemsFromOffers();
             return;
         }
 
         offers.clear();
-        for (int index = 0; index < Math.min(TEST_OFFER_COUNT, INVENTORY_SIZE); index++) {
-            ItemStack stack = new ItemStack(ModItems.RUBY_CHESTPLATE);
-            offers.add(GardenShopOffer.of(stack, new ItemStack(ModItems.GARDEN_COIN, TEST_PRICE_PER_ITEM)));
-        }
+        offers.addAll(configuredOffers);
         syncItemsFromOffers();
         markDirty();
     }

--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenShopOfferManager.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenShopOfferManager.java
@@ -1,0 +1,233 @@
+package net.jeremy.gardenkingmod.shop;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+
+import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
+import net.minecraft.resource.Resource;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+
+/**
+ * Loads garden shop offers from {@code data/gardenkingmod/garden_shop_offers.json} so they can be
+ * configured with simple {@code offer}/ {@code price} lines instead of hard-coded Java.
+ */
+public final class GardenShopOfferManager implements SimpleSynchronousResourceReloadListener {
+    private static final Identifier RELOAD_ID = new Identifier(GardenKingMod.MOD_ID, "garden_shop_offers");
+    private static final Identifier OFFERS_FILE = new Identifier(GardenKingMod.MOD_ID, "garden_shop_offers.json");
+    private static final GardenShopOfferManager INSTANCE = new GardenShopOfferManager();
+
+    private volatile List<GardenShopOffer> offers = List.of();
+
+    private GardenShopOfferManager() {
+    }
+
+    public static GardenShopOfferManager getInstance() {
+        return INSTANCE;
+    }
+
+    public List<GardenShopOffer> getOffers() {
+        return offers;
+    }
+
+    @Override
+    public Identifier getFabricId() {
+        return RELOAD_ID;
+    }
+
+    @Override
+    public void reload(ResourceManager manager) {
+        offers = loadOffers(manager);
+    }
+
+    private List<GardenShopOffer> loadOffers(ResourceManager manager) {
+        Optional<Resource> resourceOptional = manager.getResource(OFFERS_FILE);
+        if (resourceOptional.isEmpty()) {
+            GardenKingMod.LOGGER.warn("No garden shop offer file found at {}", OFFERS_FILE);
+            return List.of();
+        }
+
+        List<GardenShopOffer> loaded = new ArrayList<>();
+        try (InputStream stream = resourceOptional.get().getInputStream();
+             BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            JsonElement root = JsonParser.parseReader(reader);
+            if (root.isJsonObject()) {
+                JsonObject rootObject = root.getAsJsonObject();
+                if (rootObject.has("offers")) {
+                    parseOffersArray(rootObject.get("offers"), loaded);
+                } else {
+                    GardenShopOffer single = parseOfferObject(rootObject);
+                    if (single != null) {
+                        loaded.add(single);
+                    }
+                }
+            } else if (root.isJsonArray()) {
+                parseOffersArray(root, loaded);
+            } else {
+                GardenKingMod.LOGGER.warn("garden_shop_offers.json must contain an array of offers");
+            }
+        } catch (IOException | JsonParseException exception) {
+            GardenKingMod.LOGGER.error("Failed to load garden shop offers", exception);
+        }
+
+        if (loaded.isEmpty()) {
+            return List.of();
+        }
+
+        return List.copyOf(loaded);
+    }
+
+    private void parseOffersArray(JsonElement element, List<GardenShopOffer> destination) {
+        if (!element.isJsonArray()) {
+            GardenKingMod.LOGGER.warn("Expected an array of offers in garden_shop_offers.json");
+            return;
+        }
+
+        JsonArray offersArray = element.getAsJsonArray();
+        for (JsonElement offerElement : offersArray) {
+            if (!offerElement.isJsonObject()) {
+                GardenKingMod.LOGGER.warn("Skipping malformed garden shop offer entry: {}", offerElement);
+                continue;
+            }
+
+            GardenShopOffer offer = parseOfferObject(offerElement.getAsJsonObject());
+            if (offer != null) {
+                destination.add(offer);
+            }
+        }
+    }
+
+    private GardenShopOffer parseOfferObject(JsonObject object) {
+        if (!object.has("offer")) {
+            GardenKingMod.LOGGER.warn("Garden shop offer entry is missing an 'offer' field: {}", object);
+            return null;
+        }
+
+        ItemStack result = parseStack(object.get("offer"), "offer");
+        if (result.isEmpty()) {
+            return null;
+        }
+
+        if (!object.has("price")) {
+            GardenKingMod.LOGGER.warn("Garden shop offer entry for {} is missing a 'price' field", describeStack(result));
+            return null;
+        }
+
+        List<ItemStack> costs = parsePrice(object.get("price"));
+        if (costs.isEmpty()) {
+            GardenKingMod.LOGGER.warn("Garden shop offer entry for {} has no valid price entries", describeStack(result));
+            return null;
+        }
+
+        return GardenShopOffer.of(result, costs);
+    }
+
+    private List<ItemStack> parsePrice(JsonElement priceElement) {
+        List<ItemStack> costs = new ArrayList<>();
+        if (priceElement.isJsonArray()) {
+            JsonArray priceArray = priceElement.getAsJsonArray();
+            for (JsonElement costElement : priceArray) {
+                ItemStack cost = parseStack(costElement, "price");
+                if (!cost.isEmpty()) {
+                    costs.add(cost);
+                }
+            }
+        } else {
+            ItemStack cost = parseStack(priceElement, "price");
+            if (!cost.isEmpty()) {
+                costs.add(cost);
+            }
+        }
+        return costs;
+    }
+
+    private ItemStack parseStack(JsonElement element, String fieldName) {
+        if (element.isJsonPrimitive() && element.getAsJsonPrimitive().isString()) {
+            return parseDescriptor(element.getAsString().trim(), fieldName);
+        }
+
+        if (element.isJsonObject()) {
+            JsonObject object = element.getAsJsonObject();
+            if (!object.has("item")) {
+                GardenKingMod.LOGGER.warn("Garden shop {} entry is missing an 'item' field: {}", fieldName, object);
+                return ItemStack.EMPTY;
+            }
+            String itemId = JsonHelper.getString(object, "item");
+            int count = JsonHelper.getInt(object, "count", 1);
+            return createStack(itemId, count, fieldName);
+        }
+
+        GardenKingMod.LOGGER.warn("Garden shop {} entry must be a string or object: {}", fieldName, element);
+        return ItemStack.EMPTY;
+    }
+
+    private ItemStack parseDescriptor(String descriptor, String fieldName) {
+        if (descriptor.isEmpty()) {
+            GardenKingMod.LOGGER.warn("Garden shop {} entry cannot be empty", fieldName);
+            return ItemStack.EMPTY;
+        }
+
+        String itemPart = descriptor;
+        int count = 1;
+        int multiplierIndex = descriptor.indexOf('*');
+        if (multiplierIndex >= 0) {
+            itemPart = descriptor.substring(0, multiplierIndex).trim();
+            String countPart = descriptor.substring(multiplierIndex + 1).trim();
+            if (!countPart.isEmpty()) {
+                try {
+                    count = Integer.parseInt(countPart);
+                } catch (NumberFormatException exception) {
+                    GardenKingMod.LOGGER.warn("Invalid stack count '{}' in garden shop {} entry '{}'", countPart, fieldName, descriptor);
+                    return ItemStack.EMPTY;
+                }
+            }
+        }
+
+        return createStack(itemPart, count, fieldName);
+    }
+
+    private ItemStack createStack(String itemId, int count, String fieldName) {
+        if (count <= 0) {
+            GardenKingMod.LOGGER.warn("Garden shop {} entry for '{}' must specify a positive count", fieldName, itemId);
+            return ItemStack.EMPTY;
+        }
+
+        Identifier id = Identifier.tryParse(itemId);
+        if (id == null) {
+            GardenKingMod.LOGGER.warn("Garden shop {} entry '{}' is not a valid identifier", fieldName, itemId);
+            return ItemStack.EMPTY;
+        }
+
+        Optional<Item> itemOptional = Registries.ITEM.getOrEmpty(id);
+        if (itemOptional.isEmpty()) {
+            GardenKingMod.LOGGER.warn("Garden shop {} entry references unknown item '{}'", fieldName, id);
+            return ItemStack.EMPTY;
+        }
+
+        return new ItemStack(itemOptional.get(), count);
+    }
+
+    private static String describeStack(ItemStack stack) {
+        Identifier id = Registries.ITEM.getId(stack.getItem());
+        return stack.getCount() + "x " + (id != null ? id.toString() : stack.getName().getString());
+    }
+}

--- a/src/main/resources/data/gardenkingmod/garden_shop_offers.json
+++ b/src/main/resources/data/gardenkingmod/garden_shop_offers.json
@@ -1,0 +1,15 @@
+{
+  "offers": [
+    {
+      "offer": "croptopia:cheese",
+      "price": [
+        "minecraft:milk_bucket",
+        "croptopia:butter"
+      ]
+    },
+    {
+      "offer": "minecraft:elytra",
+      "price": "gardenkingmod:ruby*32"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- load garden shop offers from `data/gardenkingmod/garden_shop_offers.json` through a new resource reload listener
- have the garden shop block entity mirror whatever offers are configured instead of hard-coded stacks
- document the simplified offer/price format in the README and seed the config with the requested cheese and elytra trades

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68e2f2fd55988321b6dc916d6913943e