### PR TITLE
Fix bank block lighting and placement orientation

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/BankBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/BankBlock.java
@@ -58,7 +58,7 @@ public class BankBlock extends BlockWithEntity {
             return null;
         }
 
-        return this.getDefaultState().with(FACING, ctx.getHorizontalPlayerFacing().getOpposite());
+        return this.getDefaultState().with(FACING, ctx.getHorizontalPlayerFacing());
     }
 
     @Override

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/BankBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/BankBlockEntityRenderer.java
@@ -55,8 +55,13 @@ public class BankBlockEntityRenderer implements BlockEntityRenderer<BankBlockEnt
         World world = entity.getWorld();
         int combinedLight = LightmapTextureManager.MAX_LIGHT_COORDINATE;
         if (world != null) {
-            BlockPos posAbove = entity.getPos().up();
-            combinedLight = WorldRenderer.getLightmapCoordinates(world, posAbove);
+            BlockPos lowerPos = entity.getPos();
+            BlockPos upperPos = lowerPos.up();
+            int lowerLight = WorldRenderer.getLightmapCoordinates(world, lowerPos);
+            int upperLight = WorldRenderer.getLightmapCoordinates(world, upperPos);
+            int blockLight = Math.max(lowerLight & 0xFFFF, upperLight & 0xFFFF);
+            int skyLight = Math.max((lowerLight >> 16) & 0xFFFF, (upperLight >> 16) & 0xFFFF);
+            combinedLight = (skyLight << 16) | blockLight;
         }
 
         VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));


### PR DESCRIPTION
## Summary
- ensure the bank block records the player's facing direction during placement so its interactive south face points at the placer
- sample both halves of the bank block entity when computing light to avoid overly dark rendering

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68edc4318d748321a52bd66e104d1d96