### PR TITLE
Allow Garden Shop cost slots to hold large stacks

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/inventory/GardenShopCostInventory.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/inventory/GardenShopCostInventory.java
@@ -1,0 +1,20 @@
+package net.jeremy.gardenkingmod.screen.inventory;
+
+import net.minecraft.inventory.SimpleInventory;
+
+/**
+ * Specialized inventory for Garden Shop cost slots that allows storing stack
+ * counts beyond the vanilla stack limit so large offers can be displayed and
+ * validated without splitting across multiple slots.
+ */
+public class GardenShopCostInventory extends SimpleInventory {
+
+    public GardenShopCostInventory(int size) {
+        super(size);
+    }
+
+    @Override
+    public int getMaxCountPerStack() {
+        return Integer.MAX_VALUE;
+    }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenShopStackHelper.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenShopStackHelper.java
@@ -26,10 +26,10 @@ public final class GardenShopStackHelper {
             return;
         }
 
-        int clamped = Math.max(1, Math.min(requestedCount, stack.getMaxCount()));
-        stack.setCount(clamped);
-        if (requestedCount > clamped) {
-            stack.getOrCreateNbt().putInt(FULL_COUNT_KEY, requestedCount);
+        int sanitized = Math.max(1, requestedCount);
+        stack.setCount(sanitized);
+        if (sanitized > stack.getMaxCount()) {
+            stack.getOrCreateNbt().putInt(FULL_COUNT_KEY, sanitized);
         } else {
             removeFullCount(stack);
         }


### PR DESCRIPTION
## Summary
- add a dedicated Garden Shop cost inventory that accepts stack counts larger than the vanilla limit and update stack helper handling so counts above 64 are retained on the item itself
- override slot transfer logic to aggregate additional items into cost slots when quick-moving or manually placing stacks, enabling offers with high costs to fit in a single slot

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e74c04c3c88321a20f00d04428fc3d