### PR TITLE
Support per-tab garden shop offers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,35 +45,39 @@ Crow models, textures, and other assets follow the same conventions as the rest 
 ## Garden shop trades
 
 The garden shop's inventory is now data-driven. All default trades live in
-[`data/gardenkingmod/garden_shop_offers.json`](src/main/resources/data/gardenkingmod/garden_shop_offers.json), so you can add
-new entries without touching Java code. Each entry follows a simple "offer / price" layout:
+[`data/gardenkingmod/garden_shop_offers.json`](src/main/resources/data/gardenkingmod/garden_shop_offers.json), which groups
+offers by UI tab through a `pages` array:
 
 ```json
 {
-  "offer": "minecraft:elytra",
-  "price": "gardenkingmod:ruby*32"
+  "pages": [
+    {
+      "offers": [
+        {
+          "offer": "minecraft:elytra",
+          "price": "gardenkingmod:ruby*32"
+        }
+      ]
+    }
+  ]
 }
 ```
 
+* Each object inside `pages` represents one tab from top to bottom. The example file defines five pages to match the five tab
+  buttons in the UI, but you can leave an `offers` array empty if you want a blank tab.
 * `offer` is the item the shop will sell. You can provide it as a plain string (`"namespace:item"`) or as an object with
-  explicit fields:
-
-  ```json
-  { "item": "croptopia:cheese", "count": 2 }
-  ```
-
+  explicit fields such as `{ "item": "croptopia:cheese", "count": 2 }`.
 * `price` accepts either a single string/object or an array if you want multiple inputs. To specify stack sizes inline, append
   `*<count>` to the identifier (for example, `"gardenkingmod:ruby*32"`).
 
-The current configuration supplies two trades:
-
-1. One Minecraft milk bucket plus one Croptopia butter yields one Croptopia cheese.
-2. Thirty-two Garden King rubies yield one Minecraft elytra.
+The stock configuration distributes the ruby-for-elytra upgrades across all five tabs while keeping the cheese trade on the
+first tab.
 
 ### Adding more trades
 
 1. Open [`garden_shop_offers.json`](src/main/resources/data/gardenkingmod/garden_shop_offers.json).
-2. Add a new JSON object to the `offers` array using the format above (one `offer`, one `price`).
+2. Decide which tab should display the trade and add a new JSON object to that page's `offers` array using the format above.
+   Add a brand-new page object under `pages` if you want to populate another tab.
 3. Save the file and reload your data packs (or restart the game/server) so Fabric's resource loader picks up the change.
 4. If the trade produces a brand-new item, place its `.png` texture inside `assets/gardenkingmod/textures/item/` so Fabric can
    find it at runtime.

--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -105,14 +105,14 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
         protected void init() {
                 super.init();
                 updateScrollLimits();
-                lastOfferCount = handler.getOffers().size();
+                lastOfferCount = getOffersForActiveTab().size();
         }
 
         @Override
         protected void handledScreenTick() {
                 super.handledScreenTick();
 
-                int currentOfferCount = handler.getOffers().size();
+                int currentOfferCount = getOffersForActiveTab().size();
                 if (currentOfferCount != lastOfferCount) {
                         updateScrollLimits();
                         lastOfferCount = currentOfferCount;
@@ -208,7 +208,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
         }
 
         private void drawOfferList(DrawContext context, int originX, int originY, int mouseX, int mouseY) {
-                List<GardenShopOffer> offers = handler.getOffers();
+                List<GardenShopOffer> offers = getOffersForActiveTab();
                 int listLeft = originX + OFFER_LIST_X;
                 int listTop = originY + OFFER_LIST_Y;
                 int hoveredOffer = getOfferIndexAt(mouseX, mouseY);
@@ -288,7 +288,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
         }
 
         private void updateScrollLimits() {
-                int offerCount = handler.getOffers().size();
+                int offerCount = getOffersForActiveTab().size();
                 maxScrollSteps = Math.max(offerCount - MAX_VISIBLE_OFFERS, 0);
                 setScrollAmount(scrollAmount);
                 if (selectedOffer >= offerCount) {
@@ -370,6 +370,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                         selectedOffer = -1;
                         setScrollAmount(0.0F);
                         updateScrollLimits();
+                        lastOfferCount = getOffersForActiveTab().size();
                 }
         }
 
@@ -397,12 +398,13 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                 }
 
                 int offerIndex = scrollOffset + row;
