### PR TITLE
Add per-page slot layout support for garden shop

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/mixin/SlotAccessor.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/SlotAccessor.java
@@ -1,0 +1,18 @@
+package net.jeremy.gardenkingmod.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.screen.slot.Slot;
+
+@Mixin(Slot.class)
+public interface SlotAccessor {
+        @Accessor("x")
+        @Mutable
+        void setX(int x);
+
+        @Accessor("y")
+        @Mutable
+        void setY(int y);
+}

--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -182,6 +182,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
         @Override
         protected void init() {
                 super.init();
+                handler.setDisplayedPage(activeTab);
                 updateScrollLimits();
                 lastOfferCount = getOffersForActiveTab().size();
         }
@@ -577,6 +578,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                 int clampedIndex = MathHelper.clamp(tabIndex, 0, TAB_DEFINITIONS.length - 1);
                 if (activeTab != clampedIndex) {
                         activeTab = clampedIndex;
+                        handler.setDisplayedPage(activeTab);
                         clearSelectedOffer();
                         setScrollAmount(0.0F);
                         updateScrollLimits();

--- a/src/main/resources/gardenkingmod.mixins.json
+++ b/src/main/resources/gardenkingmod.mixins.json
@@ -9,7 +9,8 @@
                 "BlockMixin",
                 "CropBlockMixin",
                 "CroptopiaCropBlockMixin",
-                "EnchantmentHelperMixin"
+                "EnchantmentHelperMixin",
+                "SlotAccessor"
         ],
         "injectors": {
                 "defaultRequire": 1


### PR DESCRIPTION
## Summary
- add page-specific slot layout data to the garden shop screen handler so cost and result slots can move per page
- update the garden shop screen to request layout changes whenever the active tab changes
- register a Slot accessor mixin to allow the handler to reposition slot coordinates dynamically

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68e75c72fa108321b5f038d1784c4a56