### PR TITLE
Add interactive bank buttons with hover feedback

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/BankScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/BankScreen.java
@@ -10,6 +10,9 @@ import net.jeremy.gardenkingmod.network.ModPackets;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
+import net.minecraft.client.gui.screen.narration.NarrationPart;
+import net.minecraft.client.gui.widget.ClickableWidget;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
@@ -56,6 +59,8 @@ public class BankScreen extends HandledScreen<BankScreenHandler> {
     private static final int BUTTON_HOVER_V = 223;
 
     private TextFieldWidget withdrawField;
+    private BankActionButton withdrawButton;
+    private BankActionButton depositButton;
 
     public BankScreen(BankScreenHandler handler, PlayerInventory inventory, Text title) {
         super(handler, inventory, title);
@@ -84,6 +89,26 @@ public class BankScreen extends HandledScreen<BankScreenHandler> {
         this.withdrawField.setPlaceholder(Text.translatable("screen.gardenkingmod.bank.withdraw_placeholder"));
         this.withdrawField.setDrawsBackground(false);
         this.addDrawableChild(this.withdrawField);
+
+        this.withdrawButton = new BankActionButton(
+                left + WITHDRAW_BUTTON_X_OFFSET,
+                top + WITHDRAW_BUTTON_Y_OFFSET,
+                WITHDRAW_BUTTON_WIDTH,
+                WITHDRAW_BUTTON_HEIGHT,
+                Text.translatable("screen.gardenkingmod.bank.withdraw"),
+                this::attemptWithdraw);
+        this.addDrawableChild(this.withdrawButton);
+
+        this.depositButton = new BankActionButton(
+                left + DEPOSIT_BUTTON_X_OFFSET,
+                top + DEPOSIT_BUTTON_Y_OFFSET,
+                DEPOSIT_BUTTON_WIDTH,
+                DEPOSIT_BUTTON_HEIGHT,
+                Text.translatable("screen.gardenkingmod.bank.deposit"),
+                this::attemptDeposit);
+        this.addDrawableChild(this.depositButton);
+
+        updateButtonStates();
 
         setInitialFocus(this.withdrawField);
     }
@@ -137,6 +162,7 @@ public class BankScreen extends HandledScreen<BankScreenHandler> {
         if (this.withdrawField != null) {
             this.withdrawField.tick();
         }
+        updateButtonStates();
     }
 
     @Override
@@ -168,19 +194,6 @@ public class BankScreen extends HandledScreen<BankScreenHandler> {
             return true;
         }
 
-        if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
-            if (isPointWithinBounds(WITHDRAW_BUTTON_X_OFFSET, WITHDRAW_BUTTON_Y_OFFSET, WITHDRAW_BUTTON_WIDTH,
-                    WITHDRAW_BUTTON_HEIGHT, mouseX, mouseY)) {
-                attemptWithdraw();
-                return true;
-            }
-
-            if (isPointWithinBounds(DEPOSIT_BUTTON_X_OFFSET, DEPOSIT_BUTTON_Y_OFFSET, DEPOSIT_BUTTON_WIDTH,
-                    DEPOSIT_BUTTON_HEIGHT, mouseX, mouseY)) {
-                attemptDeposit();
-                return true;
-            }
-        }
         return super.mouseClicked(mouseX, mouseY, button);
     }
 
@@ -239,5 +252,52 @@ public class BankScreen extends HandledScreen<BankScreenHandler> {
         }
 
         return Math.max(value, 0L);
+    }
+
+    private void updateButtonStates() {
+        if (this.depositButton != null) {
+            this.depositButton.setActive(this.handler.hasDepositItem());
+        }
+
+        if (this.withdrawButton != null) {
+            long amount = getWithdrawAmount();
+            boolean canWithdraw = amount > 0 && amount <= this.handler.getTotalDollars();
+            this.withdrawButton.setActive(canWithdraw);
+        }
+    }
+
+    private class BankActionButton extends ClickableWidget {
+        private final Runnable onPressAction;
+
+        BankActionButton(int x, int y, int width, int height, Text narration, Runnable onPressAction) {
+            super(x, y, width, height, narration);
+            this.onPressAction = onPressAction;
+        }
+
+        @Override
+        public void onClick(double mouseX, double mouseY) {
+            this.onPressAction.run();
+        }
+
+        @Override
+        public void renderButton(DrawContext context, int mouseX, int mouseY, float delta) {
+            if (!this.visible) {
+                return;
+            }
+
+            if ((this.isHovered() || this.isFocused()) && this.active) {
+                context.drawTexture(BACKGROUND_TEXTURE, this.getX(), this.getY(), BUTTON_HOVER_U, BUTTON_HOVER_V,
+                        this.width, this.height, TEXTURE_WIDTH, TEXTURE_HEIGHT);
+            }
+        }
+
+        @Override
+        protected void appendClickableNarrations(NarrationMessageBuilder builder) {
+            builder.put(NarrationPart.TITLE, this.getMessage());
+        }
+
+        void setActive(boolean active) {
+            this.active = active;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated clickable widgets for the bank screen deposit and withdraw controls
- show the bank GUI hover overlay when the buttons are active and the pointer is over them
- update button enabled state in sync with the withdraw amount field and deposit slot contents

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68ebe3c075348321b3a0b2b3fa85a252