### PR TITLE
Keep market tab buttons stationary across tabs

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -431,14 +431,12 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         }
 
         private void updateTabButtonPositions() {
-                int baseX = activeTab == Tab.BUY ? getBuyBackgroundX() : this.x;
-                int baseY = activeTab == Tab.BUY ? getBuyBackgroundY() : this.y;
-                int buttonY = baseY + TAB_BUTTON_Y_OFFSET;
+                int buttonY = this.y + TAB_BUTTON_Y_OFFSET;
                 if (sellTabButton != null) {
-                        sellTabButton.reposition(baseX + SELL_TAB_TEXT_X - TAB_BUTTON_TEXT_PADDING_X, buttonY);
+                        sellTabButton.reposition(this.x + SELL_TAB_TEXT_X - TAB_BUTTON_TEXT_PADDING_X, buttonY);
                 }
                 if (buyTabButton != null) {
-                        buyTabButton.reposition(baseX + BUY_TAB_TEXT_X - TAB_BUTTON_TEXT_PADDING_X, buttonY);
+                        buyTabButton.reposition(this.x + BUY_TAB_TEXT_X - TAB_BUTTON_TEXT_PADDING_X, buttonY);
                 }
         }
 


### PR DESCRIPTION
## Summary
- keep the Market screen's Buy and Sell tab buttons at a fixed screen position
- remove the conditional repositioning that shifted the tab hitboxes when swapping between tabs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9fca09b988321a4ede1b6e0f19cbf