### PR TITLE
Fix garden shop cost slots returning full costs

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
@@ -504,15 +504,28 @@ public class GardenShopScreenHandler extends ScreenHandler {
                 boolean changed = false;
                 PlayerInventory playerInventory = player.getInventory();
                 for (int slot = 0; slot < this.costInventory.size(); slot++) {
-                        ItemStack stack = this.costInventory.removeStack(slot);
-                        if (stack.isEmpty()) {
+                        ItemStack original = this.costInventory.getStack(slot);
+                        if (original.isEmpty()) {
                                 continue;
                         }
 
-                        int requested = Math.max(GardenShopStackHelper.getRequestedCount(stack), stack.getCount());
-                        ItemStack comparison = GardenShopStackHelper.copyWithoutRequestedCount(stack);
+                        int requested = GardenShopStackHelper.getRequestedCount(original);
+                        ItemStack comparison = GardenShopStackHelper.copyWithoutRequestedCount(original);
+                        ItemStack removed = this.costInventory.removeStack(slot);
+                        if (removed.isEmpty()) {
+                                continue;
+                        }
+
+                        if (requested <= 0) {
+                                requested = Math.max(GardenShopStackHelper.getRequestedCount(removed), removed.getCount());
+                        }
+
                         if (comparison.isEmpty()) {
-                                comparison = stack.copy();
+                                comparison = GardenShopStackHelper.copyWithoutRequestedCount(removed);
+                        }
+
+                        if (comparison.isEmpty()) {
+                                comparison = removed.copy();
                                 comparison.setCount(Math.min(requested, comparison.getMaxCount()));
                         }
 

--- a/src/main/java/net/jeremy/gardenkingmod/screen/inventory/GardenShopCostInventory.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/inventory/GardenShopCostInventory.java
@@ -36,13 +36,13 @@ public class GardenShopCostInventory extends SimpleInventory {
             return super.removeStack(slot, amount);
         }
 
-        ItemStack removed = GardenShopStackHelper.copyWithoutRequestedCount(stack);
-        int removedCount = Math.min(Math.min(amount, requestedCount), removed.getMaxCount());
-        removed.setCount(removedCount);
+        int removedCount = Math.min(amount, requestedCount);
+        ItemStack removed = stack.copy();
+        GardenShopStackHelper.applyRequestedCount(removed, removedCount);
 
         int remaining = requestedCount - removedCount;
         if (remaining > 0) {
-            ItemStack replacement = GardenShopStackHelper.copyWithoutRequestedCount(stack);
+            ItemStack replacement = stack.copy();
             GardenShopStackHelper.applyRequestedCount(replacement, remaining);
             setStack(slot, replacement);
         } else {
@@ -61,24 +61,10 @@ public class GardenShopCostInventory extends SimpleInventory {
         }
 
         int requestedCount = GardenShopStackHelper.getRequestedCount(stack);
-        if (requestedCount <= stack.getCount()) {
-            return super.removeStack(slot);
+        if (requestedCount <= 0) {
+            return ItemStack.EMPTY;
         }
 
-        ItemStack removed = GardenShopStackHelper.copyWithoutRequestedCount(stack);
-        int removedCount = Math.min(requestedCount, removed.getMaxCount());
-        removed.setCount(removedCount);
-
-        int remaining = requestedCount - removedCount;
-        if (remaining > 0) {
-            ItemStack replacement = GardenShopStackHelper.copyWithoutRequestedCount(stack);
-            GardenShopStackHelper.applyRequestedCount(replacement, remaining);
-            setStack(slot, replacement);
-        } else {
-            setStack(slot, ItemStack.EMPTY);
-        }
-
-        markDirty();
-        return removed;
+        return removeStack(slot, requestedCount);
     }
 }


### PR DESCRIPTION
## Summary
- preserve the full requested count metadata when removing stacks from the garden shop cost inventory so large costs return correctly
- restore garden shop cost returns using the pre-removal stack data so full requested counts are reinserted into the player inventory

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7de7c85548321aee1b5387196a85f