### PR TITLE
Align garden shop cost slot rendering

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -144,8 +144,8 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
 
         @Override
         protected void drawBackground(DrawContext context, float delta, int mouseX, int mouseY) {
-                int originX = (width - backgroundWidth) / 2;
-                int originY = (height - backgroundHeight) / 2;
+                int originX = x;
+                int originY = y;
                 Identifier backgroundTexture = getBackgroundTexture();
                 context.drawTexture(backgroundTexture, originX, originY, 0, 0, backgroundWidth, backgroundHeight,
                                 TEXTURE_WIDTH,
@@ -418,10 +418,8 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
         }
 
         private boolean isPointWithinScrollbar(double mouseX, double mouseY) {
-                int originX = (width - backgroundWidth) / 2;
-                int originY = (height - backgroundHeight) / 2;
-                int scrollbarX = originX + SCROLLBAR_OFFSET_X;
-                int scrollbarY = originY + SCROLLBAR_OFFSET_Y;
+                int scrollbarX = x + SCROLLBAR_OFFSET_X;
+                int scrollbarY = y + SCROLLBAR_OFFSET_Y;
                 return mouseX >= scrollbarX && mouseX < scrollbarX + SCROLLBAR_TRACK_WIDTH && mouseY >= scrollbarY
                                 && mouseY < scrollbarY + SCROLLBAR_TRACK_HEIGHT;
         }
@@ -431,10 +429,8 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                         return false;
                 }
 
-                int originX = (width - backgroundWidth) / 2;
-                int originY = (height - backgroundHeight) / 2;
-                int buttonX = originX + BUY_BUTTON_OFFSET_X;
-                int buttonY = originY + BUY_BUTTON_OFFSET_Y;
+                int buttonX = x + BUY_BUTTON_OFFSET_X;
+                int buttonY = y + BUY_BUTTON_OFFSET_Y;
                 return mouseX >= buttonX && mouseX < buttonX + BUY_BUTTON_WIDTH && mouseY >= buttonY
                                 && mouseY < buttonY + BUY_BUTTON_HEIGHT;
         }
@@ -453,8 +449,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
         }
 
         private void updateScrollFromMouse(double mouseY) {
-                int originY = (height - backgroundHeight) / 2;
-                int scrollbarY = originY + SCROLLBAR_OFFSET_Y;
+                int scrollbarY = y + SCROLLBAR_OFFSET_Y;
                 double relativeY = mouseY - scrollbarY - (SCROLLBAR_KNOB_HEIGHT / 2.0);
                 double available = SCROLLBAR_TRACK_HEIGHT - SCROLLBAR_KNOB_HEIGHT;
                 setScrollAmount((float) (relativeY / available));
@@ -507,12 +502,10 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
         }
 
         private int getTabIndexAt(double mouseX, double mouseY) {
-                int originX = (width - backgroundWidth) / 2;
-                int originY = (height - backgroundHeight) / 2;
-                int tabX = originX + TAB_X;
+                int tabX = x + TAB_X;
                 for (int i = 0; i < TAB_DEFINITIONS.length; i++) {
                         TabDefinition definition = TAB_DEFINITIONS[i];
-                        int tabY = originY + definition.yOffset();
+                        int tabY = y + definition.yOffset();
                         if (isPointWithinTab(mouseX, mouseY, tabX, tabY)) {
                                 return i;
                         }
@@ -535,10 +528,8 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
         }
 
         private int getOfferIndexAt(double mouseX, double mouseY) {
-                int originX = (width - backgroundWidth) / 2;
-                int originY = (height - backgroundHeight) / 2;
-                int listLeft = originX + OFFER_LIST_X;
-                int listTop = originY + OFFER_LIST_Y;
+                int listLeft = x + OFFER_LIST_X;
+                int listTop = y + OFFER_LIST_Y;
 
                 if (mouseX < listLeft || mouseX >= listLeft + OFFER_ENTRY_WIDTH) {
                         return -1;
@@ -565,10 +556,8 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                         return Optional.empty();
                 }
 
-                int originX = (width - backgroundWidth) / 2;
-                int originY = (height - backgroundHeight) / 2;
-                int listLeft = originX + OFFER_LIST_X;
-                int listTop = originY + OFFER_LIST_Y;
+                int listLeft = x + OFFER_LIST_X;
+                int listTop = y + OFFER_LIST_Y;
                 int relativeMouseY = mouseY - listTop;
                 if (relativeMouseY < 0) {
                         return Optional.empty();

--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
@@ -17,6 +17,7 @@ import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
 
 public class GardenShopScreenHandler extends ScreenHandler {
         private static final int HOTBAR_SLOT_COUNT = 9;
@@ -24,15 +25,15 @@ public class GardenShopScreenHandler extends ScreenHandler {
         private static final int PLAYER_INVENTORY_COLUMN_COUNT = 9;
         private static final int PLAYER_INVENTORY_SLOT_COUNT = PLAYER_INVENTORY_ROW_COUNT * PLAYER_INVENTORY_COLUMN_COUNT;
         private static final int SLOT_SIZE = 18;
+        private static final int SLOT_SPACING = SLOT_SIZE * 2;
         private static final int SHOP_SLOT_START_X = 8;
         private static final int PLAYER_INVENTORY_START_Y = 123;
         private static final int PLAYER_INVENTORY_START_X = 132;
         private static final int PLAYER_HOTBAR_Y = 181;
         private static final int PLAYER_HOTBAR_X = 132;
-        private static final int COST_SLOT_COUNT = 2;
+        public static final int COST_SLOT_COUNT = 2;
         private static final int RESULT_SLOT_COUNT = 1;
-        private static final int COST_SLOT_ONE_X = 144;
-        private static final int COST_SLOT_TWO_X = 180;
+        private static final int COST_SLOT_START_X = 144;
         private static final int COST_SLOTS_Y = 45;
         private static final int RESULT_SLOT_X = 244;
         private static final int RESULT_SLOT_Y = 52;
@@ -82,6 +83,15 @@ public class GardenShopScreenHandler extends ScreenHandler {
         private static int decodeOfferIndex(int id) {
                 int value = id & OFFER_INDEX_MASK;
                 return value == OFFER_INDEX_MASK ? -1 : value;
+        }
+
+        public static int getCostSlotX(int slotIndex) {
+                int clampedIndex = MathHelper.clamp(slotIndex, 0, COST_SLOT_COUNT - 1);
+                return COST_SLOT_START_X + clampedIndex * SLOT_SPACING;
+        }
+
+        public static int getCostSlotY() {
+                return COST_SLOTS_Y;
         }
 
         public GardenShopScreenHandler(int syncId, PlayerInventory playerInventory, PacketByteBuf buf) {
@@ -757,8 +767,8 @@ public class GardenShopScreenHandler extends ScreenHandler {
         }
 
         private void addCostSlots() {
-                this.addSlot(new Slot(this.costInventory, 0, COST_SLOT_ONE_X, COST_SLOTS_Y));
-                this.addSlot(new Slot(this.costInventory, 1, COST_SLOT_TWO_X, COST_SLOTS_Y));
+                this.addSlot(new Slot(this.costInventory, 0, getCostSlotX(0), getCostSlotY()));
+                this.addSlot(new Slot(this.costInventory, 1, getCostSlotX(1), getCostSlotY()));
         }
 
         private void addResultSlot() {


### PR DESCRIPTION
## Summary
- ensure the garden shop handler exposes shared helpers for cost slot positions and uses them when constructing slots
- anchor the garden shop screen's coordinate math to the HandledScreen origin so rendered elements line up with the texture

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e74b2b73c08321bc4e78979bbac45b