### PR TITLE
Fix bank block orientation and lighting

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/BankBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/BankBlock.java
@@ -58,7 +58,8 @@ public class BankBlock extends BlockWithEntity {
             return null;
         }
 
-        return this.getDefaultState().with(FACING, ctx.getHorizontalPlayerFacing());
+        Direction facing = ctx.getHorizontalPlayerFacing().getOpposite();
+        return this.getDefaultState().with(FACING, facing);
     }
 
     @Override
@@ -68,8 +69,18 @@ public class BankBlock extends BlockWithEntity {
             return;
         }
 
+        Direction facing = state.get(FACING);
+        if (placer instanceof PlayerEntity player) {
+            facing = player.getHorizontalFacing().getOpposite();
+        }
+
+        BlockState lowerState = state.with(FACING, facing).with(HALF, DoubleBlockHalf.LOWER);
         BlockPos abovePos = pos.up();
-        BlockState upperState = state.with(HALF, DoubleBlockHalf.UPPER);
+        BlockState upperState = lowerState.with(HALF, DoubleBlockHalf.UPPER);
+
+        if (!state.equals(lowerState)) {
+            world.setBlockState(pos, lowerState, Block.NOTIFY_ALL);
+        }
         world.setBlockState(abovePos, upperState, Block.NOTIFY_ALL);
 
         BlockEntity blockEntity = world.getBlockEntity(pos);

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/BankBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/BankBlockEntityRenderer.java
@@ -4,7 +4,6 @@ import net.jeremy.gardenkingmod.GardenKingMod;
 import net.jeremy.gardenkingmod.block.BankBlock;
 import net.jeremy.gardenkingmod.block.entity.BankBlockEntity;
 import net.jeremy.gardenkingmod.client.model.BankBlockModel;
-import net.minecraft.block.enums.DoubleBlockHalf;
 import net.minecraft.client.render.LightmapTextureManager;
 import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.RenderLayer;
@@ -40,28 +39,20 @@ public class BankBlockEntityRenderer implements BlockEntityRenderer<BankBlockEnt
 
         Direction facing = entity.getCachedState() != null ? entity.getCachedState().get(BankBlock.FACING) : null;
         if (facing != null) {
-            float yRotation;
-            switch (facing) {
-                case SOUTH -> yRotation = 0.0f;
-                case WEST -> yRotation = 90.0f;
-                case NORTH -> yRotation = 180.0f;
-                case EAST -> yRotation = 270.0f;
-                default -> yRotation = 0.0f;
-            }
-            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(yRotation));
+            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(facing.asRotation()));
         }
 
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));
 
         World world = entity.getWorld();
-        int combinedLight = LightmapTextureManager.MAX_LIGHT_COORDINATE;
+        int combinedLight = light;
         if (world != null) {
             BlockPos basePos = entity.getPos();
-            int lowerLight = WorldRenderer.getLightmapCoordinates(world, basePos);
-            int upperLight = WorldRenderer.getLightmapCoordinates(world, basePos.up());
+            int lowerLight = WorldRenderer.getLightmapCoordinates(world, entity.getCachedState(), basePos);
+            int upperLight = WorldRenderer.getLightmapCoordinates(world, world.getBlockState(basePos.up()), basePos.up());
             int blockLight = Math.max(lowerLight & 0xFFFF, upperLight & 0xFFFF);
             int skyLight = Math.max((lowerLight >> 16) & 0xFFFF, (upperLight >> 16) & 0xFFFF);
-            combinedLight = (skyLight << 16) | blockLight;
+            combinedLight = LightmapTextureManager.pack(blockLight, skyLight);
         }
 
         VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(TEXTURE));


### PR DESCRIPTION
## Summary
- ensure the bank block sets its facing toward the player during placement and keeps both halves in sync
- update the bank block renderer to use the block state's rotation and packed light to prevent the darkened texture

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68ede4e120a48321bfa9fb53fe9bc181