### PR TITLE
Fix bank block rotation to face player

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/render/BankBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/BankBlockEntityRenderer.java
@@ -39,7 +39,7 @@ public class BankBlockEntityRenderer implements BlockEntityRenderer<BankBlockEnt
 
         Direction facing = entity.getCachedState() != null ? entity.getCachedState().get(BankBlock.FACING) : null;
         if (facing != null) {
-            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(facing.asRotation()));
+            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(-facing.asRotation()));
         }
 
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(180.0f));


### PR DESCRIPTION
## Summary
- reverse the applied horizontal rotation in the bank block renderer so the model's south face turns toward the player on placement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ede7ef26808321a012abca95bfae2f