### PR TITLE
Return market sell items when switching to buy tab

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
@@ -156,16 +156,25 @@ public class MarketBlockEntity extends BlockEntity implements ExtendedScreenHand
         @Override
         public void onClose(PlayerEntity player) {
                 Inventory.super.onClose(player);
+                returnItemsToPlayer(player);
+        }
+
+        public boolean returnItemsToPlayer(PlayerEntity player) {
                 if (!(player instanceof ServerPlayerEntity serverPlayer)) {
-                        return;
+                        return false;
                 }
+
+                boolean changed = false;
 
                 for (int slot = 0; slot < size(); slot++) {
                         ItemStack remainingStack = removeStack(slot);
                         if (!remainingStack.isEmpty()) {
                                 insertOrDrop(serverPlayer, remainingStack);
+                                changed = true;
                         }
                 }
+
+                return changed;
         }
 
         @Override

--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
@@ -176,7 +176,11 @@ public class MarketScreenHandler extends ScreenHandler {
                         }
 
                         if (id == BUTTON_SELECT_BUY_TAB) {
+                                boolean returnedItems = blockEntity.returnItemsToPlayer(player);
                                 setMarketSlotsEnabled(false);
+                                if (returnedItems) {
+                                        sendContentUpdates();
+                                }
                                 return true;
                         }
                 }


### PR DESCRIPTION
## Summary
- add a reusable helper to return the market's stored items back to a player
- call the helper when the buy tab is selected so sell-slot contents immediately go back to the player

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e9fad993208321b201e8ef6f498b4f