### PR TITLE
Preserve helper metadata when removing cost stacks

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/inventory/GardenShopCostInventory.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/inventory/GardenShopCostInventory.java
@@ -65,7 +65,7 @@ public class GardenShopCostInventory extends SimpleInventory {
             return super.removeStack(slot);
         }
 
-        ItemStack removed = GardenShopStackHelper.copyWithoutRequestedCount(stack);
+        ItemStack removed = stack.copy();
         GardenShopStackHelper.applyRequestedCount(removed, requestedCount);
         setStack(slot, ItemStack.EMPTY);
 


### PR DESCRIPTION
## Summary
- prevent Garden Shop cost slots from deleting extra items when removing stacks larger than the vanilla limit
- ensure oversized cost stacks keep their remaining items in the slot after each pickup
- preserve helper metadata when removing stored cost stacks so refunds return the full requested count

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e7c8523ee08321a240aae1f7ff5800