### PR TITLE
Render bank block with custom entity model

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -10,17 +10,23 @@ import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.jeremy.gardenkingmod.client.model.BankBlockModel;
 import net.jeremy.gardenkingmod.client.model.CrowEntityModel;
 import net.jeremy.gardenkingmod.client.model.GearShopModel;
 import net.jeremy.gardenkingmod.client.model.MarketBlockModel;
 import net.jeremy.gardenkingmod.client.model.ScarecrowModel;
+import net.jeremy.gardenkingmod.client.render.BankBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.CrowEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.GearShopBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.ScarecrowBlockEntityRenderer;
+import net.jeremy.gardenkingmod.client.render.item.BankItemRenderer;
 import net.jeremy.gardenkingmod.client.render.item.GearShopItemRenderer;
 import net.jeremy.gardenkingmod.client.render.item.MarketItemRenderer;
 import net.jeremy.gardenkingmod.client.render.item.ScarecrowItemRenderer;
+import net.jeremy.gardenkingmod.registry.ModEntities;
+import net.jeremy.gardenkingmod.ModBlockEntities;
+import net.jeremy.gardenkingmod.ModBlocks;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.item.FortuneProvidingItem;
 import net.jeremy.gardenkingmod.network.ModPackets;
@@ -38,7 +44,6 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
-import net.jeremy.gardenkingmod.registry.ModEntities;
 
 public class GardenKingModClient implements ClientModInitializer {
     @Override
@@ -47,17 +52,20 @@ public class GardenKingModClient implements ClientModInitializer {
         HandledScreens.register(ModScreenHandlers.MARKET_SCREEN_HANDLER, MarketScreen::new);
         HandledScreens.register(ModScreenHandlers.SCARECROW_SCREEN_HANDLER, ScarecrowScreen::new);
         HandledScreens.register(ModScreenHandlers.BANK_SCREEN_HANDLER, BankScreen::new);
+        EntityModelLayerRegistry.registerModelLayer(BankBlockModel.LAYER_LOCATION, BankBlockModel::getTexturedModelData);
         EntityModelLayerRegistry.registerModelLayer(MarketBlockModel.LAYER_LOCATION, MarketBlockModel::getTexturedModelData);
         EntityModelLayerRegistry.registerModelLayer(GearShopModel.LAYER_LOCATION,
                         GearShopModel::getTexturedModelData);
         EntityModelLayerRegistry.registerModelLayer(ScarecrowModel.LAYER_LOCATION, ScarecrowModel::getTexturedModelData);
 
         EntityModelLayerRegistry.registerModelLayer(CrowEntityModel.LAYER_LOCATION, CrowEntityModel::getTexturedModelData);
+        BlockEntityRendererFactories.register(ModBlockEntities.BANK_BLOCK_ENTITY, BankBlockEntityRenderer::new);
         BlockEntityRendererFactories.register(ModBlockEntities.MARKET_BLOCK_ENTITY, MarketBlockEntityRenderer::new);
         BlockEntityRendererFactories.register(ModBlockEntities.GEAR_SHOP_BLOCK_ENTITY,
                         GearShopBlockEntityRenderer::new);
         BlockEntityRendererFactories.register(ModBlockEntities.SCARECROW_BLOCK_ENTITY, ScarecrowBlockEntityRenderer::new);
         EntityRendererRegistry.register(ModEntities.CROW, CrowEntityRenderer::new);
+        BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.BANK_BLOCK, new BankItemRenderer());
         BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.MARKET_BLOCK, new MarketItemRenderer());
         BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.GEAR_SHOP_BLOCK, new GearShopItemRenderer());
         BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.SCARECROW_BLOCK, new ScarecrowItemRenderer());

