### PR TITLE
Hide vanilla cost stack counts in Garden Shop UI

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -243,7 +243,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                                 int slotY = this.y + slot.y;
                                 ItemStack stack = slot.getStack();
                                 context.drawItem(stack, slotX, slotY);
-                                drawStackCountOverlay(context, stack, slotX, slotY, false);
+                                drawStackCountOverlay(context, stack, slotX, slotY, true);
                         }
                 }
         }


### PR DESCRIPTION
## Summary
- mask the vanilla stack count overlay when rendering Garden Shop cost slots so only the custom cost amount is visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e774bf3dd483219850b170e65d4184