### PR TITLE
Restore Garden Shop offer list cost counts

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/inventory/GardenShopCostInventory.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/inventory/GardenShopCostInventory.java
@@ -1,0 +1,20 @@
+package net.jeremy.gardenkingmod.screen.inventory;
+
+import net.minecraft.inventory.SimpleInventory;
+
+/**
+ * Specialized inventory for Garden Shop cost slots that allows storing stack
+ * counts beyond the vanilla stack limit so large offers can be displayed and
+ * validated without splitting across multiple slots.
+ */
+public class GardenShopCostInventory extends SimpleInventory {
+
+    public GardenShopCostInventory(int size) {
+        super(size);
+    }
+
+    @Override
+    public int getMaxCountPerStack() {
+        return Integer.MAX_VALUE;
+    }
+}


### PR DESCRIPTION
## Summary
- clamp the visible stack count back to the item's max while preserving the full requested amount in NBT so oversize costs keep their metadata
- ensure Garden Shop offer lists once again render their cost amounts while still allowing oversized payments to be tracked

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e74c04c3c88321a20f00d04428fc3d