### PR TITLE
Restore quantity overlay in gear shop offer costs

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GearShopScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GearShopScreen.java
@@ -383,6 +383,14 @@ public class GearShopScreen extends HandledScreen<GearShopScreenHandler> {
 
         private void drawCostStack(DrawContext context, ItemStack stack, int x, int y) {
                 context.drawItem(stack, x, y);
+
+                int requestedCount = GearShopStackHelper.getRequestedCount(stack);
+                if (requestedCount > stack.getCount()) {
+                        String label = formatRequestedCount(requestedCount);
+                        context.drawItemInSlot(textRenderer, stack, x, y, label);
+                } else {
+                        context.drawItemInSlot(textRenderer, stack, x, y);
+                }
         }
 
         private void drawCostSlotText(DrawContext context, String label, ItemStack stack, int slotX, int slotY) {


### PR DESCRIPTION
## Summary
- add quantity overlay rendering back to gear shop offer cost stacks so large costs display their required amount

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eae8ea4e7c8321b0c42ed82cdddb97