### PR TITLE
Fix returning large cost stacks from garden shop

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/inventory/GardenShopCostInventory.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/inventory/GardenShopCostInventory.java
@@ -1,6 +1,8 @@
 package net.jeremy.gardenkingmod.screen.inventory;
 
+import net.jeremy.gardenkingmod.shop.GardenShopStackHelper;
 import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.item.ItemStack;
 
 /**
  * Specialized inventory for Garden Shop cost slots that allows storing stack
@@ -16,5 +18,67 @@ public class GardenShopCostInventory extends SimpleInventory {
     @Override
     public int getMaxCountPerStack() {
         return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public ItemStack removeStack(int slot, int amount) {
+        if (amount <= 0) {
+            return ItemStack.EMPTY;
+        }
+
+        ItemStack stack = getStack(slot);
+        if (stack.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+
+        int requestedCount = GardenShopStackHelper.getRequestedCount(stack);
+        if (requestedCount <= stack.getCount()) {
+            return super.removeStack(slot, amount);
+        }
+
+        ItemStack removed = GardenShopStackHelper.copyWithoutRequestedCount(stack);
+        int removedCount = Math.min(Math.min(amount, requestedCount), removed.getMaxCount());
+        removed.setCount(removedCount);
+
+        int remaining = requestedCount - removedCount;
+        if (remaining > 0) {
+            ItemStack replacement = GardenShopStackHelper.copyWithoutRequestedCount(stack);
+            GardenShopStackHelper.applyRequestedCount(replacement, remaining);
+            setStack(slot, replacement);
+        } else {
+            setStack(slot, ItemStack.EMPTY);
+        }
+
+        markDirty();
+        return removed;
+    }
+
+    @Override
+    public ItemStack removeStack(int slot) {
+        ItemStack stack = getStack(slot);
+        if (stack.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+
+        int requestedCount = GardenShopStackHelper.getRequestedCount(stack);
+        if (requestedCount <= stack.getCount()) {
+            return super.removeStack(slot);
+        }
+
+        ItemStack removed = GardenShopStackHelper.copyWithoutRequestedCount(stack);
+        int removedCount = Math.min(requestedCount, removed.getMaxCount());
+        removed.setCount(removedCount);
+
+        int remaining = requestedCount - removedCount;
+        if (remaining > 0) {
+            ItemStack replacement = GardenShopStackHelper.copyWithoutRequestedCount(stack);
+            GardenShopStackHelper.applyRequestedCount(replacement, remaining);
+            setStack(slot, replacement);
+        } else {
+            setStack(slot, ItemStack.EMPTY);
+        }
+
+        markDirty();
+        return removed;
     }
 }


### PR DESCRIPTION
## Summary
- prevent Garden Shop cost slots from deleting extra items when removing stacks larger than the vanilla limit
- ensure oversized cost stacks keep their remaining items in the slot after each pickup

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e76db1cf1083218b343c7193057aa9