### PR TITLE
Implement Garden Market buy transactions

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -5,18 +5,28 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
+
+import com.mojang.blaze3d.systems.RenderSystem;
 
 import net.jeremy.gardenkingmod.GardenKingMod;
 import net.jeremy.gardenkingmod.client.gui.toast.SaleResultToast;
 import net.jeremy.gardenkingmod.shop.GearShopOffer;
 import net.jeremy.gardenkingmod.shop.GardenMarketOfferManager;
 import net.jeremy.gardenkingmod.shop.GearShopStackHelper;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.ClickableWidget;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.screen.narration.NarrationPart;
+import net.minecraft.client.render.DiffuseLighting;
+import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.render.OverlayTexture;
+import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.json.ModelTransformationMode;
 import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.Item;
@@ -27,7 +37,11 @@ import net.minecraft.text.Text;
 import net.minecraft.text.Texts;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.Util;
+import net.minecraft.util.math.RotationAxis;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.screen.slot.Slot;
 
 public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         private static final Identifier SELL_TEXTURE = new Identifier(GardenKingMod.MOD_ID,
@@ -80,6 +94,49 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         private static final int BUY_OFFER_ARROW_HEIGHT = 9;
         private static final int SELECTED_HIGHLIGHT_COLOR = 0x40FFFFFF;
 
+        private static final int COST_TEXT_COLOR = 0xFFFFFF;
+        private static final String COST_LABEL_TRANSLATION_KEY = "screen.gardenkingmod.gear_shop.cost_label";
+        private static final int COST_SLOT_LABEL_ANCHOR_X = 9;
+        private static final int COST_SLOT_LABEL_OFFSET_Y = 20;
+        private static final int COST_SLOT_VALUE_ANCHOR_X = 9;
+        private static final int COST_SLOT_VALUE_OFFSET_Y = 29;
+        private static final float COST_SLOT_TEXT_SCALE = 0.8F;
+
+        private static final float OFFER_DISPLAY_SCALE = 3.25F;
+        private static final float OFFER_ROTATION_SPEED = 30.0F;
+        private static final float OFFER_ROTATION_PERIOD_TICKS = 20.0F * (360.0F / OFFER_ROTATION_SPEED);
+        private static final float RESULT_SLOT_BASE_Z = 200.0F;
+        private static final float RESULT_SLOT_ANIMATION_SCALE = 1.0F;
+        private static final float RESULT_SLOT_ANIMATION_OFFSET_X = 0.0F;
+        private static final float RESULT_SLOT_ANIMATION_OFFSET_Y = -1.5F;
+        private static final float RESULT_SLOT_ANIMATION_OFFSET_Z = 0.0F;
+        private static final float RESULT_SLOT_ROTATION_PERIOD_TICKS = 90.0F;
+        private static final float RESULT_SLOT_ROTATION_PHASE_TICKS = 0.0F;
+        private static final RotationAxis RESULT_SLOT_ROTATION_AXIS = RotationAxis.POSITIVE_Y;
+        private static final float RESULT_SLOT_STATIC_PITCH = 0.0F;
+        private static final float RESULT_SLOT_STATIC_YAW = 0.0F;
+        private static final float RESULT_SLOT_STATIC_ROLL = 0.0F;
+        private static final float RESULT_SLOT_BOB_AMPLITUDE = 1.0F;
+        private static final float RESULT_SLOT_BOB_OFFSET = 0.0F;
+        private static final float RESULT_SLOT_BOB_PERIOD_TICKS = 20.0F;
+        private static final float RESULT_SLOT_BOB_PHASE_TICKS = 0.0F;
+
+        private static final OfferDisplayAnimation RESULT_SLOT_ANIMATION = buildAnimation(builder -> {
+                builder.scale(RESULT_SLOT_ANIMATION_SCALE);
+                builder.offset(RESULT_SLOT_ANIMATION_OFFSET_X, RESULT_SLOT_ANIMATION_OFFSET_Y,
+                                RESULT_SLOT_ANIMATION_OFFSET_Z);
+                builder.rotationAxis(RESULT_SLOT_ROTATION_AXIS);
+                builder.rotationPeriodTicks(RESULT_SLOT_ROTATION_PERIOD_TICKS);
+                builder.rotationPhaseTicks(RESULT_SLOT_ROTATION_PHASE_TICKS);
+                builder.staticPitch(RESULT_SLOT_STATIC_PITCH);
+                builder.staticYaw(RESULT_SLOT_STATIC_YAW);
+                builder.staticRoll(RESULT_SLOT_STATIC_ROLL);
+                builder.bobAmplitude(RESULT_SLOT_BOB_AMPLITUDE);
+                builder.bobOffset(RESULT_SLOT_BOB_OFFSET);
+                builder.bobPeriodTicks(RESULT_SLOT_BOB_PERIOD_TICKS);
+                builder.bobPhaseTicks(RESULT_SLOT_BOB_PHASE_TICKS);
+        });
+
         private static final class BuyBackground {
                 private static final int TEXTURE_WIDTH = 512;
                 private static final int TEXTURE_HEIGHT = 256;
@@ -117,6 +174,9 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         private boolean scrollbarDragging;
         private int selectedOffer = -1;
         private int lastOfferCount = -1;
+        private float lastRenderDelta;
+        private float resultSlotAnimationStartTicks = Float.NaN;
+        private ItemStack lastAnimatedResultSlotStack = ItemStack.EMPTY;
 
         public MarketScreen(MarketScreenHandler handler, PlayerInventory inventory, Text title) {
                 super(handler, inventory, title);
@@ -168,6 +228,7 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
 
         @Override
         public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+                lastRenderDelta = delta;
                 renderBackground(context);
                 if (sellButton != null) {
                         sellButton.visible = activeTab == Tab.SELL;
@@ -176,7 +237,20 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
                 if (activeTab == Tab.BUY) {
                         updateBuyScrollLimits();
                 }
-                super.render(context, mouseX, mouseY, delta);
+                ResultSlotSnapshot suppressedResult = activeTab == Tab.BUY ? suppressVanillaResultSlot() : null;
+                List<CostSlotSnapshot> suppressedCounts = activeTab == Tab.BUY ? suppressVanillaCostCounts() : List.of();
+                try {
+                        super.render(context, mouseX, mouseY, delta);
+                } finally {
+                        if (activeTab == Tab.BUY) {
+                                restoreVanillaCostCounts(suppressedCounts);
+                                restoreVanillaResultSlot(suppressedResult);
+                        }
+                }
+                if (activeTab == Tab.BUY) {
+                        drawAnimatedResultSlot(context);
+                        drawCostSlotOverlays(context);
+                }
                 drawMouseoverTooltip(context, mouseX, mouseY);
         }
 
@@ -348,6 +422,7 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
                 this.activeTab = tab;
                 if (this.handler != null) {
                         this.handler.setMarketSlotsEnabled(tab == Tab.SELL);
+                        this.handler.setBuySlotsEnabled(tab == Tab.BUY);
                         sendTabChangeToServer(tab);
                 }
                 updateTabButtonState();
@@ -453,6 +528,7 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
                 setScrollAmount(0.0F);
                 lastOfferCount = -1;
                 updateBuyScrollLimits();
+                sendOfferSelectionToServer(-1);
         }
 
         private void drawBuyLabels(DrawContext context) {
@@ -670,7 +746,262 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         }
 
         private void selectOffer(int offerIndex) {
-                selectedOffer = MathHelper.clamp(offerIndex, -1, getBuyOffers().size() - 1);
+                int clamped = MathHelper.clamp(offerIndex, -1, getBuyOffers().size() - 1);
+                if (this.selectedOffer != clamped) {
+                        this.selectedOffer = clamped;
+                        sendOfferSelectionToServer(clamped);
+                } else if (clamped >= 0) {
+                        sendOfferSelectionToServer(clamped);
+                }
+        }
+
+        private void sendOfferSelectionToServer(int offerIndex) {
+                if (handler == null || client == null || client.interactionManager == null) {
+                        return;
+                }
+
+                int buttonId = MarketScreenHandler.encodeSelectBuyOfferButtonId(offerIndex);
+                client.interactionManager.clickButton(handler.syncId, buttonId);
+        }
+
+        private void drawCostSlotOverlays(DrawContext context) {
+                if (handler == null) {
+                        return;
+                }
+
+                String label = Text.translatable(COST_LABEL_TRANSLATION_KEY).getString();
+                for (Slot slot : handler.slots) {
+                        if (handler.isCostSlot(slot) && slot.isEnabled() && slot.hasStack()) {
+                                int slotX = this.x + slot.x;
+                                int slotY = this.y + slot.y;
+                                ItemStack stack = slot.getStack();
+                                context.drawItem(stack, slotX, slotY);
+                                drawCostSlotText(context, label, stack, slotX, slotY);
+                        }
+                }
+        }
+
+        private void drawCostSlotText(DrawContext context, String label, ItemStack stack, int slotX, int slotY) {
+                int requiredCount = GearShopStackHelper.getRequestedCount(stack);
+                if (requiredCount <= 0) {
+                        return;
+                }
+
+                String valueText = formatRequestedCount(requiredCount);
+
+                RenderSystem.disableDepthTest();
+                RenderSystem.enableBlend();
+                RenderSystem.defaultBlendFunc();
+                RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+
+                drawCostTextLine(context, label, slotX + COST_SLOT_LABEL_ANCHOR_X,
+                                slotY + COST_SLOT_LABEL_OFFSET_Y, COST_SLOT_TEXT_SCALE);
+                drawCostTextLine(context, valueText, slotX + COST_SLOT_VALUE_ANCHOR_X,
+                                slotY + COST_SLOT_VALUE_OFFSET_Y, COST_SLOT_TEXT_SCALE);
+
+                RenderSystem.disableBlend();
+                RenderSystem.enableDepthTest();
+        }
+
+        private void drawCostTextLine(DrawContext context, String text, int anchorX, int baselineY, float scale) {
+                if (text == null || text.isEmpty()) {
+                        return;
+                }
+
+                float scaledWidth = textRenderer.getWidth(text) * scale;
+                float drawX = anchorX - scaledWidth / 2.0F;
+                MatrixStack matrices = context.getMatrices();
+                matrices.push();
+                matrices.translate(drawX, baselineY, 300.0F);
+                matrices.scale(scale, scale, 1.0F);
+                context.drawText(textRenderer, text, 0, 0, COST_TEXT_COLOR, false);
+                matrices.pop();
+        }
+
+        private void drawAnimatedResultSlot(DrawContext context) {
+                Slot resultSlot = getResultSlot();
+                if (resultSlot == null || !resultSlot.isEnabled()) {
+                        return;
+                }
+
+                ItemStack stack = resultSlot.getStack();
+                if (stack.isEmpty()) {
+                        resetResultSlotAnimation();
+                        return;
+                }
+
+                if (!ItemStack.areEqual(lastAnimatedResultSlotStack, stack)
+                                || stack.getCount() != lastAnimatedResultSlotStack.getCount()) {
+                        lastAnimatedResultSlotStack = stack.copy();
+                        resultSlotAnimationStartTicks = Float.NaN;
+                }
+
+                if (Float.isNaN(resultSlotAnimationStartTicks)) {
+                        resultSlotAnimationStartTicks = getAnimationTicks(0.0F);
+                }
+
+                float animationTicks = getAnimationTicks(lastRenderDelta) - resultSlotAnimationStartTicks;
+                if (animationTicks < 0.0F) {
+                        animationTicks = 0.0F;
+                }
+
+                int slotLeft = this.x + resultSlot.x;
+                int slotTop = this.y + resultSlot.y;
+                float slotCenterX = slotLeft + 8.0F;
+                float slotCenterY = slotTop + 8.0F;
+
+                OfferDisplayAnimation animation = RESULT_SLOT_ANIMATION;
+                MatrixStack matrices = context.getMatrices();
+                matrices.push();
+                matrices.translate(slotCenterX + animation.offsetX(), slotCenterY + animation.offsetY(),
+                                RESULT_SLOT_BASE_Z + animation.offsetZ());
+
+                float bobTranslation = animation.bobOffset();
+                if (animation.bobPeriodTicks() > 0.0F && animation.bobAmplitude() != 0.0F) {
+                        float bobAngle = (animationTicks + animation.bobPhaseTicks()) / animation.bobPeriodTicks();
+                        bobTranslation += MathHelper.sin(bobAngle) * animation.bobAmplitude();
+                }
+                if (bobTranslation != 0.0F) {
+                        matrices.translate(0.0F, bobTranslation, 0.0F);
+                }
+
+                float scale = animation.scale();
+                if (scale != 1.0F) {
+                        matrices.scale(scale, scale, scale);
+                }
+
+                if (animation.rotationPeriodTicks() > 0.0F) {
+                        float rotationDegrees = ((animationTicks + animation.rotationPhaseTicks())
+                                        / animation.rotationPeriodTicks()) * 360.0F;
+                        matrices.multiply(animation.rotationAxis().rotationDegrees(rotationDegrees));
+                }
+
+                if (animation.staticYaw() != 0.0F) {
+                        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(animation.staticYaw()));
+                }
+                if (animation.staticPitch() != 0.0F) {
+                        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(animation.staticPitch()));
+                }
+                if (animation.staticRoll() != 0.0F) {
+                        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(animation.staticRoll()));
+                }
+
+                drawResultStack(context, stack);
+                matrices.pop();
+
+                context.drawItemInSlot(textRenderer, stack, slotLeft, slotTop);
+        }
+
+        private void drawResultStack(DrawContext context, ItemStack stack) {
+                MinecraftClient minecraftClient = client;
+                if (minecraftClient == null) {
+                        return;
+                }
+
+                ItemRenderer renderer = minecraftClient.getItemRenderer();
+                BakedModel model = renderer.getModel(stack, null, null, 0);
+                MatrixStack matrices = context.getMatrices();
+                matrices.push();
+                matrices.scale(16.0F, -16.0F, 16.0F);
+                boolean disableLighting = !model.isSideLit();
+                if (disableLighting) {
+                        DiffuseLighting.disableGuiDepthLighting();
+                }
+                renderer.renderItem(stack, ModelTransformationMode.GUI, false, matrices, context.getVertexConsumers(),
+                                LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, model);
+                context.draw();
+                if (disableLighting) {
+                        DiffuseLighting.enableGuiDepthLighting();
+                }
+                matrices.pop();
+        }
+
+        private Slot getResultSlot() {
+                for (Slot slot : handler.slots) {
+                        if (handler.isResultSlot(slot)) {
+                                return slot;
+                        }
+                }
+                return null;
+        }
+
+        private void resetResultSlotAnimation() {
+                resultSlotAnimationStartTicks = Float.NaN;
+                lastAnimatedResultSlotStack = ItemStack.EMPTY;
+        }
+
+        private float getAnimationTicks(float delta) {
+                MinecraftClient minecraftClient = client;
+                if (minecraftClient != null && minecraftClient.world != null) {
+                        return minecraftClient.world.getTime() + delta;
+                }
+                return Util.getMeasuringTimeMs() / 50.0F;
+        }
+
+        private ResultSlotSnapshot suppressVanillaResultSlot() {
+                Slot resultSlot = getResultSlot();
+                if (resultSlot == null) {
+                        return null;
+                }
+
+                ItemStack stack = resultSlot.getStack();
+                if (stack.isEmpty()) {
+                        return null;
+                }
+
+                int originalCount = stack.getCount();
+                stack.setCount(0);
+                return new ResultSlotSnapshot(resultSlot, stack, originalCount);
+        }
+
+        private void restoreVanillaResultSlot(ResultSlotSnapshot snapshot) {
+                if (snapshot == null) {
+                        return;
+                }
+
+                if (snapshot.slot().getStack() == snapshot.stack()) {
+                        snapshot.stack().setCount(snapshot.originalCount());
+                }
+        }
+
+        private List<CostSlotSnapshot> suppressVanillaCostCounts() {
+                if (handler == null) {
+                        return List.of();
+                }
+
+                List<CostSlotSnapshot> modified = new ArrayList<>();
+                for (Slot slot : handler.slots) {
+                        if (!handler.isCostSlot(slot)) {
+                                continue;
+                        }
+
+                        ItemStack stack = slot.getStack();
+                        if (stack.isEmpty()) {
+                                continue;
+                        }
+
+                        int originalCount = stack.getCount();
+                        int requested = GearShopStackHelper.getRequestedCount(stack);
+                        if (requested <= stack.getCount()) {
+                                continue;
+                        }
+
+                        stack.setCount(Math.min(requested, stack.getMaxCount()));
+                        modified.add(new CostSlotSnapshot(slot, stack, originalCount));
+                }
+                return modified;
+        }
+
+        private void restoreVanillaCostCounts(List<CostSlotSnapshot> snapshots) {
+                if (snapshots == null) {
+                        return;
+                }
+
+                for (CostSlotSnapshot snapshot : snapshots) {
+                        if (snapshot.slot().getStack() == snapshot.stack()) {
+                                snapshot.stack().setCount(snapshot.originalCount());
+                        }
+                }
         }
 
         private void drawCostTooltip(DrawContext context, ItemStack stack, int mouseX, int mouseY) {
@@ -716,6 +1047,127 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
                         return;
                 }
                 client.getSoundManager().play(PositionedSoundInstance.master(SoundEvents.UI_BUTTON_CLICK, 1.0F));
