### PR TITLE
Align buy tab background with sell layout

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -429,11 +429,12 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         }
 
         private int getBuyBackgroundX() {
-                return (this.width - BuyBackground.BACKGROUND_WIDTH) / 2;
+                int extraWidth = Math.max(0, BuyBackground.BACKGROUND_WIDTH - this.backgroundWidth);
+                return this.x - extraWidth;
         }
 
         private int getBuyBackgroundY() {
-                return (this.height - BuyBackground.BACKGROUND_HEIGHT) / 2;
+                return this.y;
         }
 
         private void resetBuyTabState() {


### PR DESCRIPTION
## Summary
- offset the market buy tab background so the inventory portion aligns with the sell layout
- anchor the buy background vertically with the sell screen for a consistent transition

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e9ef17877083219a13b0fbdc155dbc