-                return offerIndex < handler.getOffers().size() ? offerIndex : -1;
+                return offerIndex < getOffersForActiveTab().size() ? offerIndex : -1;
         }
 
         private Optional<ItemStack> getHoveredOfferStack(int mouseX, int mouseY) {
                 int offerIndex = getOfferIndexAt(mouseX, mouseY);
-                if (offerIndex < 0 || offerIndex >= handler.getOffers().size()) {
+                List<GardenShopOffer> offers = getOffersForActiveTab();
+                if (offerIndex < 0 || offerIndex >= offers.size()) {
                         return Optional.empty();
                 }
 
@@ -426,7 +428,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                         return Optional.empty();
                 }
 
-                GardenShopOffer offer = handler.getOffers().get(offerIndex);
+                GardenShopOffer offer = offers.get(offerIndex);
                 int costStart = listLeft + OFFER_COST_ITEM_OFFSET_X;
                 int arrowLeft = listLeft + OFFER_ARROW_OFFSET_X;
                 int maxCostRight = arrowLeft - 2;
@@ -447,5 +449,9 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                 }
 
                 return Optional.empty();
+        }
+
+        private List<GardenShopOffer> getOffersForActiveTab() {
+                return handler.getOffers(activeTab);
         }
 }

--- a/src/main/resources/data/gardenkingmod/garden_shop_offers.json
+++ b/src/main/resources/data/gardenkingmod/garden_shop_offers.json
@@ -1,53 +1,71 @@
 {
-  "offers": [
+  "pages": [
     {
-      "offer": "croptopia:cheese*2",
-      "price": [
-        "minecraft:milk_bucket",
-        "croptopia:butter"
+      "offers": [
+        {
+          "offer": "croptopia:cheese*2",
+          "price": [
+            "minecraft:milk_bucket",
+            "croptopia:butter"
+          ]
+        },
+        {
+          "offer": "minecraft:elytra",
+          "price": "gardenkingmod:ruby*1"
+        },
+        {
+          "offer": "minecraft:elytra",
+          "price": "gardenkingmod:ruby*2"
+        }
       ]
     },
     {
-      "offer": "minecraft:elytra",
-      "price": "gardenkingmod:ruby*1"
+      "offers": [
+        {
+          "offer": "minecraft:elytra",
+          "price": "gardenkingmod:ruby*3"
+        },
+        {
+          "offer": "minecraft:elytra",
+          "price": "gardenkingmod:ruby*4"
+        }
+      ]
     },
     {
-      "offer": "minecraft:elytra",
-      "price": "gardenkingmod:ruby*2"
+      "offers": [
+        {
+          "offer": "minecraft:elytra",
+          "price": "gardenkingmod:ruby*5"
+        },
+        {
+          "offer": "minecraft:elytra",
+          "price": "gardenkingmod:ruby*6"
+        }
+      ]
     },
     {
-      "offer": "minecraft:elytra",
-      "price": "gardenkingmod:ruby*3"
+      "offers": [
+        {
+          "offer": "minecraft:elytra",
+          "price": "gardenkingmod:ruby*7"
+        },
+        {
+          "offer": "minecraft:elytra",
+          "price": "gardenkingmod:ruby*8"
+        }
+      ]
     },
     {
-      "offer": "minecraft:elytra",
-      "price": "gardenkingmod:ruby*4"
-    },
-    {
-      "offer": "minecraft:elytra",
-      "price": "gardenkingmod:ruby*5"
-    },
-    {
-      "offer": "minecraft:elytra",
-      "price": "gardenkingmod:ruby*6"
-    },
-    {
-      "offer": "minecraft:elytra",
-      "price": "gardenkingmod:ruby*7"
-    },
-    {
-      "offer": "minecraft:elytra",
-      "price": "gardenkingmod:ruby*8"
-    },
-    {
-      "offer": "minecraft:elytra",
-      "price": "gardenkingmod:ruby*9"
-    },
-    {
-      "offer": "minecraft:elytra",
-      "price": "gardenkingmod:ruby*10"
+      "offers": [
+        {
+          "offer": "minecraft:elytra",
+          "price": "gardenkingmod:ruby*9"
+        },
+        {
+          "offer": "minecraft:elytra",
+          "price": "gardenkingmod:ruby*10"
+        }
+      ]
     }
-
-
   ]
 }


### PR DESCRIPTION
## Summary
- load garden shop trades as per-tab pages and persist them on the block entity
- update the shop screen handler and GUI to only show offers for the active tab
- document the new JSON layout and reorganize the default offers into page blocks

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68e4122676e48321a35c53ae8ada3513