### PR TITLE
Restore requested counts when removing cost slot stacks

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/inventory/GardenShopCostInventory.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/inventory/GardenShopCostInventory.java
@@ -66,17 +66,8 @@ public class GardenShopCostInventory extends SimpleInventory {
         }
 
         ItemStack removed = GardenShopStackHelper.copyWithoutRequestedCount(stack);
-        int removedCount = Math.min(requestedCount, removed.getMaxCount());
-        removed.setCount(removedCount);
-
-        int remaining = requestedCount - removedCount;
-        if (remaining > 0) {
-            ItemStack replacement = GardenShopStackHelper.copyWithoutRequestedCount(stack);
-            GardenShopStackHelper.applyRequestedCount(replacement, remaining);
-            setStack(slot, replacement);
-        } else {
-            setStack(slot, ItemStack.EMPTY);
-        }
+        GardenShopStackHelper.applyRequestedCount(removed, requestedCount);
+        setStack(slot, ItemStack.EMPTY);
 
         markDirty();
         return removed;


### PR DESCRIPTION
## Summary
- ensure cost inventory removals keep the helper requested count metadata so large refunds are accurate

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e76fc263b883219df7cf0a1689ef06