### PR TITLE
Consume cost slot stacks before charging player inventory

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
@@ -523,7 +523,7 @@ public class GardenShopScreenHandler extends ScreenHandler {
                         return false;
                 }
 
-                removeCostStacks(offer.costStacks(), playerInv);
+                boolean costSlotsChanged = removeCostStacks(offer.costStacks(), playerInv);
                 if (!resultTakenFromSlot) {
                         ItemStack result = offer.copyResultStack();
                         if (!result.isEmpty()) {
@@ -534,7 +534,9 @@ public class GardenShopScreenHandler extends ScreenHandler {
                 }
                 populateSelectedOffer(player, offer, false);
                 playerInv.markDirty();
-                this.costInventory.markDirty();
+                if (costSlotsChanged) {
+                        this.costInventory.markDirty();
+                }
                 return true;
         }
 
@@ -602,8 +604,10 @@ public class GardenShopScreenHandler extends ScreenHandler {
                 return providedCount >= requiredCount;
         }
 
-        private void removeCostStacks(List<ItemStack> costs, PlayerInventory playerInventory) {
-                for (ItemStack cost : costs) {
+        private boolean removeCostStacks(List<ItemStack> costs, PlayerInventory playerInventory) {
+                boolean costSlotsChanged = false;
+                for (int index = 0; index < costs.size(); index++) {
+                        ItemStack cost = costs.get(index);
                         if (cost.isEmpty()) {
                                 continue;
                         }
@@ -615,11 +619,55 @@ public class GardenShopScreenHandler extends ScreenHandler {
 
                         ItemStack comparisonStack = GardenShopStackHelper.copyWithoutRequestedCount(cost);
                         int remaining = required;
-                        remaining = removeFromInventory(this.costInventory, comparisonStack, remaining);
+                        if (index < COST_SLOT_COUNT) {
+                                SlotConsumptionResult result = consumeCostSlot(index, comparisonStack, required);
+                                remaining = result.remaining();
+                                if (result.changed()) {
+                                        costSlotsChanged = true;
+                                }
+                        }
                         if (remaining > 0) {
                                 remaining = removeFromInventory(playerInventory, comparisonStack, remaining);
                         }
                 }
+                return costSlotsChanged;
+        }
+
+        private SlotConsumptionResult consumeCostSlot(int slotIndex, ItemStack comparisonStack, int required) {
+                if (required <= 0) {
+                        return new SlotConsumptionResult(0, false);
+                }
+
+                ItemStack slotStack = this.costInventory.getStack(slotIndex);
+                if (slotStack.isEmpty()) {
+                        return new SlotConsumptionResult(required, false);
+                }
+
+                ItemStack comparisonSource = GardenShopStackHelper.copyWithoutRequestedCount(slotStack);
+                if (!ItemStack.canCombine(comparisonSource, comparisonStack)) {
+                        return new SlotConsumptionResult(required, false);
+                }
+
+                int provided = GardenShopStackHelper.getRequestedCount(slotStack);
+                if (provided <= 0) {
+                        this.costInventory.setStack(slotIndex, ItemStack.EMPTY);
+                        return new SlotConsumptionResult(required, true);
+                }
+
+                int consumed = Math.min(provided, required);
+                int leftover = provided - consumed;
+                if (leftover > 0) {
+                        ItemStack replacement = GardenShopStackHelper.copyWithoutRequestedCount(slotStack);
+                        GardenShopStackHelper.applyRequestedCount(replacement, leftover);
+                        this.costInventory.setStack(slotIndex, replacement);
+                } else {
+                        this.costInventory.setStack(slotIndex, ItemStack.EMPTY);
+                }
+
+                return new SlotConsumptionResult(required - consumed, true);
+        }
+
+        private record SlotConsumptionResult(int remaining, boolean changed) {
         }
 
         private int removeFromInventory(Inventory inventory, ItemStack comparisonStack, int remaining) {
@@ -633,7 +681,11 @@ public class GardenShopScreenHandler extends ScreenHandler {
                         if (stack.isEmpty()) {
                                 continue;
                         }
-                        if (!ItemStack.canCombine(stack, comparisonStack)) {
+                        ItemStack comparisonSource = stack;
+                        if (inventory == this.costInventory) {
+                                comparisonSource = GardenShopStackHelper.copyWithoutRequestedCount(stack);
+                        }
+                        if (!ItemStack.canCombine(comparisonSource, comparisonStack)) {
                                 continue;
                         }
 


### PR DESCRIPTION
## Summary
- consume cost slot stacks directly during trades so the slot contents are cleared before pulling from the player inventory
- add helper to track how much was removed from each cost slot and only mark the inventory dirty when needed

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e740809c54832199a5261190750314