### PR TITLE
Restore vanilla stack counts in offer list

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -427,31 +427,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
 
         private void drawCostStack(DrawContext context, ItemStack stack, int x, int y) {
                 context.drawItem(stack, x, y);
-                drawStackCountOverlay(context, stack, x, y, false);
-        }
-
-        private void drawStackCountOverlay(DrawContext context, ItemStack stack, int x, int y, boolean hideVanillaCount) {
-                int count = GardenShopStackHelper.getRequestedCount(stack);
-                if (count <= 1) {
-                        return;
-                }
-
-                PageLayout layout = getPageLayout();
-                String label = Text.translatable(COST_LABEL_TRANSLATION_KEY).getString();
-                String text = formatRequestedCount(count);
-
-                RenderSystem.disableDepthTest();
-                RenderSystem.enableBlend();
-                RenderSystem.defaultBlendFunc();
-                RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-
-                drawCostTextLine(context, label, x + layout.costTextLabelAnchorOffsetX(),
-                                y + layout.costTextLabelOffsetY(), layout.costTextScale());
-                drawCostTextLine(context, text, x + layout.costTextValueAnchorOffsetX(),
-                                y + layout.costTextValueOffsetY(), layout.costTextScale());
-
-                RenderSystem.disableBlend();
-                RenderSystem.enableDepthTest();
+                context.drawItemInSlot(textRenderer, stack, x, y);
         }
 
         private void drawCostSlotText(DrawContext context, String label, ItemStack stack, int slotX, int slotY,


### PR DESCRIPTION
## Summary
- restore vanilla stack count rendering for offer list entries to remove custom cost labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8324eced48321abfaea1420339661