### PR TITLE
Allow _comment annotations in data-driven JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Bonus harvest drops
 
-Garden King now loads bonus crop drop definitions from JSON files under `data/gardenkingmod/bonus_harvest_drops/`. Each file maps a crop block or direct loot table identifier to one or more bonus entries with an `item`, `chance`, and integer `count` range. The new [`wheat_diamonds.json`](src/main/resources/data/gardenkingmod/bonus_harvest_drops/wheat_diamonds.json) file, for example, grants wheat a 5% chance to drop 1–3 diamonds when harvested.
+Garden King now loads bonus crop drop definitions from JSON files under `data/gardenkingmod/bonus_harvest_drops/`. Each file maps a crop block or direct loot table identifier to one or more bonus entries with an `item`, `chance`, and integer `count` range. All of the project's data-driven loaders strip any field named `_comment`, so you can document bonus drops, garden shop offers, or rotten crop definitions with entries such as `"_comment": "This is a general comment about the file."` anywhere in the JSON tree. The new [`wheat_diamonds.json`](src/main/resources/data/gardenkingmod/bonus_harvest_drops/wheat_diamonds.json) file, for example, grants wheat a 5% chance to drop 1–3 diamonds when harvested.
 
 ### Creating event packs
 
@@ -46,14 +46,17 @@ Crow models, textures, and other assets follow the same conventions as the rest 
 
 The garden shop's inventory is now data-driven. All default trades live in
 [`data/gardenkingmod/garden_shop_offers.json`](src/main/resources/data/gardenkingmod/garden_shop_offers.json), which groups
