### PR TITLE
Refill garden shop offers after purchases

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
@@ -662,7 +662,7 @@ public class GardenShopScreenHandler extends ScreenHandler {
                                 }
                         }
                 }
-                populateSelectedOffer(player, offer, false, false);
+                populateSelectedOffer(player, offer, false, true);
                 playerInv.markDirty();
                 if (costSlotsChanged) {
                         this.costInventory.markDirty();


### PR DESCRIPTION
## Summary
- re-populate the selected garden shop offer from the player's inventory after completing a purchase so large coin sack trades remain repeatable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e76bb253c0832190a810a5c772526e