### PR TITLE
Remove unused cost and buy labels from market buy tab

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/datagen/RottenLanguageProvider.java
+++ b/src/main/java/net/jeremy/gardenkingmod/datagen/RottenLanguageProvider.java
@@ -30,8 +30,6 @@ public final class RottenLanguageProvider extends FabricLanguageProvider {
                 translationBuilder.add("screen.gardenkingmod.market.tab.sell", "Sell");
                 translationBuilder.add("screen.gardenkingmod.market.tab.buy", "Buy");
                 translationBuilder.add("screen.gardenkingmod.market.offers", "OFFERS");
-                translationBuilder.add("screen.gardenkingmod.market.cost_label", "COST");
-                translationBuilder.add("screen.gardenkingmod.market.buy_label", "BUY");
                 translationBuilder.add("screen.gardenkingmod.market.cost_count", "%s required");
                 translationBuilder.add("screen.gardenkingmod.market.sale_result",
                                 "You sold %1$s crops and earned %2$s garden coins.");

--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -58,10 +58,6 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         private static final int BUY_HEADER_COLOR = 0x404040;
         private static final int BUY_OFFERS_LABEL_X = 6;
         private static final int BUY_OFFERS_LABEL_Y = 22;
-        private static final int BUY_COST_LABEL_X = 58;
-        private static final int BUY_COST_LABEL_Y = 20;
-        private static final int BUY_RESULT_LABEL_X = 156;
-        private static final int BUY_RESULT_LABEL_Y = 20;
 
         private static final int BUY_OFFER_LIST_X = 5;
         private static final int BUY_OFFER_LIST_Y = 32;
@@ -462,10 +458,6 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         private void drawBuyLabels(DrawContext context) {
                 context.drawText(textRenderer, Text.translatable("screen.gardenkingmod.market.offers"),
                                 BUY_OFFERS_LABEL_X, BUY_OFFERS_LABEL_Y, BUY_HEADER_COLOR, false);
-                context.drawText(textRenderer, Text.translatable("screen.gardenkingmod.market.cost_label"),
-                                BUY_COST_LABEL_X, BUY_COST_LABEL_Y, BUY_HEADER_COLOR, false);
-                context.drawText(textRenderer, Text.translatable("screen.gardenkingmod.market.buy_label"),
-                                BUY_RESULT_LABEL_X, BUY_RESULT_LABEL_Y, BUY_HEADER_COLOR, false);
         }
 
         private void drawBuyOfferList(DrawContext context, int originX, int originY, int mouseX, int mouseY) {

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -94,8 +94,6 @@
   "screen.gardenkingmod.market.tab.sell": "Sell",
   "screen.gardenkingmod.market.tab.buy": "Buy",
   "screen.gardenkingmod.market.offers": "OFFERS",
-  "screen.gardenkingmod.market.cost_label": "COST",
-  "screen.gardenkingmod.market.buy_label": "BUY",
   "screen.gardenkingmod.market.cost_count": "%s required",
   "screen.gardenkingmod.gear_shop.offers": "OFFERS",
   "screen.gardenkingmod.gear_shop.buy_button": "BUY",


### PR DESCRIPTION
## Summary
- remove the COST and BUY column headers from the market buy tab so only the offers title remains
- delete the associated translation strings and datagen entries for the removed labels

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68ea084e4b608321b8bf5e67f3f30141