--- a/src/main/java/net/jeremy/gardenkingmod/block/BankBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/BankBlock.java
@@ -152,7 +152,7 @@ public class BankBlock extends BlockWithEntity {
 
     @Override
     public BlockRenderType getRenderType(BlockState state) {
-        return BlockRenderType.MODEL;
+        return BlockRenderType.ENTITYBLOCK_ANIMATED;
     }
 
     @Override

--- a/src/main/java/net/jeremy/gardenkingmod/client/model/BankBlockModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/BankBlockModel.java
@@ -1,46 +1,81 @@
 package net.jeremy.gardenkingmod.client.model;
 
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.minecraft.client.model.Dilation;
+import net.minecraft.client.model.ModelData;
+import net.minecraft.client.model.ModelPart;
+import net.minecraft.client.model.ModelPartBuilder;
+import net.minecraft.client.model.ModelPartData;
+import net.minecraft.client.model.ModelTransform;
+import net.minecraft.client.model.TexturedModelData;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.entity.model.EntityModel;
+import net.minecraft.client.render.entity.model.EntityModelLayer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.Identifier;
+
 // Made with Blockbench 4.12.6
 // Exported for Minecraft version 1.17+ for Yarn
-// Paste this class into your mod and generate all required imports
-public class bank_block extends EntityModel<Entity> {
-	private final ModelPart left_case;
-	private final ModelPart right_case;
-	private final ModelPart bb_main;
-	public bank_block(ModelPart root) {
-		this.left_case = root.getChild("left_case");
-		this.right_case = root.getChild("right_case");
-		this.bb_main = root.getChild("bb_main");
-	}
-	public static TexturedModelData getTexturedModelData() {
-		ModelData modelData = new ModelData();
-		ModelPartData modelPartData = modelData.getRoot();
-		ModelPartData left_case = modelPartData.addChild("left_case", ModelPartBuilder.create().uv(64, 0).cuboid(-1.0F, 0.0F, -3.0F, 2.0F, 5.0F, 8.0F, new Dilation(0.0F))
-		.uv(66, 59).cuboid(-1.0F, -2.0F, -3.0F, 2.0F, 2.0F, 7.0F, new Dilation(0.0F))
-		.uv(18, 68).cuboid(-1.0F, -4.0F, -3.0F, 2.0F, 2.0F, 5.0F, new Dilation(0.0F))
-		.uv(64, 26).cuboid(-1.0F, -6.0F, -3.0F, 2.0F, 2.0F, 3.0F, new Dilation(0.0F)), ModelTransform.pivot(7.0F, -2.0F, 3.0F));
+public class BankBlockModel extends EntityModel<Entity> {
+    public static final EntityModelLayer LAYER_LOCATION = new EntityModelLayer(
+            new Identifier(GardenKingMod.MOD_ID, "bank_block"),
+            "main"
+    );
 
-		ModelPartData right_case = modelPartData.addChild("right_case", ModelPartBuilder.create().uv(32, 73).cuboid(-1.0F, 4.0F, -3.0F, 2.0F, 2.0F, 3.0F, new Dilation(0.0F))
-		.uv(66, 68).cuboid(-1.0F, 6.0F, -3.0F, 2.0F, 2.0F, 5.0F, new Dilation(0.0F))
-		.uv(0, 68).cuboid(-1.0F, 8.0F, -3.0F, 2.0F, 2.0F, 7.0F, new Dilation(0.0F))
-		.uv(64, 13).cuboid(-1.0F, 10.0F, -3.0F, 2.0F, 5.0F, 8.0F, new Dilation(0.0F)), ModelTransform.pivot(-7.0F, -12.0F, 3.0F));
+    private final ModelPart leftCase;
+    private final ModelPart rightCase;
+    private final ModelPart bbMain;
 
-		ModelPartData bb_main = modelPartData.addChild("bb_main", ModelPartBuilder.create().uv(0, 0).cuboid(-8.0F, -16.0F, -8.0F, 16.0F, 16.0F, 16.0F, new Dilation(0.0F))
-		.uv(0, 32).cuboid(-8.0F, -32.0F, -8.0F, 16.0F, 16.0F, 8.0F, new Dilation(0.0F))
-		.uv(48, 46).cuboid(-8.0F, -21.0F, 0.0F, 16.0F, 5.0F, 8.0F, new Dilation(0.0F))
-		.uv(48, 32).cuboid(-8.0F, -35.0F, -8.0F, 16.0F, 3.0F, 11.0F, new Dilation(0.0F))
-		.uv(0, 56).cuboid(-8.0F, -44.0F, -4.0F, 16.0F, 9.0F, 3.0F, new Dilation(0.0F)), ModelTransform.pivot(0.0F, 24.0F, 0.0F));
+    public BankBlockModel(ModelPart root) {
+        this.leftCase = root.getChild("left_case");
+        this.rightCase = root.getChild("right_case");
+        this.bbMain = root.getChild("bb_main");
+    }
 
-		ModelPartData screen_r1 = bb_main.addChild("screen_r1", ModelPartBuilder.create().uv(38, 59).cuboid(-6.0F, -9.0F, -1.0F, 12.0F, 12.0F, 2.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, -23.0F, 3.0F, 0.48F, 0.0F, 0.0F));
-		return TexturedModelData.of(modelData, 128, 128);
-	}
-	@Override
-	public void setAngles(Entity entity, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch) {
-	}
-	@Override
-	public void render(MatrixStack matrices, VertexConsumer vertexConsumer, int light, int overlay, float red, float green, float blue, float alpha) {
-		left_case.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
-		right_case.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
-		bb_main.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
-	}
+    public static TexturedModelData getTexturedModelData() {
+        ModelData modelData = new ModelData();
+        ModelPartData modelPartData = modelData.getRoot();
+
+        modelPartData.addChild("left_case", ModelPartBuilder.create().uv(64, 0).cuboid(-1.0F, 0.0F, -3.0F, 2.0F, 5.0F, 8.0F,
+                        new Dilation(0.0F))
+                .uv(66, 59).cuboid(-1.0F, -2.0F, -3.0F, 2.0F, 2.0F, 7.0F, new Dilation(0.0F))
+                .uv(18, 68).cuboid(-1.0F, -4.0F, -3.0F, 2.0F, 2.0F, 5.0F, new Dilation(0.0F))
+                .uv(64, 26).cuboid(-1.0F, -6.0F, -3.0F, 2.0F, 2.0F, 3.0F, new Dilation(0.0F)),
+                ModelTransform.pivot(7.0F, -2.0F, 3.0F));
+
+        modelPartData.addChild("right_case",
+                ModelPartBuilder.create().uv(32, 73).cuboid(-1.0F, 4.0F, -3.0F, 2.0F, 2.0F, 3.0F, new Dilation(0.0F))
+                        .uv(66, 68).cuboid(-1.0F, 6.0F, -3.0F, 2.0F, 2.0F, 5.0F, new Dilation(0.0F))
+                        .uv(0, 68).cuboid(-1.0F, 8.0F, -3.0F, 2.0F, 2.0F, 7.0F, new Dilation(0.0F))
+                        .uv(64, 13).cuboid(-1.0F, 10.0F, -3.0F, 2.0F, 5.0F, 8.0F, new Dilation(0.0F)),
+                ModelTransform.pivot(-7.0F, -12.0F, 3.0F));
+
+        ModelPartData bbMain = modelPartData.addChild("bb_main",
+                ModelPartBuilder.create().uv(0, 0).cuboid(-8.0F, -16.0F, -8.0F, 16.0F, 16.0F, 16.0F, new Dilation(0.0F))
+                        .uv(0, 32).cuboid(-8.0F, -32.0F, -8.0F, 16.0F, 16.0F, 8.0F, new Dilation(0.0F))
+                        .uv(48, 46).cuboid(-8.0F, -21.0F, 0.0F, 16.0F, 5.0F, 8.0F, new Dilation(0.0F))
+                        .uv(48, 32).cuboid(-8.0F, -35.0F, -8.0F, 16.0F, 3.0F, 11.0F, new Dilation(0.0F))
+                        .uv(0, 56).cuboid(-8.0F, -44.0F, -4.0F, 16.0F, 9.0F, 3.0F, new Dilation(0.0F)),
+                ModelTransform.pivot(0.0F, 24.0F, 0.0F));
+
+        bbMain.addChild("screen_r1",
+                ModelPartBuilder.create().uv(38, 59).cuboid(-6.0F, -9.0F, -1.0F, 12.0F, 12.0F, 2.0F, new Dilation(0.0F)),
+                ModelTransform.of(0.0F, -23.0F, 3.0F, 0.48F, 0.0F, 0.0F));
+
+        return TexturedModelData.of(modelData, 128, 128);
+    }
+
+    @Override
+    public void setAngles(Entity entity, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw,
+            float headPitch) {
+    }
+
+    @Override
+    public void render(MatrixStack matrices, VertexConsumer vertexConsumer, int light, int overlay, float red, float green,
+            float blue, float alpha) {
+        leftCase.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
+        rightCase.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
+        bbMain.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
+    }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/BankBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/BankBlockEntityRenderer.java
@@ -1,0 +1,67 @@
+package net.jeremy.gardenkingmod.client.render;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.block.BankBlock;
+import net.jeremy.gardenkingmod.block.entity.BankBlockEntity;
+import net.jeremy.gardenkingmod.client.model.BankBlockModel;
+import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.render.OverlayTexture;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.client.render.block.entity.BlockEntityRenderer;
+import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.RotationAxis;
+import net.minecraft.world.World;
+
+public class BankBlockEntityRenderer implements BlockEntityRenderer<BankBlockEntity> {
+    private static final Identifier TEXTURE = new Identifier(
+            GardenKingMod.MOD_ID,
+            "textures/entity/bank/bank.png"
+    );
+
+    private final BankBlockModel model;
+
+    public BankBlockEntityRenderer(BlockEntityRendererFactory.Context context) {
+        this.model = new BankBlockModel(context.getLayerModelPart(BankBlockModel.LAYER_LOCATION));
+    }
+
+    @Override
+    public void render(BankBlockEntity entity, float tickDelta, MatrixStack matrices,
+                       VertexConsumerProvider vertexConsumers, int light, int overlay) {
+        matrices.push();
+        matrices.translate(0.5f, 1.5f, 0.5f);
+
+        Direction facing = entity.getCachedState() != null ? entity.getCachedState().get(BankBlock.FACING) : null;
+        if (facing != null) {
+            float yRotation;
+            switch (facing) {
+                case NORTH -> yRotation = 0.0f;
+                case EAST -> yRotation = 90.0f;
+                case SOUTH -> yRotation = 180.0f;
+                case WEST -> yRotation = 270.0f;
+                default -> yRotation = 0.0f;
+            }
+            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(yRotation));
+        }
+
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
+
+        World world = entity.getWorld();
+        int combinedLight = LightmapTextureManager.MAX_LIGHT_COORDINATE;
+        if (world != null) {
+            BlockPos posAbove = entity.getPos().up();
+            combinedLight = WorldRenderer.getLightmapCoordinates(world, posAbove);
+        }
+
+        VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));
+        this.model.render(matrices, vertexConsumer, combinedLight, OverlayTexture.DEFAULT_UV, 1.0f, 1.0f, 1.0f, 1.0f);
+
+        matrices.pop();
+    }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/item/BankItemRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/item/BankItemRenderer.java
@@ -1,0 +1,68 @@
+package net.jeremy.gardenkingmod.client.render.item;
+
+import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.client.model.BankBlockModel;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.model.json.ModelTransformationMode;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.RotationAxis;
+
+public class BankItemRenderer implements BuiltinItemRendererRegistry.DynamicItemRenderer {
+    private static final Identifier TEXTURE = new Identifier(
+            GardenKingMod.MOD_ID,
+            "textures/entity/bank/bank.png"
+    );
+
+    private BankBlockModel model;
+
+    public BankItemRenderer() {
+    }
+
+    @Override
+    public void render(ItemStack stack, ModelTransformationMode mode, MatrixStack matrices,
+                       VertexConsumerProvider vertexConsumers, int light, int overlay) {
+        matrices.push();
+        matrices.translate(0.5f, 1.5f, 0.5f);
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
+
+        if (mode != null) {
+            switch (mode) {
+                case GUI -> {
+                    matrices.scale(0.18f, 0.18f, 0.18f);
+                    matrices.translate(0.0, 4.0, 0.0);
+                }
+                case GROUND -> {
+                    matrices.scale(0.18f, 0.18f, 0.18f);
+                    matrices.translate(0.0, 2.8, 0.0);
+                }
+                case FIXED -> {
+                    matrices.scale(0.18f, 0.18f, 0.18f);
+                    matrices.translate(0.0, 3.0, 0.0);
+                }
+                case FIRST_PERSON_LEFT_HAND, FIRST_PERSON_RIGHT_HAND,
+                        THIRD_PERSON_LEFT_HAND, THIRD_PERSON_RIGHT_HAND -> {
+                    matrices.scale(0.16f, 0.16f, 0.16f);
+                    matrices.translate(0.0f, 3.0f, 0.0f);
+                }
+                default -> {
+                }
+            }
+        }
+
+        if (this.model == null) {
+            this.model = new BankBlockModel(MinecraftClient.getInstance().getEntityModelLoader()
+                    .getModelPart(BankBlockModel.LAYER_LOCATION));
+        }
+
+        VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));
+        this.model.render(matrices, vertexConsumer, light, overlay, 1.0f, 1.0f, 1.0f, 1.0f);
+
+        matrices.pop();
+    }
+}

