### PR TITLE
Add dollar currency item with conversion recipes

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/ModItems.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModItems.java
@@ -41,6 +41,7 @@ import net.minecraft.util.Identifier;
 public final class ModItems {
         public static final Item GARDEN_COIN = registerItem("garden_coin", new Item(new FabricItemSettings()));
         public static final Item COIN_SACK = registerItem("coin_sack", new Item(new FabricItemSettings()));
+        public static final Item DOLLAR = registerItem("dollar", new Item(new FabricItemSettings()));
         public static final Item RUBY = registerItem("ruby", new Item(new FabricItemSettings()));
         public static final Item BLUE_SAPPHIRE = registerItem("blue_sapphire", new Item(new FabricItemSettings()));
         public static final Item TOPAZ = registerItem("topaz", new Item(new FabricItemSettings()));
@@ -241,6 +242,7 @@ public final class ModItems {
                                 .register(entries -> {
                                         entries.add(GARDEN_COIN);
                                         entries.add(COIN_SACK);
+                                        entries.add(DOLLAR);
                                         entries.add(RUBY);
                                         entries.add(BLUE_SAPPHIRE);
                                         entries.add(TOPAZ);

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -80,6 +80,7 @@
   "container.gardenkingmod.scarecrow": "Scarecrow",
   "item.gardenkingmod.garden_coin": "Garden Coin",
   "item.gardenkingmod.coin_sack": "Coin Sack",
+  "item.gardenkingmod.dollar": "Dollar",
   "message.gardenkingmod.market.empty": "There are no crops to sell.",
   "message.gardenkingmod.market.invalid": "Only Crops and Food can be sold here!",
   "message.gardenkingmod.market.sold": "Sold %1$s Croptopia crops for %2$s coins.",

--- a/src/main/resources/assets/gardenkingmod/models/item/dollar.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/dollar.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "gardenkingmod:item/dollar"
+  }
+}

--- a/src/main/resources/data/gardenkingmod/recipes/coin_sack_from_dollar.json
+++ b/src/main/resources/data/gardenkingmod/recipes/coin_sack_from_dollar.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "gardenkingmod:dollar"
+    }
+  ],
+  "result": {
+    "item": "gardenkingmod:coin_sack",
+    "count": 9
+  }
+}

--- a/src/main/resources/data/gardenkingmod/recipes/dollar.json
+++ b/src/main/resources/data/gardenkingmod/recipes/dollar.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "gardenkingmod:coin_sack"
+    }
+  },
+  "result": {
+    "item": "gardenkingmod:dollar"
+  }
+}


### PR DESCRIPTION
## Summary
- register a new dollar currency item and expose it in the ingredients creative tab
- add item model, texture reference, and localization for the dollar asset
- add crafting recipes to convert between coin sacks and the new dollar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e57380b46c83218424b29480b7db8f