### PR TITLE
Adjust cost count alignment for large numbers

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -281,10 +281,14 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                 }
 
                 String text = Integer.toString(count);
+                int textWidth = textRenderer.getWidth(text);
+                int singleDigitWidth = textRenderer.getWidth("0");
+                int extraOffset = Math.max(0, Math.round((textWidth - singleDigitWidth) / 2.0f));
+
                 MatrixStack matrices = context.getMatrices();
                 matrices.push();
                 matrices.translate(0.0F, 0.0F, 200.0F);
-                context.drawTextWithShadow(textRenderer, text, x + 19 - textRenderer.getWidth(text), y + 6, 0xFFFFFF);
+                context.drawTextWithShadow(textRenderer, text, x + 19 - textWidth + extraOffset, y + 6, 0xFFFFFF);
                 matrices.pop();
         }
 


### PR DESCRIPTION
## Summary
- adjust the shop cost count overlay so large counts shift right similarly to small counts
- calculate an additional offset based on the rendered text width to center larger numbers over the item slot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e44924b63c8321aff57c9dd8d47f60