### PR TITLE
Fix result slot animation scale

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -14,6 +14,7 @@ import net.jeremy.gardenkingmod.screen.inventory.GardenShopCostInventory;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.render.DiffuseLighting;
 import net.minecraft.client.render.LightmapTextureManager;
 import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.item.ItemRenderer;
@@ -723,10 +724,20 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
 
                 ItemRenderer renderer = minecraftClient.getItemRenderer();
                 BakedModel model = renderer.getModel(stack, null, null, 0);
-                renderer.renderItem(stack, ModelTransformationMode.GUI, false, context.getMatrices(),
-                                context.getVertexConsumers(), LightmapTextureManager.MAX_LIGHT_COORDINATE,
-                                OverlayTexture.DEFAULT_UV, model);
+                MatrixStack matrices = context.getMatrices();
+                matrices.push();
+                matrices.scale(16.0F, -16.0F, 16.0F);
+                boolean disableLighting = !model.isSideLit();
+                if (disableLighting) {
+                        DiffuseLighting.disableGuiDepthLighting();
+                }
+                renderer.renderItem(stack, ModelTransformationMode.GUI, false, matrices, context.getVertexConsumers(),
+                                LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, model);
                 context.draw();
+                if (disableLighting) {
+                        DiffuseLighting.enableGuiDepthLighting();
+                }
+                matrices.pop();
         }
 
         private Slot getResultSlot() {


### PR DESCRIPTION
## Summary
- scale the animated result-slot item using GUI-appropriate transforms so it renders at full size
- restore GUI lighting around the custom render so side-lit models stay consistent

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e8a6860f648321a1217db9a73c6630