### PR TITLE
Remove duplicate dollar icon from bank screen

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/BankScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/BankScreen.java
@@ -30,20 +30,14 @@ public class BankScreen extends HandledScreen<BankScreenHandler> {
     private static final int DEPOSIT_TITLE_X_OFFSET = 188;
     private static final int DEPOSIT_TITLE_Y_OFFSET = 94;
     private static final ItemStack DOLLAR_STACK = new ItemStack(ModItems.DOLLAR);
-    private static final Identifier DOLLAR_ITEM_TEXTURE = new Identifier(GardenKingMod.MOD_ID,
-            "textures/item/dollar.png");
-    private static final int DOLLAR_TEXTURE_WIDTH = 16;
-    private static final int DOLLAR_TEXTURE_HEIGHT = 16;
-    private static final int DOLLAR_TEXTURE_X_OFFSET = 80;
-    private static final int DOLLAR_TEXTURE_Y_OFFSET = 36;
 
     private static final int TEXTURE_WIDTH = 300;
     private static final int TEXTURE_HEIGHT = 256;
     private static final int BASE_GUI_WIDTH = 176;
     private static final int BALANCE_SLOT_X_OFFSET = (BASE_GUI_WIDTH - BankScreenHandler.SLOT_SIZE) / 2;
     private static final int BALANCE_SLOT_Y_OFFSET = 24;
-    private static final int BALANCE_SLOT_LABEL_OFFSET = BankScreenHandler.SLOT_SIZE + 12;
-    private static final int BALANCE_TEXT_Y_OFFSET = BALANCE_SLOT_Y_OFFSET + BankScreenHandler.SLOT_SIZE + 28;
+    private static final int BALANCE_SLOT_LABEL_OFFSET = BankScreenHandler.SLOT_SIZE + 22;
+    private static final int BALANCE_TEXT_Y_OFFSET = BALANCE_SLOT_Y_OFFSET + BankScreenHandler.SLOT_SIZE + 38;
     private static final int WITHDRAW_FIELD_WIDTH = 72;
     private static final int WITHDRAW_FIELD_HEIGHT = 22;
     private static final int WITHDRAW_FIELD_X_OFFSET = 196;
@@ -118,9 +112,6 @@ public class BankScreen extends HandledScreen<BankScreenHandler> {
     protected void drawBackground(DrawContext context, float delta, int mouseX, int mouseY) {
         context.drawTexture(BACKGROUND_TEXTURE, x, y, 0, 0, backgroundWidth, backgroundHeight,
                 BACKGROUND_TEXTURE_WIDTH, BACKGROUND_TEXTURE_HEIGHT);
-        context.drawTexture(DOLLAR_ITEM_TEXTURE, x + DOLLAR_TEXTURE_X_OFFSET, y + DOLLAR_TEXTURE_Y_OFFSET, 0, 0,
-                DOLLAR_TEXTURE_WIDTH, DOLLAR_TEXTURE_HEIGHT, DOLLAR_TEXTURE_WIDTH, DOLLAR_TEXTURE_HEIGHT);
-
         context.drawText(this.textRenderer,
                 Text.translatable("screen.gardenkingmod.bank.withdraw"),
                 x + WITHDRAW_TITLE_X_OFFSET,


### PR DESCRIPTION
## Summary
- stop rendering the extra dollar texture on the bank screen
- shift the dollar slot label and balance text 10 pixels lower to match the updated layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebe9dd0a6883219337467d8b895638