### PR TITLE
Display market sale results as toast notifications

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/gui/toast/SaleResultToast.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/gui/toast/SaleResultToast.java
@@ -1,0 +1,36 @@
+package net.jeremy.gardenkingmod.client.gui.toast;
+
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.toast.Toast;
+import net.minecraft.client.toast.ToastManager;
+import net.minecraft.text.Text;
+
+public class SaleResultToast implements Toast {
+        private static final long DISPLAY_DURATION_MS = 5000L;
+        private static final int WIDTH = 160;
+        private static final int HEIGHT = 32;
+
+        private final Text primaryLine;
+        private final Text secondaryLine;
+
+        public SaleResultToast(Text primaryLine, Text secondaryLine) {
+                this.primaryLine = primaryLine == null ? Text.empty() : primaryLine;
+                this.secondaryLine = secondaryLine == null ? Text.empty() : secondaryLine;
+        }
+
+        @Override
+        public Visibility draw(DrawContext context, ToastManager manager, long startTime) {
+                context.drawTexture(TEXTURE, 0, 0, 0, 0, WIDTH, HEIGHT);
+
+                TextRenderer textRenderer = manager.getClient().textRenderer;
+                if (!primaryLine.getString().isEmpty()) {
+                        context.drawTextWithShadow(textRenderer, primaryLine, 30, 7, 0xFFFFFF);
+                }
+                if (!secondaryLine.getString().isEmpty()) {
+                        context.drawTextWithShadow(textRenderer, secondaryLine, 30, 18, 0xFFFFFF);
+                }
+
+                return startTime >= DISPLAY_DURATION_MS ? Visibility.HIDE : Visibility.SHOW;
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.client.gui.toast.SaleResultToast;
 import net.jeremy.gardenkingmod.shop.GearShopOffer;
 import net.jeremy.gardenkingmod.shop.GearShopOfferManager;
 import net.jeremy.gardenkingmod.shop.GearShopStackHelper;
@@ -53,8 +54,6 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         private static final int BUY_TAB_TEXT_X = 54;
         private static final int SCOREBOARD_BAND_TOP = 107;
         private static final int SCOREBOARD_BAND_BOTTOM = 138;
-        private static final int RESULT_TEXT_TOP_OFFSET = -5;
-        private static final int RESULT_TEXT_LINE_SPACING = 12;
 
         private static final int BUY_HEADER_COLOR = 0x404040;
         private static final int BUY_OFFERS_LABEL_X = 10;
@@ -222,6 +221,8 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
                         }
                         this.lifetimeResultLine = Text.empty();
                 }
+
+                showSaleResultToast();
         }
 
         private Text buildSoldItemsText(Map<Item, Integer> soldItemCounts) {
@@ -253,20 +254,21 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
                         context.getMatrices().pop();
                         return;
                 }
+        }
 
-                if (lastItemsSold < 0 || saleResultLine == null || saleResultLine.getString().isEmpty()) {
+        private void showSaleResultToast() {
+                if (client == null || client.getToastManager() == null) {
                         return;
                 }
 
-                int firstLineY = RESULT_TEXT_TOP_OFFSET;
-                int firstLineX = (backgroundWidth - textRenderer.getWidth(saleResultLine)) / 2;
-                context.drawText(textRenderer, saleResultLine, firstLineX, firstLineY, 0xFFFFFF, false);
-
-                if (lastLifetimeTotal >= 0 && lifetimeResultLine != null && !lifetimeResultLine.getString().isEmpty()) {
-                        int secondLineY = firstLineY + RESULT_TEXT_LINE_SPACING;
-                        int secondLineX = (backgroundWidth - textRenderer.getWidth(lifetimeResultLine)) / 2;
-                        context.drawText(textRenderer, lifetimeResultLine, secondLineX, secondLineY, 0xFFFFFF, false);
+                if (saleResultLine == null || saleResultLine.getString().isEmpty()) {
+                        return;
                 }
+
+                Text secondaryLine = lifetimeResultLine != null && !lifetimeResultLine.getString().isEmpty()
+                                ? lifetimeResultLine
+                                : Text.empty();
+                client.getToastManager().add(new SaleResultToast(saleResultLine, secondaryLine));
         }
 
         @Override


### PR DESCRIPTION
## Summary
- add a custom toast that renders sale result messages in the bottom-right notification area
- update the market screen to trigger the toast and stop drawing the scoreboard text inside the GUI

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e9fbd647348321add0fed3aca3d89a