### PR TITLE
Fix garden shop offer display for oversized stacks

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenShopStackHelper.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenShopStackHelper.java
@@ -27,8 +27,9 @@ public final class GardenShopStackHelper {
         }
 
         int sanitized = Math.max(1, requestedCount);
-        stack.setCount(sanitized);
-        if (sanitized > stack.getMaxCount()) {
+        int displayCount = Math.min(sanitized, stack.getMaxCount());
+        stack.setCount(displayCount);
+        if (sanitized > displayCount) {
             stack.getOrCreateNbt().putInt(FULL_COUNT_KEY, sanitized);
         } else {
             removeFullCount(stack);


### PR DESCRIPTION
## Summary
- clamp the item stack count written to garden shop offers to the item's maximum stack size
- preserve the full requested amount in NBT so large costs continue to render their custom overlay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e756701d288321b42428371f3b1bb8