### PR TITLE
Disable market sell slots while viewing buy tab

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -347,6 +347,9 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
                         return;
                 }
                 this.activeTab = tab;
+                if (this.handler != null) {
+                        this.handler.setMarketSlotsEnabled(tab == Tab.SELL);
+                }
                 updateTabButtonState();
                 updateSellButtonVisibility();
                 if (tab == Tab.BUY) {


### PR DESCRIPTION
## Summary
- add a toggleable sell slot implementation so the market inventory can be disabled
- switch the market screen to disable sell slots when the buy tab is active

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e9f5bd93d48321977631ecb369fe25