### PR TITLE
Fix scarecrow screen model orientation

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/ScarecrowScreen.java
@@ -156,6 +156,7 @@ public class ScarecrowScreen extends HandledScreen<ScarecrowScreenHandler> {
                 matrices.scale(1.0F, -1.0F, 1.0F);
                 matrices.scale(PREVIEW_SCALE, PREVIEW_SCALE, PREVIEW_SCALE);
                 matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0F));
+                matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
                 matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(pitch * 20.0F));
                 matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(yaw * 40.0F));
 


### PR DESCRIPTION
## Summary
- rotate the scarecrow preview model around the Y axis so it faces the player in the inventory screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5747c847c8321b41e42e0f5aa413b