-offers by UI tab through a `pages` array:
+offers by UI tab through a `pages` array. Use `_comment` fields at the root, page, or offer level to label long files without affecting parsing:
 
 ```json
 {
+  "_comment": "Starter inventory for the travelling gardener.",
   "pages": [
     {
+      "_comment": "Page 1: equipment",
       "offers": [
         {
+          "_comment": "Keep the elytra trade near the top for visibility.",
           "offer": "minecraft:elytra",
           "price": "gardenkingmod:ruby*32"
         }

--- a/src/main/java/net/jeremy/gardenkingmod/crop/BonusHarvestDropManager.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/BonusHarvestDropManager.java
@@ -29,6 +29,8 @@ import net.minecraft.util.JsonHelper;
 import net.minecraft.util.profiler.DummyProfiler;
 import net.minecraft.util.profiler.Profiler;
 
+import net.jeremy.gardenkingmod.util.JsonCommentHelper;
+
 /**
  * Loads bonus harvest drop definitions from JSON files so datapacks can
  * dynamically reconfigure seasonal events without code changes.
@@ -113,7 +115,7 @@ public final class BonusHarvestDropManager extends JsonDataLoader implements Ide
 
                 for (Map.Entry<Identifier, JsonElement> entry : prepared.entrySet()) {
                         Identifier fileId = entry.getKey();
-                        JsonElement json = entry.getValue();
+                        JsonElement json = JsonCommentHelper.sanitize(entry.getValue());
 
                         if (!json.isJsonObject()) {
                                 GardenKingMod.LOGGER.warn("Ignoring bonus harvest drops at {} because it is not a JSON object", fileId);
@@ -165,6 +167,9 @@ public final class BonusHarvestDropManager extends JsonDataLoader implements Ide
                         }
 
                         JsonObject entryObject = element.getAsJsonObject();
+                        if (entryObject.entrySet().isEmpty()) {
+                                continue;
+                        }
                         try {
                                 String itemIdString = JsonHelper.getString(entryObject, "item");
                                 Identifier itemId = parseIdentifier(itemIdString, fileId);

--- a/src/main/java/net/jeremy/gardenkingmod/crop/RottenCropDefinitions.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/RottenCropDefinitions.java
@@ -29,6 +29,7 @@ import com.google.gson.JsonParser;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.util.JsonCommentHelper;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
@@ -197,7 +198,8 @@ public final class RottenCropDefinitions {
                 List<RottenCropDefinition> definitions = new ArrayList<>();
 
                 JsonElement root = JsonParser.parseReader(reader);
-                JsonArray entries = extractEntriesArray(root);
+                JsonElement sanitized = JsonCommentHelper.sanitize(root);
+                JsonArray entries = extractEntriesArray(sanitized);
                 if (entries == null) {
                         GardenKingMod.LOGGER.warn("Expected an array of rotten crop entries in {}.", RESOURCE_PATH);
                         return List.of();

--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenShopOfferManager.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenShopOfferManager.java
@@ -18,6 +18,7 @@ import com.google.gson.JsonParser;
 import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
 
 import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.util.JsonCommentHelper;
 
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -97,8 +98,9 @@ public final class GardenShopOfferManager implements SimpleSynchronousResourceRe
         try (InputStream stream = resourceOptional.get().getInputStream();
              BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
             JsonElement root = JsonParser.parseReader(reader);
-            if (root.isJsonObject()) {
-                JsonObject rootObject = root.getAsJsonObject();
+            JsonElement sanitized = JsonCommentHelper.sanitize(root);
+            if (sanitized.isJsonObject()) {
+                JsonObject rootObject = sanitized.getAsJsonObject();
                 if (rootObject.has("pages")) {
                     parsePagesArray(rootObject.get("pages"), loadedPages);
                 } else if (rootObject.has("offers")) {
@@ -110,8 +112,8 @@ public final class GardenShopOfferManager implements SimpleSynchronousResourceRe
                         loadedPages.add(List.of(single));
                     }
                 }
-            } else if (root.isJsonArray()) {
-                List<GardenShopOffer> page = parseOffersArray(root, "root array");
+            } else if (sanitized.isJsonArray()) {
+                List<GardenShopOffer> page = parseOffersArray(sanitized, "root array");
                 loadedPages.add(List.copyOf(page));
             } else {
                 GardenKingMod.LOGGER.warn("garden_shop_offers.json must contain an array of offers");

--- a/src/main/java/net/jeremy/gardenkingmod/util/JsonCommentHelper.java
+++ b/src/main/java/net/jeremy/gardenkingmod/util/JsonCommentHelper.java
@@ -1,0 +1,59 @@
+package net.jeremy.gardenkingmod.util;
+
+import java.util.Map;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+
+/**
+ * Utility methods for sanitizing data-driven JSON files that allow inline
+ * documentation fields such as {@code "_comment"}.
+ */
+public final class JsonCommentHelper {
+        private JsonCommentHelper() {
+        }
+
+        /**
+         * Returns a deep copy of {@code element} with any {@code "_comment"}
+         * properties stripped from every object in the tree.
+         *
+         * @param element The element to sanitize.
+         * @return A deep copy with comment fields removed, or {@link JsonNull} if the
+         *         input is {@code null}.
+         */
+        public static JsonElement sanitize(JsonElement element) {
+                if (element == null || element.isJsonNull()) {
+                        return JsonNull.INSTANCE;
+                }
+
+                JsonElement copy = element.deepCopy();
+                stripComments(copy);
+                return copy;
+        }
+
+        /**
+         * Removes {@code "_comment"} properties from the supplied element in place.
+         *
+         * @param element The element to clean.
+         */
+        public static void stripComments(JsonElement element) {
+                if (element == null || element.isJsonNull()) {
+                        return;
+                }
+
+                if (element.isJsonObject()) {
+                        JsonObject object = element.getAsJsonObject();
+                        object.remove("_comment");
+                        for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
+                                stripComments(entry.getValue());
+                        }
+                } else if (element.isJsonArray()) {
+                        JsonArray array = element.getAsJsonArray();
+                        for (JsonElement child : array) {
+                                stripComments(child);
+                        }
+                }
+        }
+}

--- a/src/main/resources/data/gardenkingmod/bonus_harvest_drops/bonus_harvest_drops.json
+++ b/src/main/resources/data/gardenkingmod/bonus_harvest_drops/bonus_harvest_drops.json
@@ -1,6 +1,8 @@
 {
+  "_comment": "This is a general comment about the file.",
   "minecraft:wheat": [
     {
+      "_comment": "Ruby drops make wheat harvests feel special during events.",
       "item": "gardenkingmod:ruby",
       "chance": 0.15,
       "count": { "min": 1, "max": 1 }

--- a/src/main/resources/data/gardenkingmod/garden_shop_offers.json
+++ b/src/main/resources/data/gardenkingmod/garden_shop_offers.json
@@ -1,8 +1,11 @@
 {
+  "_comment": "Default Garden King shop layout. Use _comment fields anywhere to annotate long pages.",
   "pages": [
     {
+      "_comment": "Page 1: Food and starter upgrades",
       "offers": [
         {
+          "_comment": "Cheese bundle pairs well with early farming.",
           "offer": "croptopia:cheese*2",
           "price": [
             "minecraft:milk_bucket",
@@ -10,6 +13,7 @@
           ]
         },
         {
+          "_comment": "First tier elytra trade for seasonal events.",
           "offer": "minecraft:elytra",
           "price": "gardenkingmod:ruby*1"
         },
@@ -20,6 +24,7 @@
       ]
     },
     {
+      "_comment": "Page 2: Advanced elytra upgrades",
       "offers": [
         {
           "offer": "minecraft:elytra",
@@ -56,6 +61,7 @@
       ]
     },
     {
+      "_comment": "Page 5: High-end elytra trades",
       "offers": [
         {
           "offer": "minecraft:elytra",


### PR DESCRIPTION
## Summary
- add a reusable JsonCommentHelper that strips `_comment` fields from parsed JSON
- update bonus drops, rotten crop definitions, and garden shop offers to sanitize data before parsing
- document the cross-feature comment support and illustrate it in the bundled garden shop offers file

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e41b745b7483218d33411fa41eccf2