### PR TITLE
Ensure extra cost items are returned from Garden Shop slots

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
@@ -628,9 +628,10 @@ public class GardenShopScreenHandler extends ScreenHandler {
                         return CostReturnResult.NO_CHANGE;
                 }
 
-                int requested = GardenShopStackHelper.getRequestedCount(originalCopy);
+                int provided = Math.max(GardenShopStackHelper.getRequestedCount(removed), removed.getCount());
+                int requested = Math.max(GardenShopStackHelper.getRequestedCount(originalCopy), provided);
                 if (requested <= 0) {
-                        requested = Math.max(GardenShopStackHelper.getRequestedCount(removed), removed.getCount());
+                        requested = provided;
                 }
 
                 ItemStack comparison = GardenShopStackHelper.copyWithoutRequestedCount(originalCopy);


### PR DESCRIPTION
## Summary
- ensure Garden Shop cost slots refund the full amount actually provided instead of only the template requirement

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e80ae2fe348321bae7b00aa0f641ca