### PR TITLE
Reset shader color before rendering bank screen textures

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/BankScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/BankScreen.java
@@ -2,6 +2,8 @@ package net.jeremy.gardenkingmod.screen;
 
 import org.lwjgl.glfw.GLFW;
 
+import com.mojang.blaze3d.systems.RenderSystem;
+
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.jeremy.gardenkingmod.GardenKingMod;
@@ -125,6 +127,7 @@ public class BankScreen extends HandledScreen<BankScreenHandler> {
 
     @Override
     protected void drawBackground(DrawContext context, float delta, int mouseX, int mouseY) {
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
         context.drawTexture(BACKGROUND_TEXTURE, x, y, 0, 0, backgroundWidth, backgroundHeight,
                 BACKGROUND_TEXTURE_WIDTH, BACKGROUND_TEXTURE_HEIGHT);
         context.drawText(this.textRenderer,
@@ -321,6 +324,7 @@ public class BankScreen extends HandledScreen<BankScreenHandler> {
             }
 
             if ((this.isHovered() || this.isFocused()) && this.active) {
+                RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
                 context.drawTexture(BACKGROUND_TEXTURE, this.getX(), this.getY(), BUTTON_HOVER_U, BUTTON_HOVER_V,
                         this.width, this.height, TEXTURE_WIDTH, TEXTURE_HEIGHT);
             }


### PR DESCRIPTION
## Summary
- ensure the bank screen background and hover overlays reset the shader color before drawing so the texture renders without stray tinting

## Testing
- not run (environment lacks access to required dependencies for `genSources`)


------
https://chatgpt.com/codex/tasks/task_e_68ec07cebfb08321b3686363665bef38