### PR TITLE
Add Garden Market buy button

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
@@ -30,6 +30,7 @@ public class MarketScreenHandler extends ScreenHandler {
         public static final int BUTTON_SELL = 0;
         public static final int BUTTON_SELECT_SELL_TAB = 1;
         public static final int BUTTON_SELECT_BUY_TAB = 2;
+        public static final int BUTTON_BUY = 3;
         private static final int BUTTON_SELECT_BUY_OFFER_BASE = 1000;
 
         private static final int SLOT_SIZE = 18;
@@ -421,6 +422,13 @@ public class MarketScreenHandler extends ScreenHandler {
                                 setMarketSlotsEnabled(false);
                                 setBuySlotsEnabled(true);
                                 if (returnedItems) {
+                                        sendContentUpdates();
+                                }
+                                return true;
+                        }
+
+                        if (id == BUTTON_BUY && player instanceof ServerPlayerEntity serverPlayer) {
+                                if (processPurchase(serverPlayer, this.selectedOfferIndex, false)) {
                                         sendContentUpdates();
                                 }
                                 return true;


### PR DESCRIPTION
## Summary
- add a buy button to the Garden Market UI that mirrors the Gear Shop interaction flow
- send purchase clicks to the handler and process them server-side when the button is used
- center the BUY label and hover effects between the two cost slots on the buy tab

## Testing
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68eab6456b0483219567decec1423404