### PR TITLE
Fix wallet bank balance sync when opening

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/item/WalletItem.java
+++ b/src/main/java/net/jeremy/gardenkingmod/item/WalletItem.java
@@ -19,6 +19,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.text.Text;
@@ -393,7 +394,15 @@ public class WalletItem extends Item {
                 public ScreenHandler createMenu(int syncId, PlayerInventory playerInventory, PlayerEntity player) {
                         BankScreenHandler handler = BankScreenHandler.createRemote(syncId, playerInventory);
                         if (player instanceof ServerPlayerEntity serverPlayer) {
-                                handler.sendBalanceUpdate(serverPlayer);
+                                MinecraftServer server = serverPlayer.getServer();
+                                if (server != null) {
+                                        server.execute(() -> {
+                                                if (serverPlayer.currentScreenHandler instanceof BankScreenHandler bankHandler
+                                                                && bankHandler.syncId == syncId) {
+                                                        bankHandler.sendBalanceUpdate(serverPlayer);
+                                                }
+                                        });
+                                }
                         }
                         return handler;
                 }


### PR DESCRIPTION
## Summary
- delay remote bank balance synchronization until after the wallet bank screen opens
- ensure the bank balance packet is sent once the player is actually viewing the screen to prevent stale zeros

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68ec986b7aec8321ac35b01c5434b166