### PR TITLE
Delay bank balance update until bank screen handler is ready

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/BankBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/BankBlockEntity.java
@@ -20,6 +20,7 @@ import net.minecraft.scoreboard.Scoreboard;
 import net.minecraft.scoreboard.ScoreboardObjective;
 import net.minecraft.scoreboard.ScoreboardPlayerScore;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 
@@ -87,7 +88,16 @@ public class BankBlockEntity extends BlockEntity implements ExtendedScreenHandle
     @Override
     public ScreenHandler createMenu(int syncId, PlayerInventory playerInventory, PlayerEntity player) {
         if (player instanceof ServerPlayerEntity serverPlayer) {
-            sendBalanceUpdate(serverPlayer);
+            MinecraftServer server = serverPlayer.getServer();
+            if (server != null) {
+                BlockPos bankPos = getPos();
+                server.execute(() -> {
+                    if (serverPlayer.currentScreenHandler instanceof BankScreenHandler handler
+                            && handler.getBankPos().equals(bankPos)) {
+                        sendBalanceUpdate(serverPlayer);
+                    }
+                });
+            }
         }
         return new BankScreenHandler(syncId, playerInventory, this);
     }


### PR DESCRIPTION
## Summary
- delay the bank balance synchronization until after the bank screen handler is registered on the player
- ensure the queued synchronization targets the correct bank screen before sending the packet

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68eb232112e88321b9c7f60d229b9a42