### PR TITLE
Align result slot animation with page layout

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -628,8 +628,8 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                         animationTicks = 0.0F;
                 }
 
-                int slotLeft = this.x + resultSlot.x;
-                int slotTop = this.y + resultSlot.y;
+                int slotLeft = this.x + handler.getResultSlotX();
+                int slotTop = this.y + handler.getResultSlotY();
                 float slotCenterX = slotLeft + 8.0F;
                 float slotCenterY = slotTop + 8.0F;
 


### PR DESCRIPTION
## Summary
- anchor the rotating result item to the page-specific slot coordinates provided by the screen handler so it stays aligned with the GUI

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e899835e908321b4de7d73d2129c3f