### PR TITLE
Fix result slot animation scaling

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -688,6 +688,11 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                         matrices.translate(0.0F, bobTranslation, 0.0F);
                 }
 
+                float scale = animation.scale();
+                if (scale != 1.0F) {
+                        matrices.scale(scale, scale, scale);
+                }
+
                 if (animation.rotationPeriodTicks() > 0.0F) {
                         float rotationDegrees = ((animationTicks + animation.rotationPhaseTicks())
                                         / animation.rotationPeriodTicks()) * 360.0F;


### PR DESCRIPTION
## Summary
- apply the configured animation scale when drawing the animated result slot so the rendered item keeps its intended size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8a51934bc8321b75a39ce4dfea964