### PR TITLE
Fix garden shop cost slot overlay

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -241,7 +241,9 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                         if (slot.inventory instanceof GardenShopCostInventory && slot.hasStack()) {
                                 int slotX = this.x + slot.x;
                                 int slotY = this.y + slot.y;
-                                drawStackCountOverlay(context, slot.getStack(), slotX, slotY, true);
+                                ItemStack stack = slot.getStack();
+                                context.drawItem(stack, slotX, slotY);
+                                drawStackCountOverlay(context, stack, slotX, slotY, false);
                         }
                 }
         }

--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
@@ -303,7 +303,7 @@ public class GardenShopScreenHandler extends ScreenHandler {
                                         break;
                                 }
 
-                                if (ItemStack.canCombine(slotStack, stack)) {
+                                if (canCombineIgnoringRequestedCount(slotStack, stack)) {
                                         int existing = GardenShopStackHelper.getRequestedCount(slotStack);
                                         int addition = stack.getCount();
                                         if (addition > 0) {
@@ -334,7 +334,8 @@ public class GardenShopScreenHandler extends ScreenHandler {
                         if (slot != null) {
                                 ItemStack slotStack = slot.getStack();
                                 ItemStack cursor = getCursorStack();
-                                if (!slotStack.isEmpty() && !cursor.isEmpty() && ItemStack.canCombine(slotStack, cursor)) {
+                                if (!slotStack.isEmpty() && !cursor.isEmpty()
+                                                && canCombineIgnoringRequestedCount(slotStack, cursor)) {
                                         if (button == 0) {
                                                 int total = GardenShopStackHelper.getRequestedCount(slotStack) + cursor.getCount();
                                                 if (cursor.getCount() > 0) {
@@ -714,8 +715,7 @@ public class GardenShopScreenHandler extends ScreenHandler {
                         return false;
                 }
 
-                ItemStack comparison = GardenShopStackHelper.copyWithoutRequestedCount(required);
-                if (!ItemStack.canCombine(provided, comparison)) {
+                if (!canCombineIgnoringRequestedCount(provided, required)) {
                         return false;
                 }
 
@@ -726,6 +726,12 @@ public class GardenShopScreenHandler extends ScreenHandler {
 
                 int providedCount = GardenShopStackHelper.getRequestedCount(provided);
                 return providedCount >= requiredCount;
+        }
+
+        private static boolean canCombineIgnoringRequestedCount(ItemStack first, ItemStack second) {
+                ItemStack firstComparison = GardenShopStackHelper.copyWithoutRequestedCount(first);
+                ItemStack secondComparison = GardenShopStackHelper.copyWithoutRequestedCount(second);
+                return ItemStack.canCombine(firstComparison, secondComparison);
         }
 
         private boolean removeCostStacks(List<ItemStack> costs, PlayerInventory playerInventory) {


### PR DESCRIPTION
## Summary
- ignore the Garden Shop helper metadata when comparing cost slot stacks so selected offers fill the result slot
- allow combining inventory stacks into cost slots by using the metadata-agnostic comparison helper
- repaint the cost slots after the vanilla overlay so large-cost trades display a single count without a dark bar

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68e767bd7634832187428985c7d3aa3b