### PR TITLE
Handle failed market cost removals

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GearShopScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GearShopScreenHandler.java
@@ -812,7 +812,14 @@ public class GearShopScreenHandler extends ScreenHandler {
                         return false;
                 }
 
-                boolean costSlotsChanged = removeCostStacks(player, offer.costStacks(), playerInv);
+                CostRemovalResult removalResult = removeCostStacks(player, offer.costStacks(), playerInv);
+                if (!removalResult.success()) {
+                        playerInv.markDirty();
+                        if (removalResult.costSlotsChanged()) {
+                                this.costInventory.markDirty();
+                        }
+                        return false;
+                }
                 if (!resultTakenFromSlot) {
                         ItemStack result = offer.copyResultStack();
                         if (!result.isEmpty()) {
@@ -823,7 +830,7 @@ public class GearShopScreenHandler extends ScreenHandler {
                 }
                 populateSelectedOffer(player, offer, false, true);
                 playerInv.markDirty();
-                if (costSlotsChanged) {
+                if (removalResult.costSlotsChanged()) {
                         this.costInventory.markDirty();
                 }
                 return true;
@@ -927,7 +934,8 @@ public class GearShopScreenHandler extends ScreenHandler {
                 return ItemStack.canCombine(firstComparison, secondComparison);
         }
 
-        private boolean removeCostStacks(ServerPlayerEntity player, List<ItemStack> costs, PlayerInventory playerInventory) {
+        private CostRemovalResult removeCostStacks(ServerPlayerEntity player, List<ItemStack> costs,
+                        PlayerInventory playerInventory) {
                 boolean costSlotsChanged = false;
                 for (int index = 0; index < costs.size(); index++) {
                         ItemStack cost = costs.get(index);
@@ -970,7 +978,7 @@ public class GearShopScreenHandler extends ScreenHandler {
 
                                 if (coinsRequired > 0 && player != null) {
                                         if (!WalletItem.withdrawFromBank(player, coinsRequired)) {
-                                                return false;
+                                                return new CostRemovalResult(false, costSlotsChanged);
                                         }
                                 }
 
@@ -989,10 +997,10 @@ public class GearShopScreenHandler extends ScreenHandler {
                                 remaining = removeFromInventory(playerInventory, comparisonStack, remaining);
                         }
                         if (remaining > 0) {
-                                return false;
+                                return new CostRemovalResult(false, costSlotsChanged);
                         }
                 }
-                return costSlotsChanged;
+                return new CostRemovalResult(true, costSlotsChanged);
         }
 
         private SlotConsumptionResult consumeCostSlot(int slotIndex, ItemStack comparisonStack, int required) {
@@ -1030,6 +1038,9 @@ public class GearShopScreenHandler extends ScreenHandler {
         }
 
         private record SlotConsumptionResult(int remaining, boolean changed) {
+        }
+
+        private record CostRemovalResult(boolean success, boolean costSlotsChanged) {
         }
 
         private int removeFromInventory(Inventory inventory, ItemStack comparisonStack, int remaining) {


### PR DESCRIPTION
## Summary
- treat failed cost removal as a hard failure before delivering market or gear shop items
- return detailed cost removal results so inventories remain in sync when purchases abort

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68eb23756c448321901b3a356a011fa9