### PR TITLE
Fix initial scrollbar knob position in Garden Shop screen

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -311,9 +311,10 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                         return;
                 }
 
-                scrollAmount = MathHelper.clamp(amount, 0.0F, 1.0F);
-                scrollOffset = MathHelper.floor(scrollAmount * maxScrollSteps + 0.5F);
-                scrollOffset = MathHelper.clamp(scrollOffset, 0, maxScrollSteps);
+                float clampedAmount = MathHelper.clamp(amount, 0.0F, 1.0F);
+                int calculatedOffset = MathHelper.floor(clampedAmount * maxScrollSteps + 0.5F);
+                scrollOffset = MathHelper.clamp(calculatedOffset, 0, maxScrollSteps);
+                scrollAmount = maxScrollSteps > 0 ? (float) scrollOffset / (float) maxScrollSteps : 0.0F;
         }
 
         private boolean canScroll() {


### PR DESCRIPTION
## Summary
- ensure the Garden Shop scrollbar knob snaps exactly to the current offer page
- recompute the scroll amount from the discrete offset so the knob sits flush with the track when at the top

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e41e3e52948321b3cd839aea346006