### PR TITLE
Fix shift-click transfers into market sell inventory

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
@@ -270,7 +270,17 @@ public class MarketScreenHandler extends ScreenHandler {
                                 return ItemStack.EMPTY;
                         }
                 } else if (index < hotbarEnd) {
-                        if (!this.insertItem(originalStack, costSlotStart, costSlotEnd, false)) {
+                        boolean inserted = false;
+
+                        if (this.areMarketSlotsEnabled()) {
+                                inserted = this.insertItem(originalStack, 0, marketEnd, false);
+                        }
+
+                        if (!inserted && this.areBuySlotsEnabled()) {
+                                inserted = this.insertItem(originalStack, costSlotStart, costSlotEnd, false);
+                        }
+
+                        if (!inserted) {
                                 if (index < playerInventoryEnd) {
                                         if (!this.insertItem(originalStack, hotbarStart, hotbarEnd, false)) {
                                                 return ItemStack.EMPTY;


### PR DESCRIPTION
## Summary
- allow quick-moved items from the player inventory to populate market sell slots when the sell tab is active
- keep quick-move behavior for the buy tab by only targeting cost slots when they are enabled
- fall back to inventory-hotbar swapping when neither sell nor buy slot insertion succeeds

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68ea80f6b1008321a9b40ff1ced1a7ef