--- a/src/main/resources/assets/gardenkingmod/blockstates/bank_block.json
+++ b/src/main/resources/assets/gardenkingmod/blockstates/bank_block.json
@@ -1,12 +1,12 @@
 {
   "variants": {
-    "facing=north,half=lower": { "model": "gardenkingmod:block/bank_lower" },
-    "facing=south,half=lower": { "model": "gardenkingmod:block/bank_lower", "y": 180 },
-    "facing=west,half=lower": { "model": "gardenkingmod:block/bank_lower", "y": 270 },
-    "facing=east,half=lower": { "model": "gardenkingmod:block/bank_lower", "y": 90 },
-    "facing=north,half=upper": { "model": "gardenkingmod:block/bank_upper" },
-    "facing=south,half=upper": { "model": "gardenkingmod:block/bank_upper", "y": 180 },
-    "facing=west,half=upper": { "model": "gardenkingmod:block/bank_upper", "y": 270 },
-    "facing=east,half=upper": { "model": "gardenkingmod:block/bank_upper", "y": 90 }
+    "facing=north,half=lower": { "model": "minecraft:block/air" },
+    "facing=south,half=lower": { "model": "minecraft:block/air" },
+    "facing=west,half=lower": { "model": "minecraft:block/air" },
+    "facing=east,half=lower": { "model": "minecraft:block/air" },
+    "facing=north,half=upper": { "model": "minecraft:block/air" },
+    "facing=south,half=upper": { "model": "minecraft:block/air" },
+    "facing=west,half=upper": { "model": "minecraft:block/air" },
+    "facing=east,half=upper": { "model": "minecraft:block/air" }
   }
 }

--- a/src/main/resources/assets/gardenkingmod/models/item/bank_block.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/bank_block.json
@@ -1,3 +1,3 @@
 {
-  "parent": "gardenkingmod:block/bank_lower"
+  "parent": "minecraft:builtin/entity"
 }


### PR DESCRIPTION
## Summary
- replace the bank block's model class with a properly generated entity model layer
- add a block entity renderer and built-in item renderer that draw the new bank model and register them on the client
- switch the bank block to entity rendering and update its blockstate and item model JSON to rely on the custom renderer

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68ed49ea135083218f402267e6a111b2