### PR TITLE
Add configurable fertilizer from rotten crops

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
@@ -8,6 +8,7 @@ import net.jeremy.gardenkingmod.armor.ModArmorSetEffects;
 import net.jeremy.gardenkingmod.crop.BonusHarvestDropManager;
 import net.jeremy.gardenkingmod.crop.CropDropModifier;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
+import net.jeremy.gardenkingmod.item.FertilizerBalanceConfig;
 import net.jeremy.gardenkingmod.item.WalletItem;
 import net.jeremy.gardenkingmod.network.ModServerNetworking;
 import net.jeremy.gardenkingmod.registry.ModEntities;
@@ -26,6 +27,7 @@ public class GardenKingMod implements ModInitializer {
 
         @Override
         public void onInitialize() {
+                FertilizerBalanceConfig.reload();
                 ModItems.registerModItems();
                 ModBlocks.registerModBlocks();
                 ModBlockEntities.registerBlockEntities();

--- a/src/main/java/net/jeremy/gardenkingmod/ModItems.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModItems.java
@@ -9,14 +9,17 @@ import java.util.Map;
 
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.fabricmc.fabric.api.registry.CompostingChanceRegistry;
 import net.jeremy.gardenkingmod.crop.RottenCropDefinition;
 import net.jeremy.gardenkingmod.crop.RottenCropDefinitions;
 import net.jeremy.gardenkingmod.item.AmethystArmorMaterial;
 import net.jeremy.gardenkingmod.item.AmethystToolMaterial;
 import net.jeremy.gardenkingmod.item.BlueSapphireArmorMaterial;
 import net.jeremy.gardenkingmod.item.BlueSapphireToolMaterial;
+import net.jeremy.gardenkingmod.item.CompostFertilizerItem;
 import net.jeremy.gardenkingmod.item.EmeraldArmorMaterial;
 import net.jeremy.gardenkingmod.item.EmeraldToolMaterial;
+import net.jeremy.gardenkingmod.item.FertilizerBalanceConfig;
 import net.jeremy.gardenkingmod.item.FortuneHoeItem;
 import net.jeremy.gardenkingmod.item.ObsidianArmorMaterial;
 import net.jeremy.gardenkingmod.item.ObsidianToolMaterial;
@@ -38,6 +41,7 @@ import net.minecraft.item.SwordItem;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
 
 public final class ModItems {
         public static final Item WALLET = registerItem("wallet", new WalletItem(new FabricItemSettings()));
@@ -162,6 +166,8 @@ public final class ModItems {
                         new ArmorItem(AmethystArmorMaterial.INSTANCE, ArmorItem.Type.LEGGINGS, new FabricItemSettings()));
         public static final Item AMETHYST_BOOTS = registerItem("amethyst_boots",
                         new ArmorItem(AmethystArmorMaterial.INSTANCE, ArmorItem.Type.BOOTS, new FabricItemSettings()));
+        public static final Item SPECIAL_FERTILIZER = registerItem("special_fertilizer",
+                        new CompostFertilizerItem(new FabricItemSettings()));
         public static final Item OBSIDIAN_HELMET = registerItem("obsidian_helmet",
                         new ArmorItem(ObsidianArmorMaterial.INSTANCE, ArmorItem.Type.HELMET, new FabricItemSettings()));
         public static final Item OBSIDIAN_CHESTPLATE = registerItem("obsidian_chestplate",
@@ -238,6 +244,7 @@ public final class ModItems {
                 if (!initializeRottenItems()) {
                         GardenKingMod.LOGGER.warn("Skipping rotten item registration until crop definitions are available");
                 }
+                registerCompostables();
                 ItemGroupEvents.modifyEntriesEvent(ItemGroups.INGREDIENTS)
                                 .register(entries -> {
                                         entries.add(DOLLAR);
@@ -246,6 +253,7 @@ public final class ModItems {
                                         entries.add(BLUE_SAPPHIRE);
                                         entries.add(TOPAZ);
                                         entries.add(PEARL);
+                                        entries.add(SPECIAL_FERTILIZER);
                                         rottenItems.forEach(entries::add);
                                 });
                 ItemGroupEvents.modifyEntriesEvent(ItemGroups.FUNCTIONAL)
@@ -323,5 +331,17 @@ public final class ModItems {
                                         entries.add(EMERALD_LEGGINGS);
                                         entries.add(EMERALD_BOOTS);
                                 });
+        }
+
+        private static void registerCompostables() {
+                double chanceValue = MathHelper.clamp(FertilizerBalanceConfig.get().rottenCompostChance(), 0.0, 1.0);
+                if (chanceValue <= 0.0) {
+                        return;
+                }
+
+                float chance = (float) chanceValue;
+                for (Item item : rottenItems) {
+                        CompostingChanceRegistry.INSTANCE.add(item, chance);
+                }
         }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/item/CompostFertilizerItem.java
+++ b/src/main/java/net/jeremy/gardenkingmod/item/CompostFertilizerItem.java
@@ -1,0 +1,74 @@
+package net.jeremy.gardenkingmod.item;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Fertilizable;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemUsageContext;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.World;
+import net.minecraft.world.event.GameEvent;
+import net.minecraft.world.WorldEvents;
+
+/**
+ * Custom fertilizer produced from rotten crops. Works similarly to bone meal
+ * but uses the configurable growth chance defined in
+ * {@link FertilizerBalanceConfig}.
+ */
+public class CompostFertilizerItem extends Item {
+        public CompostFertilizerItem(Settings settings) {
+                super(settings);
+        }
+
+        @Override
+        public ActionResult useOnBlock(ItemUsageContext context) {
+                World world = context.getWorld();
+                BlockPos pos = context.getBlockPos();
+                BlockState state = world.getBlockState(pos);
+                if (!(state.getBlock() instanceof Fertilizable fertilizable)) {
+                        return ActionResult.PASS;
+                }
+
+                if (world.isClient) {
+                        return ActionResult.SUCCESS;
+                }
+
+                return applyFertilizer(context, (ServerWorld) world, fertilizable, state);
+        }
+
+        private ActionResult applyFertilizer(ItemUsageContext context, ServerWorld world, Fertilizable fertilizable,
+                        BlockState state) {
+                BlockPos pos = context.getBlockPos();
+                if (!fertilizable.isFertilizable(world, pos, state, false)) {
+                        return ActionResult.PASS;
+                }
+
+                ItemStack stack = context.getStack();
+                double chance = MathHelper.clamp(FertilizerBalanceConfig.get().fertilizerGrowthChance(), 0.0, 1.0);
+                boolean grew = false;
+
+                var random = world.getRandom();
+                if (fertilizable.canGrow(world, random, pos, state)) {
+                        if (chance > 0.0 && random.nextDouble() < chance) {
+                                fertilizable.grow(world, random, pos, state);
+                                grew = true;
+                        }
+                }
+
+                if (context.getPlayer() == null || !context.getPlayer().getAbilities().creativeMode) {
+                        stack.decrement(1);
+                }
+
+                world.syncWorldEvent(WorldEvents.BONE_MEAL_USED, pos, 0);
+                if (grew) {
+                        world.emitGameEvent(GameEvent.BLOCK_CHANGE, pos,
+                                        GameEvent.Emitter.of(context.getPlayer(), state));
+                        return ActionResult.SUCCESS;
+                }
+
+                return ActionResult.CONSUME;
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/item/FertilizerBalanceConfig.java
+++ b/src/main/java/net/jeremy/gardenkingmod/item/FertilizerBalanceConfig.java
@@ -1,0 +1,118 @@
+package net.jeremy.gardenkingmod.item;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+
+/**
+ * Loads configurable fertilizer settings from
+ * <code>config/gardenkingmod/fertilizer.json</code>. The JSON file is written on
+ * first launch so that pack makers and administrators can balance the growth
+ * and composting rates without recompiling the mod.
+ */
+public final class FertilizerBalanceConfig {
+        private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+        private static final Path CONFIG_PATH = FabricLoader.getInstance().getConfigDir()
+                        .resolve(GardenKingMod.MOD_ID)
+                        .resolve("fertilizer.json");
+
+        private static volatile FertilizerBalanceConfig instance = new FertilizerBalanceConfig();
+
+        private double fertilizerGrowthChance = 0.5;
+        private double rottenCompostChance = 0.65;
+        private int fertilizerOutputCount = 1;
+
+        private FertilizerBalanceConfig() {
+        }
+
+        /**
+         * Ensures the fertilizer config exists on disk and updates the cached values
+         * used by the game.
+         */
+        public static void reload() {
+                FertilizerBalanceConfig defaults = new FertilizerBalanceConfig();
+                try {
+                        Files.createDirectories(CONFIG_PATH.getParent());
+                } catch (IOException exception) {
+                        GardenKingMod.LOGGER.warn("Failed to create fertilizer config directory", exception);
+                }
+
+                if (Files.notExists(CONFIG_PATH)) {
+                        writeConfigFile(defaults);
+                        instance = defaults;
+                        return;
+                }
+
+                try (BufferedReader reader = Files.newBufferedReader(CONFIG_PATH)) {
+                        FertilizerBalanceConfig loaded = GSON.fromJson(reader, FertilizerBalanceConfig.class);
+                        if (loaded == null) {
+                                GardenKingMod.LOGGER.warn("Fertilizer config file was empty; using defaults");
+                                instance = defaults;
+                        } else {
+                                boolean updated = loaded.validateAndApplyDefaults(defaults);
+                                if (updated) {
+                                        writeConfigFile(loaded);
+                                }
+                                instance = loaded;
+                        }
+                } catch (IOException exception) {
+                        GardenKingMod.LOGGER.warn("Failed to read fertilizer config; falling back to defaults", exception);
+                        instance = defaults;
+                }
+        }
+
+        private static void writeConfigFile(FertilizerBalanceConfig config) {
+                try (BufferedWriter writer = Files.newBufferedWriter(CONFIG_PATH)) {
+                        GSON.toJson(config, writer);
+                } catch (IOException exception) {
+                        GardenKingMod.LOGGER.warn("Failed to write default fertilizer config", exception);
+                }
+        }
+
+        private boolean validateAndApplyDefaults(FertilizerBalanceConfig defaults) {
+                boolean changed = false;
+
+                if (Double.isNaN(fertilizerGrowthChance) || fertilizerGrowthChance < 0.0
+                                || fertilizerGrowthChance > 1.0) {
+                        fertilizerGrowthChance = defaults.fertilizerGrowthChance;
+                        changed = true;
+                }
+
+                if (Double.isNaN(rottenCompostChance) || rottenCompostChance < 0.0 || rottenCompostChance > 1.0) {
+                        rottenCompostChance = defaults.rottenCompostChance;
+                        changed = true;
+                }
+
+                if (fertilizerOutputCount <= 0) {
+                        fertilizerOutputCount = defaults.fertilizerOutputCount;
+                        changed = true;
+                }
+
+                return changed;
+        }
+
+        public static FertilizerBalanceConfig get() {
+                return instance;
+        }
+
+        public double fertilizerGrowthChance() {
+                return fertilizerGrowthChance;
+        }
+
+        public double rottenCompostChance() {
+                return rottenCompostChance;
+        }
+
+        public int fertilizerOutputCount() {
+                return fertilizerOutputCount;
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/mixin/BoneMealItemMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/BoneMealItemMixin.java
@@ -1,0 +1,25 @@
+package net.jeremy.gardenkingmod.mixin;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.CropBlock;
+import net.minecraft.item.BoneMealItem;
+import net.minecraft.item.ItemUsageContext;
+import net.minecraft.registry.tag.BlockTags;
+import net.minecraft.util.ActionResult;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BoneMealItem.class)
+public class BoneMealItemMixin {
+        @Inject(method = "useOnBlock", at = @At("HEAD"), cancellable = true)
+        private void gardenkingmod$preventCropAcceleration(ItemUsageContext context,
+                        CallbackInfoReturnable<ActionResult> cir) {
+                BlockState state = context.getWorld().getBlockState(context.getBlockPos());
+                if (state.getBlock() instanceof CropBlock || state.isIn(BlockTags.CROPS)) {
+                        cir.setReturnValue(ActionResult.PASS);
+                }
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/mixin/ComposterBlockMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/ComposterBlockMixin.java
@@ -1,0 +1,19 @@
+package net.jeremy.gardenkingmod.mixin;
+
+import net.jeremy.gardenkingmod.ModItems;
+import net.jeremy.gardenkingmod.item.FertilizerBalanceConfig;
+import net.minecraft.block.ComposterBlock;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(ComposterBlock.class)
+public abstract class ComposterBlockMixin {
+        @ModifyArg(method = "emptyFullComposter", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ItemEntity;<init>(Lnet/minecraft/world/World;DDDLnet/minecraft/item/ItemStack;)V"), index = 4)
+        private static ItemStack gardenkingmod$replaceComposterOutput(ItemStack original) {
+                int count = Math.max(1, FertilizerBalanceConfig.get().fertilizerOutputCount());
+                return new ItemStack(ModItems.SPECIAL_FERTILIZER, count);
+        }
+}

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -82,6 +82,7 @@
   "container.gardenkingmod.bank": "Village Bank",
   "item.gardenkingmod.dollar": "Dollar",
   "item.gardenkingmod.wallet": "Wallet",
+  "item.gardenkingmod.special_fertilizer": "Special Fertilizer",
   "tooltip.gardenkingmod.wallet.unbound": "Owner: Unbound",
   "tooltip.gardenkingmod.wallet.owner": "Owner: %s",
   "tooltip.gardenkingmod.wallet.balance": "Bank Balance: %s dollars",

--- a/src/main/resources/assets/gardenkingmod/models/item/special_fertilizer.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/special_fertilizer.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "gardenkingmod:item/special_fertilizer"
+  }
+}

--- a/src/main/resources/data/gardenkingmod/garden_market_offers.json
+++ b/src/main/resources/data/gardenkingmod/garden_market_offers.json
@@ -43,6 +43,15 @@
         "gardenkingmod:dollar*64",
         "minecraft:honeycomb*8"
       ]
+    },{
+      "offer": "gardenkingmod:rotten_tomato*8",
+      "price": "gardenkingmod:dollar*1"
+    },{
+      "offer": "gardenkingmod:rotten_potato*8",
+      "price": "gardenkingmod:dollar*1"
+    },{
+      "offer": "gardenkingmod:rotten_wheat*8",
+      "price": "gardenkingmod:dollar*1"
     }
   ]
 }

--- a/src/main/resources/gardenkingmod.mixins.json
+++ b/src/main/resources/gardenkingmod.mixins.json
@@ -10,6 +10,8 @@
                 "CropBlockMixin",
                 "CroptopiaCropBlockMixin",
                 "EnchantmentHelperMixin",
+                "BoneMealItemMixin",
+                "ComposterBlockMixin",
                 "SlotAccessor"
         ],
         "injectors": {


### PR DESCRIPTION
## Summary
- add a JSON-backed fertilizer balance config and load it during mod initialization
- introduce the special fertilizer item, register rotten crops with the composter, and redirect full composter drops to the new item
- block bone meal crop acceleration, add market offers for rotten produce, and wire up assets for the fertilizer item

## Testing
- `./gradlew build` *(fails: existing BankBlockModel.java compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ecad6e75f0832195824163c3a1ad5c