### PR TITLE
Add coin sack item and conversion recipes

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/ModItems.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModItems.java
@@ -34,6 +34,7 @@ import net.minecraft.util.Identifier;
 
 public final class ModItems {
         public static final Item GARDEN_COIN = registerItem("garden_coin", new Item(new FabricItemSettings()));
+        public static final Item COIN_SACK = registerItem("coin_sack", new Item(new FabricItemSettings()));
         public static final Item RUBY = registerItem("ruby", new Item(new FabricItemSettings()));
         public static final Item BLUE_SAPPHIRE = registerItem("blue_sapphire", new Item(new FabricItemSettings()));
         public static final Item SCARECROW_SHIRT = registerItem("scarecrow_shirt",
@@ -177,6 +178,7 @@ public final class ModItems {
                 ItemGroupEvents.modifyEntriesEvent(ItemGroups.INGREDIENTS)
                                 .register(entries -> {
                                         entries.add(GARDEN_COIN);
+                                        entries.add(COIN_SACK);
                                         entries.add(RUBY);
                                         entries.add(BLUE_SAPPHIRE);
                                         rottenItems.forEach(entries::add);

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -50,6 +50,7 @@
   "container.gardenkingmod.garden_shop": "Garden Shop",
   "container.gardenkingmod.scarecrow": "Scarecrow",
   "item.gardenkingmod.garden_coin": "Garden Coin",
+  "item.gardenkingmod.coin_sack": "Coin Sack",
   "message.gardenkingmod.market.empty": "There are no crops to sell.",
   "message.gardenkingmod.market.invalid": "Only Crops and Food can be sold here!",
   "message.gardenkingmod.market.sold": "Sold %1$s Croptopia crops for %2$s coins.",

--- a/src/main/resources/assets/gardenkingmod/models/item/coin_sack.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/coin_sack.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "gardenkingmod:item/coin_sack"
+  }
+}

--- a/src/main/resources/data/gardenkingmod/recipes/coin_sack.json
+++ b/src/main/resources/data/gardenkingmod/recipes/coin_sack.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "gardenkingmod:garden_coin"
+    }
+  },
+  "result": {
+    "item": "gardenkingmod:coin_sack"
+  }
+}

--- a/src/main/resources/data/gardenkingmod/recipes/garden_coin_from_coin_sack.json
+++ b/src/main/resources/data/gardenkingmod/recipes/garden_coin_from_coin_sack.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "gardenkingmod:coin_sack"
+    }
+  ],
+  "result": {
+    "item": "gardenkingmod:garden_coin",
+    "count": 9
+  }
+}


### PR DESCRIPTION
## Summary
- add the coin sack item and expose it alongside garden coins in the ingredients tab
- add item model, language entry, and crafting recipes to convert between coins and sacks

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68e4af019cd08321a7563342402a9904