### PR TITLE
Fix cost slot items being consumed after trades

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
@@ -633,7 +633,11 @@ public class GardenShopScreenHandler extends ScreenHandler {
                         if (stack.isEmpty()) {
                                 continue;
                         }
-                        if (!ItemStack.canCombine(stack, comparisonStack)) {
+                        ItemStack comparisonSource = stack;
+                        if (inventory == this.costInventory) {
+                                comparisonSource = GardenShopStackHelper.copyWithoutRequestedCount(stack);
+                        }
+                        if (!ItemStack.canCombine(comparisonSource, comparisonStack)) {
                                 continue;
                         }
 


### PR DESCRIPTION
## Summary
- ensure cost-slot stacks are compared without helper metadata so they are consumed when processing a purchase

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e740809c54832199a5261190750314