+        }
+
+        private record ResultSlotSnapshot(Slot slot, ItemStack stack, int originalCount) {
+        }
+
+        private record CostSlotSnapshot(Slot slot, ItemStack stack, int originalCount) {
+        }
+
+        private record OfferDisplayAnimation(float scale, float offsetX, float offsetY, float offsetZ,
+                        float rotationPeriodTicks, float rotationPhaseTicks, RotationAxis rotationAxis,
+                        float staticPitch, float staticYaw, float staticRoll, float bobAmplitude, float bobOffset,
+                        float bobPeriodTicks, float bobPhaseTicks) {
+                static Builder builder() {
+                        return new Builder();
+                }
+
+                static final class Builder {
+                        private float scale = OFFER_DISPLAY_SCALE;
+                        private float offsetX;
+                        private float offsetY;
+                        private float offsetZ;
+                        private float rotationPeriodTicks = OFFER_ROTATION_PERIOD_TICKS;
+                        private float rotationPhaseTicks;
+                        private RotationAxis rotationAxis = RotationAxis.POSITIVE_Y;
+                        private float staticPitch = 25.0F;
+                        private float staticYaw;
+                        private float staticRoll;
+                        private float bobAmplitude;
+                        private float bobOffset;
+                        private float bobPeriodTicks;
+                        private float bobPhaseTicks;
+
+                        Builder scale(float scale) {
+                                this.scale = scale;
+                                return this;
+                        }
+
+                        Builder offset(float x, float y, float z) {
+                                this.offsetX = x;
+                                this.offsetY = y;
+                                this.offsetZ = z;
+                                return this;
+                        }
+
+                        Builder offsetX(float x) {
+                                this.offsetX = x;
+                                return this;
+                        }
+
+                        Builder offsetY(float y) {
+                                this.offsetY = y;
+                                return this;
+                        }
+
+                        Builder offsetZ(float z) {
+                                this.offsetZ = z;
+                                return this;
+                        }
+
+                        Builder rotationPeriodTicks(float periodTicks) {
+                                this.rotationPeriodTicks = periodTicks;
+                                return this;
+                        }
+
+                        Builder rotationPhaseTicks(float phaseTicks) {
+                                this.rotationPhaseTicks = phaseTicks;
+                                return this;
+                        }
+
+                        Builder rotationAxis(RotationAxis axis) {
+                                this.rotationAxis = axis;
+                                return this;
+                        }
+
+                        Builder staticPitch(float pitch) {
+                                this.staticPitch = pitch;
+                                return this;
+                        }
+
+                        Builder staticYaw(float yaw) {
+                                this.staticYaw = yaw;
+                                return this;
+                        }
+
+                        Builder staticRoll(float roll) {
+                                this.staticRoll = roll;
+                                return this;
+                        }
+
+                        Builder bobAmplitude(float amplitude) {
+                                this.bobAmplitude = amplitude;
+                                return this;
+                        }
+
+                        Builder bobOffset(float offset) {
+                                this.bobOffset = offset;
+                                return this;
+                        }
+
+                        Builder bobPeriodTicks(float periodTicks) {
+                                this.bobPeriodTicks = periodTicks;
+                                return this;
+                        }
+
+                        Builder bobPhaseTicks(float phaseTicks) {
+                                this.bobPhaseTicks = phaseTicks;
+                                return this;
+                        }
+
+                        OfferDisplayAnimation build() {
+                                return new OfferDisplayAnimation(scale, offsetX, offsetY, offsetZ, rotationPeriodTicks,
+                                                rotationPhaseTicks, rotationAxis, staticPitch, staticYaw, staticRoll,
+                                                bobAmplitude, bobOffset, bobPeriodTicks, bobPhaseTicks);
+                        }
+                }
+        }
+
+        private static OfferDisplayAnimation buildAnimation(Consumer<OfferDisplayAnimation.Builder> configurer) {
+                OfferDisplayAnimation.Builder builder = OfferDisplayAnimation.builder();
+                configurer.accept(builder);
+                return builder.build();
         }
 
         private record HoveredStack(ItemStack stack, boolean isCostStack) {

--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
@@ -1,18 +1,28 @@
 package net.jeremy.gardenkingmod.screen;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import net.jeremy.gardenkingmod.ModScreenHandlers;
 import net.jeremy.gardenkingmod.block.entity.MarketBlockEntity;
+import net.jeremy.gardenkingmod.screen.inventory.GearShopCostInventory;
+import net.jeremy.gardenkingmod.shop.GardenMarketOfferManager;
+import net.jeremy.gardenkingmod.shop.GearShopOffer;
+import net.jeremy.gardenkingmod.shop.GearShopStackHelper;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.InventoryChangedListener;
 import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
+import net.minecraft.screen.slot.SlotActionType;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.BlockPos;
 
@@ -20,11 +30,40 @@ public class MarketScreenHandler extends ScreenHandler {
         public static final int BUTTON_SELL = 0;
         public static final int BUTTON_SELECT_SELL_TAB = 1;
         public static final int BUTTON_SELECT_BUY_TAB = 2;
+        private static final int BUTTON_SELECT_BUY_OFFER_BASE = 1000;
+
+        private static final int SLOT_SIZE = 18;
+        private static final int COST_SLOT_COUNT = 2;
+        private static final int RESULT_SLOT_COUNT = 1;
+        private static final int COST_SLOT_FIRST_X = 159;
+        private static final int COST_SLOT_Y = 50;
+        private static final int COST_SLOT_SPACING = 26;
+        private static final int RESULT_SLOT_X = 239;
+        private static final int RESULT_SLOT_Y = 46;
+
+        private static final int PLAYER_INVENTORY_ROW_COUNT = 3;
+        private static final int PLAYER_INVENTORY_COLUMN_COUNT = 9;
+        private static final int PLAYER_INVENTORY_SLOT_COUNT = PLAYER_INVENTORY_ROW_COUNT * PLAYER_INVENTORY_COLUMN_COUNT;
+        private static final int HOTBAR_SLOT_COUNT = 9;
 
         private final Inventory inventory;
         private final MarketBlockEntity blockEntity;
         private final List<MarketSellSlot> marketSlots;
+        private final PlayerInventory playerInventory;
+        private final GearShopCostInventory costInventory;
+        private final SimpleInventory resultInventory;
+        private final Slot[] costSlots = new Slot[COST_SLOT_COUNT];
+        private Slot resultSlot;
         private boolean marketSlotsEnabled;
+        private boolean buySlotsEnabled;
+        private final List<GearShopOffer> buyOffers;
+        private int selectedOfferIndex;
+        private final int marketInventoryEnd;
+        private final int costSlotStartIndex;
+        private final int costSlotEndIndex;
+        private final int resultSlotStartIndex;
+        private final int playerInventoryStartIndex;
+        private final int hotbarStartIndex;
 
         public MarketScreenHandler(int syncId, PlayerInventory playerInventory, PacketByteBuf buf) {
                 this(syncId, playerInventory, getBlockEntity(playerInventory, buf.readBlockPos()));
@@ -33,34 +72,75 @@ public class MarketScreenHandler extends ScreenHandler {
         public MarketScreenHandler(int syncId, PlayerInventory playerInventory, MarketBlockEntity blockEntity) {
                 super(ModScreenHandlers.MARKET_SCREEN_HANDLER, syncId);
                 this.blockEntity = blockEntity;
+                this.playerInventory = playerInventory;
                 this.inventory = blockEntity != null ? blockEntity : new SimpleInventory(MarketBlockEntity.INVENTORY_SIZE);
                 this.marketSlots = new ArrayList<>();
                 this.marketSlotsEnabled = true;
+                this.buySlotsEnabled = false;
+                this.costInventory = new GearShopCostInventory(COST_SLOT_COUNT);
+                this.resultInventory = new SimpleInventory(RESULT_SLOT_COUNT);
+                this.costInventory.addListener(this::onInventoryChanged);
+                this.resultInventory.addListener(this::onInventoryChanged);
+                this.costInventory.onOpen(playerInventory.player);
+                this.resultInventory.onOpen(playerInventory.player);
+                this.buyOffers = new ArrayList<>(GardenMarketOfferManager.getInstance().getOffers());
+                this.selectedOfferIndex = -1;
 
                 checkSize(this.inventory, MarketBlockEntity.INVENTORY_SIZE);
                 this.inventory.onOpen(playerInventory.player);
 
                 addMarketInventory();
 
+                this.marketInventoryEnd = this.slots.size();
+                this.costSlotStartIndex = this.marketInventoryEnd;
+                addCostSlots();
+                this.costSlotEndIndex = this.slots.size();
+                this.resultSlotStartIndex = this.costSlotEndIndex;
+                addResultSlot();
+                int resultSlotEndIndex = this.slots.size();
+                this.playerInventoryStartIndex = resultSlotEndIndex;
                 addPlayerInventory(playerInventory);
+                int playerInventoryEndIndex = this.slots.size();
+                this.hotbarStartIndex = playerInventoryEndIndex;
                 addPlayerHotbar(playerInventory);
+
+                setMarketSlotsEnabled(true);
+                setBuySlotsEnabled(false);
+        }
+        private void onInventoryChanged(Inventory inventory) {
+                onContentChanged(inventory);
         }
 
         private void addMarketInventory() {
                 final int slotsPerRow = 9;
-                final int slotSize = 18;
                 final int startX = 8;
                 final int startY = 34;
 
                 for (int slotIndex = 0; slotIndex < MarketBlockEntity.INVENTORY_SIZE; ++slotIndex) {
                         int column = slotIndex % slotsPerRow;
                         int row = slotIndex / slotsPerRow;
-                        int x = startX + column * slotSize;
-                        int y = startY + row * slotSize;
+                        int x = startX + column * SLOT_SIZE;
+                        int y = startY + row * SLOT_SIZE;
                         MarketSellSlot slot = new MarketSellSlot(this.inventory, slotIndex, x, y);
                         this.addSlot(slot);
                         this.marketSlots.add(slot);
                 }
+        }
+
+        private void addCostSlots() {
+                for (int index = 0; index < COST_SLOT_COUNT; index++) {
+                        Slot slot = new MarketCostSlot(this.costInventory, index, getCostSlotX(index), COST_SLOT_Y);
+                        this.costSlots[index] = this.addSlot(slot);
+                }
+        }
+
+        private void addResultSlot() {
+                this.resultSlot = this.addSlot(new MarketResultSlot(this, this.resultInventory, 0, RESULT_SLOT_X, RESULT_SLOT_Y));
+        }
+
+        private int getCostSlotX(int index) {
+                int clamped = Math.max(0, Math.min(index, COST_SLOT_COUNT - 1));
+                return COST_SLOT_FIRST_X + clamped * COST_SLOT_SPACING;
         }
 
         public void setMarketSlotsEnabled(boolean enabled) {
@@ -75,10 +155,876 @@ public class MarketScreenHandler extends ScreenHandler {
                 }
         }
 
+        public void setBuySlotsEnabled(boolean enabled) {
+                if (this.buySlotsEnabled == enabled) {
+                        return;
+                }
+
+                this.buySlotsEnabled = enabled;
+                for (Slot slot : this.costSlots) {
+                        if (slot instanceof MarketCostSlot costSlot) {
+                                costSlot.setEnabled(enabled);
+                        }
+                }
+                if (this.resultSlot instanceof MarketResultSlot resultSlot) {
+                        resultSlot.setEnabled(enabled);
+                }
+        }
+
         public boolean areMarketSlotsEnabled() {
                 return this.marketSlotsEnabled;
         }
 
+        public boolean areBuySlotsEnabled() {
+                return this.buySlotsEnabled;
+        }
+        public boolean isCostSlot(Slot slot) {
+                return slot != null && slot.inventory == this.costInventory;
+        }
+
+        public boolean isResultSlot(Slot slot) {
+                return slot == this.resultSlot;
+        }
+        public static int encodeSelectBuyOfferButtonId(int offerIndex) {
+                return BUTTON_SELECT_BUY_OFFER_BASE + (offerIndex + 1);
+        }
+
+        private static boolean isSelectBuyOfferButtonId(int id) {
+                return id >= BUTTON_SELECT_BUY_OFFER_BASE;
+        }
+
+        private static int decodeSelectBuyOfferIndex(int id) {
+                return id - BUTTON_SELECT_BUY_OFFER_BASE - 1;
+        }
+        private static MarketBlockEntity getBlockEntity(PlayerInventory playerInventory, BlockPos pos) {
+                if (playerInventory.player.getWorld().getBlockEntity(pos) instanceof MarketBlockEntity marketBlockEntity) {
+                        return marketBlockEntity;
+                }
+
+                return null;
+        }
+
+        @Override
+        public boolean canUse(PlayerEntity player) {
+                if (this.blockEntity != null) {
+                        return this.blockEntity.canPlayerUse(player);
+                }
+
+                return this.inventory.canPlayerUse(player);
+        }
+
+        @Override
+        public void onClosed(PlayerEntity player) {
+                super.onClosed(player);
+                if (this.blockEntity != null) {
+                        this.blockEntity.onClose(player);
+                } else {
+                        this.inventory.onClose(player);
+                }
+                this.costInventory.onClose(player);
+                this.resultInventory.onClose(player);
+                if (player instanceof ServerPlayerEntity serverPlayer) {
+                        returnCostItems(serverPlayer);
+                }
+        }
+        @Override
+        public ItemStack quickMove(PlayerEntity player, int index) {
+                Slot slot = this.slots.get(index);
+                if (slot == null || !slot.hasStack()) {
+                        return ItemStack.EMPTY;
+                }
+
+                ItemStack originalStack = slot.getStack();
+                ItemStack copiedStack = originalStack.copy();
+
+                int marketEnd = this.marketInventoryEnd;
+                int costSlotStart = this.costSlotStartIndex;
+                int costSlotEnd = this.costSlotEndIndex;
+                int resultSlotStart = this.resultSlotStartIndex;
+                int resultSlotEnd = resultSlotStart + RESULT_SLOT_COUNT;
+                int playerInventoryStart = this.playerInventoryStartIndex;
+                int playerInventoryEnd = playerInventoryStart + PLAYER_INVENTORY_SLOT_COUNT;
+                int hotbarStart = this.hotbarStartIndex;
+                int hotbarEnd = hotbarStart + HOTBAR_SLOT_COUNT;
+
+                if (index < marketEnd) {
+                        if (!this.insertItem(originalStack, playerInventoryStart, hotbarEnd, true)) {
+                                return ItemStack.EMPTY;
+                        }
+                } else if (index >= costSlotStart && index < costSlotEnd) {
+                        CostReturnResult result = returnCostSlot(player, index - costSlotStart, originalStack.copy());
+                        if (!result.slotChanged()) {
+                                return ItemStack.EMPTY;
+                        }
+                        if (result.playerChanged()) {
+                                player.getInventory().markDirty();
+                        }
+                        this.costInventory.markDirty();
+                        ItemStack returned = result.returnedStack();
+                        ItemStack callbackStack = returned.copy();
+                        slot.onQuickTransfer(callbackStack, ItemStack.EMPTY);
+                        slot.onTakeItem(player, callbackStack);
+                        return returned.copy();
+                } else if (index >= resultSlotStart && index < resultSlotEnd) {
+                        if (!this.insertItem(originalStack, playerInventoryStart, hotbarEnd, true)) {
+                                return ItemStack.EMPTY;
+                        }
+                } else if (index < hotbarEnd) {
+                        if (!this.insertItem(originalStack, costSlotStart, costSlotEnd, false)) {
+                                if (index < playerInventoryEnd) {
+                                        if (!this.insertItem(originalStack, hotbarStart, hotbarEnd, false)) {
+                                                return ItemStack.EMPTY;
+                                        }
+                                } else if (!this.insertItem(originalStack, playerInventoryStart, playerInventoryEnd, false)) {
+                                        return ItemStack.EMPTY;
+                                }
+                        }
+                } else {
+                        return ItemStack.EMPTY;
+                }
+
+                slot.onQuickTransfer(originalStack, copiedStack);
+
+                if (originalStack.isEmpty()) {
+                        slot.setStack(ItemStack.EMPTY);
+                } else {
+                        slot.markDirty();
+                }
+
+                if (originalStack.getCount() == copiedStack.getCount()) {
+                        return ItemStack.EMPTY;
+                }
+
+                slot.onTakeItem(player, originalStack);
+                return copiedStack;
+        }
+        @Override
+        protected boolean insertItem(ItemStack stack, int startIndex, int endIndex, boolean fromLast) {
+                if (startIndex >= this.costSlotStartIndex && endIndex <= this.costSlotEndIndex && stack != null && !stack.isEmpty()) {
+                        boolean inserted = false;
+                        int index = fromLast ? endIndex - 1 : startIndex;
+                        int step = fromLast ? -1 : 1;
+                        while (fromLast ? index >= startIndex : index < endIndex) {
+                                Slot slot = this.slots.get(index);
+                                ItemStack slotStack = slot.getStack();
+                                if (slotStack.isEmpty()) {
+                                        ItemStack moved = stack.copy();
+                                        int movedCount = stack.getCount();
+                                        stack.setCount(0);
+                                        GearShopStackHelper.applyRequestedCount(moved, movedCount);
+                                        slot.setStack(moved);
+                                        slot.markDirty();
+                                        inserted = true;
+                                        break;
+                                }
+
+                                if (canCombineIgnoringRequestedCount(slotStack, stack)) {
+                                        int existing = GearShopStackHelper.getRequestedCount(slotStack);
+                                        int addition = stack.getCount();
+                                        if (addition > 0) {
+                                                GearShopStackHelper.applyRequestedCount(slotStack, existing + addition);
+                                                slot.markDirty();
+                                                stack.setCount(0);
+                                                inserted = true;
+                                        }
+                                        break;
+                                }
+
+                                index += step;
+                        }
+
+                        if (inserted) {
+                                return true;
+                        }
+                }
+
+                return super.insertItem(stack, startIndex, endIndex, fromLast);
+        }
+        @Override
+        public void onSlotClick(int slotIndex, int button, SlotActionType actionType, PlayerEntity player) {
+                super.onSlotClick(slotIndex, button, actionType, player);
+                if (slotIndex >= this.costSlotStartIndex && slotIndex < this.costSlotEndIndex && actionType == SlotActionType.PICKUP) {
+                        Slot slot = this.slots.get(slotIndex);
+                        if (slot != null) {
+                                ItemStack slotStack = slot.getStack();
+                                ItemStack cursor = getCursorStack();
+                                if (!slotStack.isEmpty() && !cursor.isEmpty() && canCombineIgnoringRequestedCount(slotStack, cursor)) {
+                                        if (button == 0) {
+                                                int total = GearShopStackHelper.getRequestedCount(slotStack) + cursor.getCount();
+                                                if (cursor.getCount() > 0) {
+                                                        GearShopStackHelper.applyRequestedCount(slotStack, total);
+                                                        cursor.setCount(0);
+                                                        slot.markDirty();
+                                                }
+                                        } else if (button == 1 && cursor.getCount() > 0) {
+                                                int total = GearShopStackHelper.getRequestedCount(slotStack) + 1;
+                                                GearShopStackHelper.applyRequestedCount(slotStack, total);
+                                                cursor.decrement(1);
+                                                slot.markDirty();
+                                        }
+                                }
+                        }
+                }
+        }
+        @Override
+        public boolean onButtonClick(PlayerEntity player, int id) {
+                if (isSelectBuyOfferButtonId(id) && player instanceof ServerPlayerEntity serverPlayer) {
+                        int offerIndex = decodeSelectBuyOfferIndex(id);
+                        if (offerIndex < 0) {
+                                if (clearSelection(serverPlayer)) {
+                                        sendContentUpdates();
+                                }
+                        } else if (setSelectedOffer(serverPlayer, offerIndex)) {
+                                sendContentUpdates();
+                        }
+                        return true;
+                }
+
+                if (this.blockEntity != null) {
+                        if (id == BUTTON_SELL && player instanceof ServerPlayerEntity serverPlayer) {
+                                if (this.blockEntity.sell(serverPlayer)) {
+                                        sendContentUpdates();
+                                }
+                                return true;
+                        }
+
+                        if (id == BUTTON_SELECT_SELL_TAB) {
+                                if (player instanceof ServerPlayerEntity serverPlayer) {
+                                        if (clearSelection(serverPlayer)) {
+                                                sendContentUpdates();
+                                        }
+                                }
+                                setMarketSlotsEnabled(true);
+                                setBuySlotsEnabled(false);
+                                return true;
+                        }
+
+                        if (id == BUTTON_SELECT_BUY_TAB) {
+                                boolean returnedItems = this.blockEntity.returnItemsToPlayer(player);
+                                setMarketSlotsEnabled(false);
+                                setBuySlotsEnabled(true);
+                                if (returnedItems) {
+                                        sendContentUpdates();
+                                }
+                                return true;
+                        }
+                }
+
+                return super.onButtonClick(player, id);
+        }
+        public boolean hasSellableItem() {
+                for (int slot = 0; slot < MarketBlockEntity.INVENTORY_SIZE; slot++) {
+                        if (MarketBlockEntity.isSellable(this.inventory.getStack(slot))) {
+                                return true;
+                        }
+                }
+                return false;
+        }
+        @Override
+        public void onContentChanged(Inventory inventory) {
+                super.onContentChanged(inventory);
+                if (inventory == this.costInventory) {
+                        GearShopOffer offer = getSelectedOffer();
+                        if (updateResultSlot(offer) && !this.playerInventory.player.getWorld().isClient) {
+                                sendContentUpdates();
+                        }
+                }
+        }
+        private boolean setSelectedOffer(ServerPlayerEntity player, int offerIndex) {
+                if (offerIndex < 0 || offerIndex >= this.buyOffers.size()) {
+                        return clearSelection(player);
+                }
+
+                GearShopOffer offer = this.buyOffers.get(offerIndex);
+                boolean inventoryChanged = populateSelectedOffer(player, offer, true, true);
+                boolean selectionChanged = this.selectedOfferIndex != offerIndex;
+                this.selectedOfferIndex = offerIndex;
+                return inventoryChanged || selectionChanged;
+        }
+
+        private boolean clearSelection(ServerPlayerEntity player) {
+                boolean changed = returnCostItems(player);
+                ItemStack current = this.resultInventory.getStack(0);
+                if (!current.isEmpty()) {
+                        this.resultInventory.setStack(0, ItemStack.EMPTY);
+                        this.resultInventory.markDirty();
+                        changed = true;
+                }
+                boolean selectionChanged = this.selectedOfferIndex != -1;
+                this.selectedOfferIndex = -1;
+                return changed || selectionChanged;
+        }
+
+        private boolean populateSelectedOffer(ServerPlayerEntity player, GearShopOffer offer, boolean returnExisting,
+                        boolean refillFromPlayerInventory) {
+                if (offer == null) {
+                        return clearSelection(player);
+                }
+
+                PlayerInventory playerInv = player.getInventory();
+                boolean changed = false;
+
+                if (returnExisting) {
+                        if (returnCostItems(player)) {
+                                changed = true;
+                        }
+                }
+
+                boolean shouldRefill = refillFromPlayerInventory;
+                if (shouldRefill) {
+                        shouldRefill = hasSufficientResources(playerInv, offer.costStacks());
+                }
+
+                if (shouldRefill) {
+                        List<ItemStack> costs = offer.costStacks();
+                        boolean playerChanged = false;
+                        boolean slotChanged = false;
+                        for (int slotIndex = 0; slotIndex < COST_SLOT_COUNT; slotIndex++) {
+                                ItemStack template = slotIndex < costs.size() ? costs.get(slotIndex) : ItemStack.EMPTY;
+                                ExtractResult result = fillCostSlotFromPlayer(playerInv, template, slotIndex);
+                                if (result.playerChanged()) {
+                                        playerChanged = true;
+                                }
+                                if (result.slotChanged()) {
+                                        slotChanged = true;
+                                }
+                        }
+
+                        if (playerChanged) {
+                                playerInv.markDirty();
+                                changed = true;
+                        }
+
+                        if (slotChanged) {
+                                this.costInventory.markDirty();
+                                changed = true;
+                        }
+                }
+
+                if (!shouldRefill) {
+                        if (clearCostSlots()) {
+                                changed = true;
+                        }
+                }
+
+                if (updateResultSlot(offer)) {
+                        changed = true;
+                }
+
+                return changed;
+        }
+
+        private boolean clearCostSlots() {
+                boolean cleared = false;
+                for (int slot = 0; slot < this.costInventory.size(); slot++) {
+                        if (!this.costInventory.getStack(slot).isEmpty()) {
+                                this.costInventory.setStack(slot, ItemStack.EMPTY);
+                                cleared = true;
+                        }
+                }
+                if (cleared) {
+                        this.costInventory.markDirty();
+                }
+                return cleared;
+        }
+        private boolean hasSufficientResources(PlayerInventory inventory, List<ItemStack> costs) {
+                if (costs == null || costs.isEmpty()) {
+                        return true;
+                }
+
+                Map<StackComparisonKey, Integer> available = countInventoryStacks(inventory);
+                for (ItemStack cost : costs) {
+                        if (cost == null || cost.isEmpty()) {
+                                continue;
+                        }
+
+                        int required = GearShopStackHelper.getRequestedCount(cost);
+                        if (required <= 0) {
+                                continue;
+                        }
+
+                        ItemStack comparison = GearShopStackHelper.copyWithoutRequestedCount(cost);
+                        if (comparison.isEmpty()) {
+                                continue;
+                        }
+
+                        StackComparisonKey key = StackComparisonKey.of(comparison);
+                        int availableCount = available.getOrDefault(key, 0);
+                        if (availableCount < required) {
+                                return false;
+                        }
+
+                        available.put(key, availableCount - required);
+                }
+
+                return true;
+        }
+
+        private Map<StackComparisonKey, Integer> countInventoryStacks(PlayerInventory inventory) {
+                Map<StackComparisonKey, Integer> counts = new HashMap<>();
+                for (int slot = 0; slot < inventory.size(); slot++) {
+                        ItemStack stack = inventory.getStack(slot);
+                        if (stack.isEmpty()) {
+                                continue;
+                        }
+
+                        StackComparisonKey key = StackComparisonKey.of(stack);
+                        if (key == null) {
+                                continue;
+                        }
+
+                        counts.merge(key, stack.getCount(), Integer::sum);
+                }
+                return counts;
+        }
+
+        private boolean updateResultSlot(GearShopOffer offer) {
+                ItemStack previous = this.resultInventory.getStack(0);
+                ItemStack next = ItemStack.EMPTY;
+                if (offer != null && costSlotsMatchOffer(offer)) {
+                        next = offer.copyResultStack();
+                }
+
+                boolean changed = !ItemStack.areEqual(previous, next) || previous.getCount() != next.getCount();
+                if (changed) {
+                        this.resultInventory.setStack(0, next);
+                        this.resultInventory.markDirty();
+                }
+                return changed;
+        }
+        private boolean returnCostItems(ServerPlayerEntity player) {
+                boolean playerChanged = false;
+                boolean slotChanged = false;
+                for (int slot = 0; slot < this.costInventory.size(); slot++) {
+                        ItemStack original = this.costInventory.getStack(slot);
+                        if (original.isEmpty()) {
+                                continue;
+                        }
+
+                        CostReturnResult result = returnCostSlot(player, slot, original.copy());
+                        if (result.playerChanged()) {
+                                playerChanged = true;
+                        }
+                        if (result.slotChanged()) {
+                                slotChanged = true;
+                        }
+                }
+
+                if (playerChanged) {
+                        player.getInventory().markDirty();
+                }
+                if (slotChanged) {
+                        this.costInventory.markDirty();
+                }
+                return playerChanged || slotChanged;
+        }
+
+        private CostReturnResult returnCostSlot(PlayerEntity player, int slotIndex, ItemStack originalCopy) {
+                if (originalCopy == null || originalCopy.isEmpty()) {
+                        return CostReturnResult.NO_CHANGE;
+                }
+
+                ItemStack removed = this.costInventory.removeStack(slotIndex);
+                if (removed.isEmpty()) {
+                        return CostReturnResult.NO_CHANGE;
+                }
+
+                int provided = Math.max(GearShopStackHelper.getRequestedCount(removed), removed.getCount());
+                int requested = Math.max(GearShopStackHelper.getRequestedCount(originalCopy), provided);
+                if (requested <= 0) {
+                        requested = provided;
+                }
+
+                ItemStack comparison = GearShopStackHelper.copyWithoutRequestedCount(originalCopy);
+                if (comparison.isEmpty()) {
+                        comparison = GearShopStackHelper.copyWithoutRequestedCount(removed);
+                }
+
+                if (comparison.isEmpty()) {
+                        comparison = removed.copy();
+                        comparison.setCount(Math.min(requested, comparison.getMaxCount()));
+                }
+
+                PlayerInventory playerInventory = player.getInventory();
+                boolean playerChanged = false;
+
+                if (requested <= 0 || comparison.isEmpty()) {
+                        this.costInventory.setStack(slotIndex, ItemStack.EMPTY);
+                        if (!removed.isEmpty()) {
+                                ItemStack fallback = removed.copy();
+                                if (playerInventory.insertStack(fallback)) {
+                                        playerChanged = true;
+                                } else {
+                                        player.dropItem(fallback, false);
+                                }
+                        }
+                        return new CostReturnResult(playerChanged, true, removed);
+                }
+
+                int remaining = requested;
+                while (remaining > 0) {
+                        ItemStack toInsert = comparison.copy();
+                        int amount = Math.min(remaining, toInsert.getMaxCount());
+                        toInsert.setCount(amount);
+
+                        if (!player.giveItemStack(toInsert.copy())) {
+                                player.dropItem(toInsert.copy(), false);
+                        } else {
+                                playerChanged = true;
+                        }
+
+                        remaining -= amount;
+                }
+
+                return new CostReturnResult(playerChanged, true, removed);
+        }
+
+        private ExtractResult fillCostSlotFromPlayer(PlayerInventory playerInventory, ItemStack template, int slotIndex) {
+                ItemStack previous = this.costInventory.getStack(slotIndex);
+
+                if (template == null || template.isEmpty()) {
+                        boolean slotChanged = !previous.isEmpty();
+                        if (slotChanged) {
+                                this.costInventory.setStack(slotIndex, ItemStack.EMPTY);
+                        }
+                        return new ExtractResult(false, slotChanged);
+                }
+
+                int required = GearShopStackHelper.getRequestedCount(template);
+                if (required <= 0) {
+                        boolean slotChanged = !previous.isEmpty();
+                        if (slotChanged) {
+                                this.costInventory.setStack(slotIndex, ItemStack.EMPTY);
+                        }
+                        return new ExtractResult(false, slotChanged);
+                }
+
+                ItemStack comparison = GearShopStackHelper.copyWithoutRequestedCount(template);
+                if (comparison.isEmpty()) {
+                        boolean slotChanged = !previous.isEmpty();
+                        if (slotChanged) {
+                                this.costInventory.setStack(slotIndex, ItemStack.EMPTY);
+                        }
+                        return new ExtractResult(false, slotChanged);
+                }
+
+                ExtractionResult extracted = extractMatchingStacks(playerInventory, comparison, required);
+                ItemStack collected = extracted.collected();
+
+                if (collected.isEmpty()) {
+                        boolean slotChanged = !previous.isEmpty();
+                        if (slotChanged) {
+                                this.costInventory.setStack(slotIndex, ItemStack.EMPTY);
+                        }
+                        return new ExtractResult(extracted.playerChanged(), slotChanged);
+                }
+
+                boolean slotChanged = !ItemStack.areEqual(previous, collected)
+                                || previous.getCount() != collected.getCount()
+                                || GearShopStackHelper.getRequestedCount(previous) != GearShopStackHelper
+                                                .getRequestedCount(collected);
+                this.costInventory.setStack(slotIndex, collected);
+                return new ExtractResult(extracted.playerChanged(), slotChanged);
+        }
+
+        private ExtractionResult extractMatchingStacks(PlayerInventory playerInventory, ItemStack comparison, int required) {
+                if (required <= 0) {
+                        return new ExtractionResult(ItemStack.EMPTY, false);
+                }
+
+                int remaining = required;
+                int totalCollected = 0;
+                ItemStack collected = ItemStack.EMPTY;
+                boolean playerChanged = false;
+
+                for (int inventorySlot = 0; inventorySlot < playerInventory.size() && remaining > 0; inventorySlot++) {
+                        ItemStack playerStack = playerInventory.getStack(inventorySlot);
+                        if (playerStack.isEmpty() || !ItemStack.canCombine(playerStack, comparison)) {
+                                continue;
+                        }
+
+                        int taken = Math.min(playerStack.getCount(), remaining);
+                        if (taken <= 0) {
+                                continue;
+                        }
+
+                        if (collected.isEmpty()) {
+                                collected = playerStack.copy();
+                                collected.setCount(Math.min(taken, collected.getMaxCount()));
+                        } else {
+                                int newCount = Math.min(collected.getCount() + taken, collected.getMaxCount());
+                                collected.setCount(newCount);
+                        }
+
+                        playerStack.decrement(taken);
+                        remaining -= taken;
+                        totalCollected += taken;
+                        playerChanged = true;
+
+                        if (playerStack.isEmpty()) {
+                                playerInventory.setStack(inventorySlot, ItemStack.EMPTY);
+                        }
+                }
+
+                if (!playerChanged) {
+                        return new ExtractionResult(ItemStack.EMPTY, false);
+                }
+
+                GearShopStackHelper.applyRequestedCount(collected, totalCollected);
+                return new ExtractionResult(collected, true);
+        }
+        private boolean costSlotsMatchOffer(GearShopOffer offer) {
+                if (offer == null) {
+                        return false;
+                }
+
+                List<ItemStack> costs = offer.costStacks();
+                for (int slotIndex = 0; slotIndex < COST_SLOT_COUNT; slotIndex++) {
+                        ItemStack required = slotIndex < costs.size() ? costs.get(slotIndex) : ItemStack.EMPTY;
+                        ItemStack provided = this.costInventory.getStack(slotIndex);
+                        if (!costMatches(required, provided)) {
+                                return false;
+                        }
+                }
+
+                return true;
+        }
+
+        private boolean costMatches(ItemStack required, ItemStack provided) {
+                if (required == null || required.isEmpty()) {
+                        return provided.isEmpty();
+                }
+
+                if (provided.isEmpty()) {
+                        return false;
+                }
+
+                if (!canCombineIgnoringRequestedCount(provided, required)) {
+                        return false;
+                }
+
+                int requiredCount = GearShopStackHelper.getRequestedCount(required);
+                if (requiredCount <= 0) {
+                                return provided.isEmpty();
+                }
+
+                int providedCount = GearShopStackHelper.getRequestedCount(provided);
+                return providedCount >= requiredCount;
+        }
+
+        private boolean removeCostStacks(List<ItemStack> costs, PlayerInventory playerInventory) {
+                boolean costSlotsChanged = false;
+                for (int index = 0; index < costs.size(); index++) {
+                        ItemStack cost = costs.get(index);
+                        if (cost.isEmpty()) {
+                                continue;
+                        }
+
+                        int required = GearShopStackHelper.getRequestedCount(cost);
+                        if (required <= 0) {
+                                continue;
+                        }
+
+                        ItemStack comparisonStack = GearShopStackHelper.copyWithoutRequestedCount(cost);
+                        int remaining = required;
+                        if (index < COST_SLOT_COUNT) {
+                                SlotConsumptionResult result = consumeCostSlot(index, comparisonStack, required);
+                                remaining = result.remaining();
+                                if (result.changed()) {
+                                        costSlotsChanged = true;
+                                }
+                        }
+                        if (remaining > 0) {
+                                remaining = removeFromInventory(playerInventory, comparisonStack, remaining);
+                        }
+                }
+                return costSlotsChanged;
+        }
+
+        private SlotConsumptionResult consumeCostSlot(int slotIndex, ItemStack comparisonStack, int required) {
+                if (required <= 0) {
+                        return new SlotConsumptionResult(0, false);
+                }
+
+                ItemStack slotStack = this.costInventory.getStack(slotIndex);
+                if (slotStack.isEmpty()) {
+                        return new SlotConsumptionResult(required, false);
+                }
+
+                ItemStack comparisonSource = GearShopStackHelper.copyWithoutRequestedCount(slotStack);
+                if (!ItemStack.canCombine(comparisonSource, comparisonStack)) {
+                        return new SlotConsumptionResult(required, false);
+                }
+
+                int provided = GearShopStackHelper.getRequestedCount(slotStack);
+                if (provided <= 0) {
+                        this.costInventory.setStack(slotIndex, ItemStack.EMPTY);
+                        return new SlotConsumptionResult(required, true);
+                }
+
+                int consumed = Math.min(provided, required);
+                int leftover = provided - consumed;
+                if (leftover > 0) {
+                        ItemStack replacement = GearShopStackHelper.copyWithoutRequestedCount(slotStack);
+                        GearShopStackHelper.applyRequestedCount(replacement, leftover);
+                        this.costInventory.setStack(slotIndex, replacement);
+                } else {
+                        this.costInventory.setStack(slotIndex, ItemStack.EMPTY);
+                }
+
+                return new SlotConsumptionResult(required - consumed, true);
+        }
+
+        private int removeFromInventory(Inventory inventory, ItemStack comparisonStack, int remaining) {
+                if (remaining <= 0) {
+                        return 0;
+                }
+
+                boolean changed = false;
+                for (int slot = 0; slot < inventory.size() && remaining > 0; slot++) {
+                        ItemStack stack = inventory.getStack(slot);
+                        if (stack.isEmpty()) {
+                                continue;
+                        }
+                        ItemStack comparisonSource = stack;
+                        if (inventory == this.costInventory) {
+                                comparisonSource = GearShopStackHelper.copyWithoutRequestedCount(stack);
+                        }
+                        if (!ItemStack.canCombine(comparisonSource, comparisonStack)) {
+                                continue;
+                        }
+
+                        if (inventory == this.costInventory) {
+                                int requested = GearShopStackHelper.getRequestedCount(stack);
+                                if (requested <= 0) {
+                                        inventory.setStack(slot, ItemStack.EMPTY);
+                                        changed = true;
+                                        continue;
+                                }
+
+                                int taken = Math.min(requested, remaining);
+                                if (taken <= 0) {
+                                        continue;
+                                }
+
+                                remaining -= taken;
+                                changed = true;
+
+                                int leftover = requested - taken;
+                                if (leftover > 0) {
+                                        ItemStack replacement = GearShopStackHelper.copyWithoutRequestedCount(stack);
+                                        GearShopStackHelper.applyRequestedCount(replacement, leftover);
+                                        inventory.setStack(slot, replacement);
+                                } else {
+                                        inventory.setStack(slot, ItemStack.EMPTY);
+                                }
+                                continue;
+                        }
+
+                        int taken = Math.min(stack.getCount(), remaining);
+                        if (taken <= 0) {
+                                continue;
+                        }
+
+                        stack.decrement(taken);
+                        remaining -= taken;
+                        changed = true;
+                        if (stack.isEmpty()) {
+                                inventory.setStack(slot, ItemStack.EMPTY);
+                        }
+                }
+
+                if (changed) {
+                        inventory.markDirty();
+                }
+                return remaining;
+        }
+        private boolean processPurchase(ServerPlayerEntity player, int offerIndex, boolean resultTakenFromSlot) {
+                if (offerIndex < 0 || offerIndex >= this.buyOffers.size()) {
+                        return false;
+                }
+
+                GearShopOffer offer = this.buyOffers.get(offerIndex);
+                PlayerInventory playerInv = player.getInventory();
+                if (!costSlotsMatchOffer(offer)) {
+                        return false;
+                }
+
+                boolean costSlotsChanged = removeCostStacks(offer.costStacks(), playerInv);
+                if (!resultTakenFromSlot) {
+                        ItemStack result = offer.copyResultStack();
+                        if (!result.isEmpty()) {
+                                if (!player.giveItemStack(result)) {
+                                        player.dropItem(result, false);
+                                }
+                        }
+                }
+                populateSelectedOffer(player, offer, false, true);
+                playerInv.markDirty();
+                if (costSlotsChanged) {
+                        this.costInventory.markDirty();
+                }
+                return true;
+        }
+
+        private GearShopOffer getSelectedOffer() {
+                if (this.selectedOfferIndex < 0 || this.selectedOfferIndex >= this.buyOffers.size()) {
+                        return null;
+                }
+                return this.buyOffers.get(this.selectedOfferIndex);
+        }
+
+        private static boolean canCombineIgnoringRequestedCount(ItemStack first, ItemStack second) {
+                ItemStack firstComparison = GearShopStackHelper.copyWithoutRequestedCount(first);
+                ItemStack secondComparison = GearShopStackHelper.copyWithoutRequestedCount(second);
+                return ItemStack.canCombine(firstComparison, secondComparison);
+        }
+
+        private record ExtractResult(boolean playerChanged, boolean slotChanged) {
+        }
+
+        private record ExtractionResult(ItemStack collected, boolean playerChanged) {
+        }
+
+        private record CostReturnResult(boolean playerChanged, boolean slotChanged, ItemStack returnedStack) {
+                static final CostReturnResult NO_CHANGE = new CostReturnResult(false, false, ItemStack.EMPTY);
+        }
+
+        private record SlotConsumptionResult(int remaining, boolean changed) {
+        }
+
+        private record StackComparisonKey(Item item, NbtCompound components) {
+                static StackComparisonKey of(ItemStack stack) {
+                        if (stack == null || stack.isEmpty()) {
+                                return null;
+                        }
+
+                        ItemStack sanitized = GearShopStackHelper.copyWithoutRequestedCount(stack);
+                        if (sanitized.isEmpty()) {
+                                return null;
+                        }
+
+                        Item item = sanitized.getItem();
+                        NbtCompound nbt = sanitized.hasNbt() ? sanitized.getNbt().copy() : null;
+                        return new StackComparisonKey(item, nbt);
+                }
+        }
+        private void addPlayerInventory(PlayerInventory playerInventory) {
+                final int baseY = 138;
+                for (int row = 0; row < PLAYER_INVENTORY_ROW_COUNT; ++row) {
+                        for (int column = 0; column < PLAYER_INVENTORY_COLUMN_COUNT; ++column) {
+                                this.addSlot(new Slot(playerInventory, column + row * PLAYER_INVENTORY_COLUMN_COUNT + HOTBAR_SLOT_COUNT,
+                                                8 + column * SLOT_SIZE, baseY + row * SLOT_SIZE));
+                        }
+                }
+        }
+
+        private void addPlayerHotbar(PlayerInventory playerInventory) {
+                final int hotbarY = 196;
+                for (int slot = 0; slot < HOTBAR_SLOT_COUNT; ++slot) {
+                        this.addSlot(new Slot(playerInventory, slot, 8 + slot * SLOT_SIZE, hotbarY));
+                }
+        }
         private static class MarketSellSlot extends Slot {
                 private boolean enabled = true;
 
@@ -106,111 +1052,72 @@ public class MarketScreenHandler extends ScreenHandler {
                 }
         }
 
-        private static MarketBlockEntity getBlockEntity(PlayerInventory playerInventory, BlockPos pos) {
-                if (playerInventory.player.getWorld().getBlockEntity(pos) instanceof MarketBlockEntity marketBlockEntity) {
-                        return marketBlockEntity;
+        private static class MarketCostSlot extends Slot {
+                private boolean enabled = false;
+
+                protected MarketCostSlot(Inventory inventory, int index, int x, int y) {
+                        super(inventory, index, x, y);
                 }
 
-                return null;
-        }
-
-        @Override
-        public boolean canUse(PlayerEntity player) {
-                if (this.blockEntity != null) {
-                        return this.blockEntity.canPlayerUse(player);
+                public void setEnabled(boolean enabled) {
+                        this.enabled = enabled;
                 }
 
-                return this.inventory.canPlayerUse(player);
-        }
-
-        @Override
-        public void onClosed(PlayerEntity player) {
-                super.onClosed(player);
-                if (this.blockEntity != null) {
-                        this.blockEntity.onClose(player);
-                } else {
-                        this.inventory.onClose(player);
-                }
-        }
-
-        @Override
-        public ItemStack quickMove(PlayerEntity player, int index) {
-                ItemStack newStack = ItemStack.EMPTY;
-                Slot slot = this.slots.get(index);
-                if (slot != null && slot.hasStack()) {
-                        ItemStack originalStack = slot.getStack();
-                        newStack = originalStack.copy();
-                        if (index < MarketBlockEntity.INVENTORY_SIZE) {
-                                if (!this.insertItem(originalStack, MarketBlockEntity.INVENTORY_SIZE, this.slots.size(),
-                                                true)) {
-                                        return ItemStack.EMPTY;
-                                }
-                        } else if (!this.marketSlotsEnabled || !MarketBlockEntity.isSellable(originalStack)
-                                        || !this.insertItem(originalStack, 0, MarketBlockEntity.INVENTORY_SIZE, false)) {
-                                return ItemStack.EMPTY;
-                        }
-
-                        if (originalStack.isEmpty()) {
-                                slot.setStack(ItemStack.EMPTY);
-                        } else {
-                                slot.markDirty();
-                        }
+                @Override
+                public boolean canInsert(ItemStack stack) {
+                        return this.enabled;
                 }
 
-                return newStack;
-        }
-
-        @Override
-        public boolean onButtonClick(PlayerEntity player, int id) {
-                if (blockEntity != null) {
-                        if (id == BUTTON_SELL && player instanceof ServerPlayerEntity serverPlayer) {
-                                if (blockEntity.sell(serverPlayer)) {
-                                        sendContentUpdates();
-                                }
-                                return true;
-                        }
-
-                        if (id == BUTTON_SELECT_SELL_TAB) {
-                                setMarketSlotsEnabled(true);
-                                return true;
-                        }
-
-                        if (id == BUTTON_SELECT_BUY_TAB) {
-                                boolean returnedItems = blockEntity.returnItemsToPlayer(player);
-                                setMarketSlotsEnabled(false);
-                                if (returnedItems) {
-                                        sendContentUpdates();
-                                }
-                                return true;
-                        }
+                @Override
+                public boolean canTakeItems(PlayerEntity player) {
+                        return this.enabled;
                 }
 
-                return super.onButtonClick(player, id);
-        }
-
-        public boolean hasSellableItem() {
-                for (int slot = 0; slot < MarketBlockEntity.INVENTORY_SIZE; slot++) {
-                        if (MarketBlockEntity.isSellable(this.inventory.getStack(slot))) {
-                                return true;
-                        }
-                }
-                return false;
-        }
-
-        private void addPlayerInventory(PlayerInventory playerInventory) {
-                final int baseY = 138;
-                for (int row = 0; row < 3; ++row) {
-                        for (int column = 0; column < 9; ++column) {
-                                this.addSlot(new Slot(playerInventory, column + row * 9 + 9, 8 + column * 18,
-                                                baseY + row * 18));
-                        }
+                @Override
+                public boolean isEnabled() {
+                        return this.enabled;
                 }
         }
 
-        private void addPlayerHotbar(PlayerInventory playerInventory) {
-                final int hotbarY = 196;
-                for (int slot = 0; slot < 9; ++slot) {
-                        this.addSlot(new Slot(playerInventory, slot, 8 + slot * 18, hotbarY));
+        private static class MarketResultSlot extends Slot {
+                private final MarketScreenHandler handler;
+                private boolean enabled;
+
+                public MarketResultSlot(MarketScreenHandler handler, Inventory inventory, int index, int x, int y) {
+                        super(inventory, index, x, y);
+                        this.handler = handler;
+                        this.enabled = false;
+                }
+
+                public void setEnabled(boolean enabled) {
+                        this.enabled = enabled;
+                }
+
+                @Override
+                public boolean canInsert(ItemStack stack) {
+                        return false;
+                }
+
+                @Override
+                public boolean canTakeItems(PlayerEntity player) {
+                        return this.enabled && !getStack().isEmpty();
+                }
+
+                @Override
+                public boolean isEnabled() {
+                        return this.enabled;
+                }
+
+                @Override
+                public void onTakeItem(PlayerEntity player, ItemStack stack) {
+                        boolean purchased = false;
+                        if (this.enabled && player instanceof ServerPlayerEntity serverPlayer) {
+                                purchased = this.handler.processPurchase(serverPlayer, this.handler.selectedOfferIndex, true);
+                        }
+                        super.onTakeItem(player, stack);
+                        if (purchased) {
+                                this.handler.sendContentUpdates();
+                        }
                 }
         }
 }


### PR DESCRIPTION
## Summary
- add cost and result slot management to the garden market handler, mirroring gear shop purchase behaviour
- render garden market buy costs/result with custom overlays and animation, and sync offer selection with the server

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68ea77c9c6a88321b46fc45f22cea76b