### PR TITLE
Show full requested counts on offer cost stacks

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -427,31 +427,14 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
 
         private void drawCostStack(DrawContext context, ItemStack stack, int x, int y) {
                 context.drawItem(stack, x, y);
-                drawStackCountOverlay(context, stack, x, y, false);
-        }
 
-        private void drawStackCountOverlay(DrawContext context, ItemStack stack, int x, int y, boolean hideVanillaCount) {
-                int count = GardenShopStackHelper.getRequestedCount(stack);
-                if (count <= 1) {
-                        return;
+                int requestedCount = GardenShopStackHelper.getRequestedCount(stack);
+                if (requestedCount > stack.getCount()) {
+                        String label = formatRequestedCount(requestedCount);
+                        context.drawItemInSlot(textRenderer, stack, x, y, label);
+                } else {
+                        context.drawItemInSlot(textRenderer, stack, x, y);
                 }
-
-                PageLayout layout = getPageLayout();
-                String label = Text.translatable(COST_LABEL_TRANSLATION_KEY).getString();
-                String text = formatRequestedCount(count);
-
-                RenderSystem.disableDepthTest();
-                RenderSystem.enableBlend();
-                RenderSystem.defaultBlendFunc();
-                RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-
-                drawCostTextLine(context, label, x + layout.costTextLabelAnchorOffsetX(),
-                                y + layout.costTextLabelOffsetY(), layout.costTextScale());
-                drawCostTextLine(context, text, x + layout.costTextValueAnchorOffsetX(),
-                                y + layout.costTextValueOffsetY(), layout.costTextScale());
-
-                RenderSystem.disableBlend();
-                RenderSystem.enableDepthTest();
         }
 
         private void drawCostSlotText(DrawContext context, String label, ItemStack stack, int slotX, int slotY,


### PR DESCRIPTION
## Summary
- render offer cost stacks with vanilla overlay when counts fit in the stack
- show the formatted requested count when it exceeds the visible stack count so expensive offers remain accurate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8324eced48321abfaea1420339661