### PR TITLE
Expose cost count alignment constant

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -48,6 +48,12 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
         private static final int MAX_VISIBLE_OFFERS = OFFER_LIST_HEIGHT / OFFER_ENTRY_HEIGHT;
         private static final int OFFER_ITEM_OFFSET_Y = 2;
         private static final int OFFER_COST_ITEM_OFFSET_X = 6;
+        /**
+         * Controls where the cost stack count overlay hugs the right edge of the
+         * item slot. Increase to nudge the numbers further right, decrease to
+         * pull them left.
+         */
+        private static final int OFFER_COST_COUNT_RIGHT_EDGE = 21;
         private static final int OFFER_COST_ITEM_SPACING = 18;
         private static final int OFFER_RESULT_ITEM_OFFSET_X = 68;
         private static final int OFFER_BACKGROUND_U = 301;
@@ -281,10 +287,16 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                 }
 
                 String text = Integer.toString(count);
+                int textWidth = textRenderer.getWidth(text);
+                int singleDigitWidth = textRenderer.getWidth("0");
+                int extraOffset = Math.max(0, Math.round((textWidth - singleDigitWidth) / 2.0f));
+
                 MatrixStack matrices = context.getMatrices();
                 matrices.push();
                 matrices.translate(0.0F, 0.0F, 200.0F);
-                context.drawTextWithShadow(textRenderer, text, x + 19 - textRenderer.getWidth(text), y + 6, 0xFFFFFF);
+                int overlayRight = x + OFFER_COST_COUNT_RIGHT_EDGE;
+                context.drawTextWithShadow(textRenderer, text, overlayRight - textWidth + extraOffset, y + 6,
+                                0xFFFFFF);
                 matrices.pop();
         }
 


### PR DESCRIPTION
## Summary
- add a configurable right edge constant for shop cost count overlays
- use the constant when positioning the overlay so larger counts can be nudged further right

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e44924b63c8321aff57c9dd8d47f60