### PR TITLE
Document and resolve key GardenShopScreen warnings

### DIFF
--- a/docs/gardenshop-warning-audit.md
+++ b/docs/gardenshop-warning-audit.md
@@ -1,0 +1,25 @@
+# Garden Shop Screen Warning Audit
+
+This document summarizes the IntelliJ inspections that were triggered while
+working on `GardenShopScreen` and explains whether each warning requires code
+changes.
+
+## Addressed warnings
+
+| Warning message | Resolution | Notes |
+| --- | --- | --- |
+| `Statement lambda can be replaced with expression lambda` | Converted the inventory listeners in `GardenShopScreenHandler` to method references so the lambda expression noise is removed. | No behavioural change – simply cleaner syntax. |
+| `Condition 'scale != 1.0F' is always 'true'` | Simplified the buy-button label rendering path to always apply the scale transform, which eliminates the redundant branch. | The translation math now works for both scaled and unscaled labels. |
+| `Result of 'max' is the same as the first argument making the call meaningless`<br>`Condition 'maxScrollSteps > 0' is always 'true'` | Tightened the scrolling helpers so they only run when the list can actually scroll. We now divide by `maxScrollSteps` directly and document why zero is impossible in that branch. | The guard clauses still prevent divide-by-zero issues. |
+| `Condition 'row < 0' is always 'false'` | Removed redundant negative-row checks. Earlier bounds checks already ensured the row index cannot be negative. | The logic is clearer and the redundant comparisons disappear. |
+
+## Warnings that are acceptable (no change)
+
+| Warning message | Reasoning |
+| --- | --- |
+| `Calls to boolean method 'canScroll()' are always inverted` | Each call site intentionally uses `!canScroll()` so the method acts as a guard clause. In the positive branch `canScroll()` is known to be `true`, which is why the IDE thinks it is inverted. The logic is correct and more readable this way. |
+| "Value of parameter '…' is always …" in the layout builder lambdas | Each builder invocation explicitly documents which constant governs a coordinate or spacing. Although the IDE flags the parameters as constant, the builder API is designed so layouts can override the values later. Keeping the constants in one place makes it easier to tweak page layouts without hunting through multiple methods. |
+| `Return value of the method is never used` for builder calls | The builder methods return `this` to support fluent chaining. Some call sites prefer statement style for readability, so the return value is intentionally ignored. The fluent contract is used in other places (e.g. `PageLayout.defaults()`), so changing the signature to `void` would break that idiom. |
+
+If new warnings appear that do not fall into these categories, give them a second
+look – they may uncover a genuine bug.

--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreen.java
@@ -292,20 +292,13 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                         MatrixStack matrices = context.getMatrices();
                         matrices.push();
                         float scale = BUY_LABEL_SCALE;
-                        double labelX = layout.buyLabelX();
-                        double labelY = layout.buyLabelY();
-                        if (scale != 1.0F) {
-                                float textWidth = textRenderer.getWidth(buyText);
-                                float textHeight = textRenderer.fontHeight;
-                                labelX += (1.0F - scale) * textWidth / 2.0F;
-                                labelY += (1.0F - scale) * textHeight / 2.0F;
-                                matrices.translate(labelX, labelY, 0.0F);
-                                matrices.scale(scale, scale, 1.0F);
-                                context.drawText(textRenderer, buyText, 0, 0, 0xFFFFFF, false);
-                        } else {
-                                context.drawText(textRenderer, buyText, layout.buyLabelX(), layout.buyLabelY(), 0xFFFFFF,
-                                                false);
-                        }
+                        float textWidth = textRenderer.getWidth(buyText);
+                        float textHeight = textRenderer.fontHeight;
+                        double adjustedX = layout.buyLabelX() + (1.0F - scale) * textWidth / 2.0F;
+                        double adjustedY = layout.buyLabelY() + (1.0F - scale) * textHeight / 2.0F;
+                        matrices.translate(adjustedX, adjustedY, 0.0F);
+                        matrices.scale(scale, scale, 1.0F);
+                        context.drawText(textRenderer, buyText, 0, 0, 0xFFFFFF, false);
                         matrices.pop();
                 }
         }
@@ -410,7 +403,9 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                         return super.mouseScrolled(mouseX, mouseY, amount);
                 }
 
-                float scrollDelta = (float) (amount / (double) Math.max(maxScrollSteps, 1));
+                // At this point {@link #canScroll()} has already short-circuited when
+                // maxScrollSteps == 0, so dividing by maxScrollSteps is safe.
+                float scrollDelta = (float) (amount / (double) maxScrollSteps);
                 setScrollAmount(scrollAmount - scrollDelta);
                 return true;
         }
@@ -828,7 +823,9 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                 float clampedAmount = MathHelper.clamp(amount, 0.0F, 1.0F);
                 int calculatedOffset = MathHelper.floor(clampedAmount * maxScrollSteps + 0.5F);
                 scrollOffset = MathHelper.clamp(calculatedOffset, 0, maxScrollSteps);
-                scrollAmount = maxScrollSteps > 0 ? (float) scrollOffset / (float) maxScrollSteps : 0.0F;
+                // maxScrollSteps cannot be zero here because the method returns early
+                // when {@link #canScroll()} is false.
+                scrollAmount = (float) scrollOffset / (float) maxScrollSteps;
         }
 
         private boolean canScroll() {
@@ -1130,7 +1127,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                 }
 
                 int row = (int) (localY / OFFER_ENTRY_HEIGHT);
-                if (row < 0 || row >= MAX_VISIBLE_OFFERS) {
+                if (row >= MAX_VISIBLE_OFFERS) {
                         return -1;
                 }
 
@@ -1154,7 +1151,7 @@ public class GardenShopScreen extends HandledScreen<GardenShopScreenHandler> {
                 }
 
                 int row = relativeMouseY / OFFER_ENTRY_HEIGHT;
-                if (row < 0 || row >= MAX_VISIBLE_OFFERS) {
+                if (row >= MAX_VISIBLE_OFFERS) {
                         return Optional.empty();
                 }
 

--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenShopScreenHandler.java
@@ -154,8 +154,8 @@ public class GardenShopScreenHandler extends ScreenHandler {
                 this.inventory = blockEntity != null ? blockEntity : new SimpleInventory(GardenShopBlockEntity.INVENTORY_SIZE);
                 this.costInventory = new GardenShopCostInventory(COST_SLOT_COUNT);
                 this.resultInventory = new SimpleInventory(RESULT_SLOT_COUNT);
-                this.costInventory.addListener(inventory -> onContentChanged(inventory));
-                this.resultInventory.addListener(inventory -> onContentChanged(inventory));
+                this.costInventory.addListener(this::onContentChanged);
+                this.resultInventory.addListener(this::onContentChanged);
                 this.offersByPage = new ArrayList<>();
 
                 checkSize(this.inventory, GardenShopBlockEntity.INVENTORY_SIZE);


### PR DESCRIPTION
## Summary
- simplify the Garden Shop buy-button label transform and clarify scroll math to eliminate redundant conditions
- switch screen handler inventory listeners to method references and trim unreachable row checks
- add a warning audit document that captures which inspections were fixed and which remain intentional

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e8b84cbe048321ab529ac5429bca9b