### PR TITLE
Ensure garden shop auto-refill returns leftover cost items

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
@@ -662,7 +662,7 @@ public class GardenShopScreenHandler extends ScreenHandler {
                                 }
                         }
                 }
-                populateSelectedOffer(player, offer, false, true);
+                populateSelectedOffer(player, offer, true, true);
                 playerInv.markDirty();
                 if (costSlotsChanged) {
                         this.costInventory.markDirty();


### PR DESCRIPTION
## Summary
- return existing cost slot contents to the player before refilling after a purchase to avoid deleting leftovers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7ca132ed083218d4f07af0559a6b9