### PR TITLE
Add sprinkler blocks with extended farmland hydration

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -16,15 +16,18 @@ import net.jeremy.gardenkingmod.client.model.CrowEntityModel;
 import net.jeremy.gardenkingmod.client.model.GearShopModel;
 import net.jeremy.gardenkingmod.client.model.MarketBlockModel;
 import net.jeremy.gardenkingmod.client.model.ScarecrowModel;
+import net.jeremy.gardenkingmod.client.model.SprinklerModel;
 import net.jeremy.gardenkingmod.client.render.BankBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.CrowEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.GearShopBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.ScarecrowBlockEntityRenderer;
+import net.jeremy.gardenkingmod.client.render.SprinklerBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.item.BankItemRenderer;
 import net.jeremy.gardenkingmod.client.render.item.GearShopItemRenderer;
 import net.jeremy.gardenkingmod.client.render.item.MarketItemRenderer;
 import net.jeremy.gardenkingmod.client.render.item.ScarecrowItemRenderer;
+import net.jeremy.gardenkingmod.client.render.item.SprinklerItemRenderer;
 import net.jeremy.gardenkingmod.registry.ModEntities;
 import net.jeremy.gardenkingmod.ModBlockEntities;
 import net.jeremy.gardenkingmod.ModBlocks;
@@ -59,6 +62,7 @@ public class GardenKingModClient implements ClientModInitializer {
         EntityModelLayerRegistry.registerModelLayer(GearShopModel.LAYER_LOCATION,
                         GearShopModel::getTexturedModelData);
         EntityModelLayerRegistry.registerModelLayer(ScarecrowModel.LAYER_LOCATION, ScarecrowModel::getTexturedModelData);
+        EntityModelLayerRegistry.registerModelLayer(SprinklerModel.LAYER_LOCATION, SprinklerModel::getTexturedModelData);
 
         EntityModelLayerRegistry.registerModelLayer(CrowEntityModel.LAYER_LOCATION, CrowEntityModel::getTexturedModelData);
         BlockEntityRendererFactories.register(ModBlockEntities.BANK_BLOCK_ENTITY, BankBlockEntityRenderer::new);
@@ -66,11 +70,17 @@ public class GardenKingModClient implements ClientModInitializer {
         BlockEntityRendererFactories.register(ModBlockEntities.GEAR_SHOP_BLOCK_ENTITY,
                         GearShopBlockEntityRenderer::new);
         BlockEntityRendererFactories.register(ModBlockEntities.SCARECROW_BLOCK_ENTITY, ScarecrowBlockEntityRenderer::new);
+        BlockEntityRendererFactories.register(ModBlockEntities.SPRINKLER_BLOCK_ENTITY, SprinklerBlockEntityRenderer::new);
         EntityRendererRegistry.register(ModEntities.CROW, CrowEntityRenderer::new);
         BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.BANK_BLOCK, new BankItemRenderer());
         BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.MARKET_BLOCK, new MarketItemRenderer());
         BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.GEAR_SHOP_BLOCK, new GearShopItemRenderer());
         BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.SCARECROW_BLOCK, new ScarecrowItemRenderer());
+        SprinklerItemRenderer sprinklerItemRenderer = new SprinklerItemRenderer();
+        BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.IRON_SPRINKLER_BLOCK, sprinklerItemRenderer);
+        BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.GOLD_SPRINKLER_BLOCK, sprinklerItemRenderer);
+        BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.DIAMOND_SPRINKLER_BLOCK, sprinklerItemRenderer);
+        BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.EMERALD_SPRINKLER_BLOCK, sprinklerItemRenderer);
         BlockRenderLayerMap.INSTANCE.putBlock(ModBlocks.SCARECROW_BLOCK, RenderLayer.getCutout());
 
         ClientPlayNetworking.registerGlobalReceiver(ModPackets.MARKET_SALE_RESULT_PACKET,

--- a/src/main/java/net/jeremy/gardenkingmod/ModBlockEntities.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModBlockEntities.java
@@ -4,6 +4,7 @@ import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityT
 import net.jeremy.gardenkingmod.block.entity.BankBlockEntity;
 import net.jeremy.gardenkingmod.block.entity.GearShopBlockEntity;
 import net.jeremy.gardenkingmod.block.entity.MarketBlockEntity;
+import net.jeremy.gardenkingmod.block.sprinkler.SprinklerBlockEntity;
 import net.jeremy.gardenkingmod.block.ward.ScarecrowBlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.registry.Registries;
@@ -22,6 +23,12 @@ public final class ModBlockEntities {
         public static final BlockEntityType<ScarecrowBlockEntity> SCARECROW_BLOCK_ENTITY = Registry.register(
                         Registries.BLOCK_ENTITY_TYPE, new Identifier(GardenKingMod.MOD_ID, "scarecrow"),
                         FabricBlockEntityTypeBuilder.create(ScarecrowBlockEntity::new, ModBlocks.SCARECROW_BLOCK).build());
+
+        public static final BlockEntityType<SprinklerBlockEntity> SPRINKLER_BLOCK_ENTITY = Registry.register(
+                        Registries.BLOCK_ENTITY_TYPE, new Identifier(GardenKingMod.MOD_ID, "sprinkler"),
+                        FabricBlockEntityTypeBuilder.create(SprinklerBlockEntity::new, ModBlocks.IRON_SPRINKLER_BLOCK,
+                                        ModBlocks.GOLD_SPRINKLER_BLOCK, ModBlocks.DIAMOND_SPRINKLER_BLOCK,
+                                        ModBlocks.EMERALD_SPRINKLER_BLOCK).build());
 
         public static final BlockEntityType<BankBlockEntity> BANK_BLOCK_ENTITY = Registry.register(
                         Registries.BLOCK_ENTITY_TYPE, new Identifier(GardenKingMod.MOD_ID, "bank_block"),

--- a/src/main/java/net/jeremy/gardenkingmod/ModBlocks.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModBlocks.java
@@ -8,6 +8,8 @@ import net.jeremy.gardenkingmod.block.GearShopBlock;
 import net.jeremy.gardenkingmod.block.GearShopBlockPart;
 import net.jeremy.gardenkingmod.block.MarketBlock;
 import net.jeremy.gardenkingmod.block.MarketBlockPart;
+import net.jeremy.gardenkingmod.block.sprinkler.SprinklerBlock;
+import net.jeremy.gardenkingmod.block.sprinkler.SprinklerTier;
 import net.jeremy.gardenkingmod.block.ward.ScarecrowBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
@@ -29,6 +31,22 @@ public final class ModBlocks {
 
         public static final Block SCARECROW_BLOCK = registerBlock("scarecrow",
                         new ScarecrowBlock(FabricBlockSettings.copyOf(Blocks.HAY_BLOCK).strength(1.5f).nonOpaque()));
+
+        public static final Block IRON_SPRINKLER_BLOCK = registerBlock("iron_sprinkler",
+                        new SprinklerBlock(FabricBlockSettings.copyOf(Blocks.IRON_BLOCK).strength(1.5f).nonOpaque(),
+                                        SprinklerTier.IRON));
+
+        public static final Block GOLD_SPRINKLER_BLOCK = registerBlock("gold_sprinkler",
+                        new SprinklerBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).strength(1.5f).nonOpaque(),
+                                        SprinklerTier.GOLD));
+
+        public static final Block DIAMOND_SPRINKLER_BLOCK = registerBlock("diamond_sprinkler",
+                        new SprinklerBlock(FabricBlockSettings.copyOf(Blocks.DIAMOND_BLOCK).strength(2.0f).nonOpaque(),
+                                        SprinklerTier.DIAMOND));
+
+        public static final Block EMERALD_SPRINKLER_BLOCK = registerBlock("emerald_sprinkler",
+                        new SprinklerBlock(FabricBlockSettings.copyOf(Blocks.EMERALD_BLOCK).strength(2.0f).nonOpaque(),
+                                        SprinklerTier.EMERALD));
 
         public static final Block BANK_BLOCK = registerBlock("bank_block",
                         new BankBlock(FabricBlockSettings.copyOf(Blocks.SPRUCE_PLANKS).strength(2.5f)));
@@ -66,6 +84,10 @@ public final class ModBlocks {
                         entries.add(GEAR_SHOP_BLOCK);
                         entries.add(BANK_BLOCK);
                         entries.add(SCARECROW_BLOCK);
+                        entries.add(IRON_SPRINKLER_BLOCK);
+                        entries.add(GOLD_SPRINKLER_BLOCK);
+                        entries.add(DIAMOND_SPRINKLER_BLOCK);
+                        entries.add(EMERALD_SPRINKLER_BLOCK);
                 });
                 ItemGroupEvents.modifyEntriesEvent(ItemGroups.BUILDING_BLOCKS).register(entries -> entries.add(RUBY_BLOCK));
         }

--- a/src/main/java/net/jeremy/gardenkingmod/block/sprinkler/SprinklerBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/sprinkler/SprinklerBlock.java
@@ -1,0 +1,49 @@
+package net.jeremy.gardenkingmod.block.sprinkler;
+
+import net.jeremy.gardenkingmod.ModBlockEntities;
+import net.minecraft.block.BlockRenderType;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.BlockWithEntity;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityTicker;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+
+public class SprinklerBlock extends BlockWithEntity {
+        private static final VoxelShape OUTLINE_SHAPE = createCuboidShape(2.0, 0.0, 2.0, 14.0, 16.0, 14.0);
+
+        private final SprinklerTier tier;
+
+        public SprinklerBlock(Settings settings, SprinklerTier tier) {
+                super(settings);
+                this.tier = tier;
+        }
+
+        @Override
+        public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
+                return new SprinklerBlockEntity(pos, state);
+        }
+
+        public SprinklerTier getTier() {
+                return this.tier;
+        }
+
+        @Override
+        public BlockRenderType getRenderType(BlockState state) {
+                return BlockRenderType.ENTITYBLOCK_ANIMATED;
+        }
+
+        @Override
+        public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+                return OUTLINE_SHAPE;
+        }
+
+        @Override
+        public <T extends BlockEntity> BlockEntityTicker<T> getTicker(World world, BlockState state, BlockEntityType<T> type) {
+                return checkType(type, ModBlockEntities.SPRINKLER_BLOCK_ENTITY, SprinklerBlockEntity::tick);
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/block/sprinkler/SprinklerBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/sprinkler/SprinklerBlockEntity.java
@@ -1,0 +1,98 @@
+package net.jeremy.gardenkingmod.block.sprinkler;
+
+import net.jeremy.gardenkingmod.ModBlockEntities;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class SprinklerBlockEntity extends BlockEntity {
+        private int animationTicks;
+        private SprinklerTier tier;
+
+        public SprinklerBlockEntity(BlockPos pos, BlockState state) {
+                super(ModBlockEntities.SPRINKLER_BLOCK_ENTITY, pos, state);
+                this.tier = determineTier(state);
+        }
+
+        public static void tick(World world, BlockPos pos, BlockState state, SprinklerBlockEntity sprinkler) {
+                if (!world.isClient && world instanceof ServerWorld serverWorld) {
+                        sprinkler.ensureRegistered(serverWorld);
+                }
+                sprinkler.animationTicks++;
+        }
+
+        public SprinklerTier getTier() {
+                return this.tier;
+        }
+
+        public boolean isWithinRange(BlockPos target) {
+                BlockPos origin = this.getPos();
+                int dx = Math.abs(target.getX() - origin.getX());
+                int dz = Math.abs(target.getZ() - origin.getZ());
+                int dy = Math.abs(target.getY() - origin.getY());
+                return Math.max(dx, dz) <= this.tier.getHorizontalRadius() && dy <= this.tier.getVerticalRadius();
+        }
+
+        public float getAnimationProgress(float tickDelta) {
+                return (this.animationTicks + tickDelta) / 20.0F;
+        }
+
+        @Override
+        public void setCachedState(BlockState state) {
+                super.setCachedState(state);
+                this.tier = determineTier(state);
+        }
+
+        @Override
+        public void setWorld(World world) {
+                super.setWorld(world);
+                if (world instanceof ServerWorld serverWorld) {
+                        SprinklerHydrationManager.register(serverWorld, this);
+                }
+        }
+
+        @Override
+        public void cancelRemoval() {
+                super.cancelRemoval();
+                if (this.world instanceof ServerWorld serverWorld) {
+                        SprinklerHydrationManager.register(serverWorld, this);
+                }
+        }
+
+        @Override
+        public void markRemoved() {
+                if (this.world instanceof ServerWorld) {
+                        SprinklerHydrationManager.unregister(this);
+                }
+                super.markRemoved();
+        }
+
+        @Override
+        protected void writeNbt(NbtCompound nbt) {
+                super.writeNbt(nbt);
+                nbt.putInt("AnimTicks", this.animationTicks);
+        }
+
+        @Override
+        public void readNbt(NbtCompound nbt) {
+                super.readNbt(nbt);
+                this.animationTicks = nbt.getInt("AnimTicks");
+                if (this.getCachedState() != null) {
+                        this.tier = determineTier(this.getCachedState());
+                }
+        }
+
+        private SprinklerTier determineTier(BlockState state) {
+                if (state.getBlock() instanceof SprinklerBlock sprinklerBlock) {
+                        return sprinklerBlock.getTier();
+                }
+                return SprinklerTier.IRON;
+        }
+
+        private void ensureRegistered(ServerWorld world) {
+                SprinklerHydrationManager.register(world, this);
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/block/sprinkler/SprinklerHydrationManager.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/sprinkler/SprinklerHydrationManager.java
@@ -1,0 +1,52 @@
+package net.jeremy.gardenkingmod.block.sprinkler;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+
+public final class SprinklerHydrationManager {
+        private static final WeakHashMap<ServerWorld, Set<SprinklerBlockEntity>> ACTIVE = new WeakHashMap<>();
+
+        private SprinklerHydrationManager() {
+        }
+
+        public static void register(ServerWorld world, SprinklerBlockEntity entity) {
+                ACTIVE.compute(world, (ignored, entities) -> {
+                        Set<SprinklerBlockEntity> result = entities;
+                        if (result == null) {
+                                result = Collections.newSetFromMap(new WeakHashMap<>());
+                        }
+                        result.add(entity);
+                        return result;
+                });
+        }
+
+        public static void unregister(SprinklerBlockEntity entity) {
+                if (!(entity.getWorld() instanceof ServerWorld serverWorld)) {
+                        return;
+                }
+                Set<SprinklerBlockEntity> entities = ACTIVE.get(serverWorld);
+                if (entities != null) {
+                        entities.remove(entity);
+                        if (entities.isEmpty()) {
+                                ACTIVE.remove(serverWorld);
+                        }
+                }
+        }
+
+        public static boolean keepsFarmlandWet(ServerWorld world, BlockPos farmland) {
+                Set<SprinklerBlockEntity> entities = ACTIVE.get(world);
+                if (entities == null || entities.isEmpty()) {
+                        return false;
+                }
+                for (SprinklerBlockEntity entity : entities) {
+                        if (!entity.isRemoved() && entity.isWithinRange(farmland)) {
+                                return true;
+                        }
+                }
+                return false;
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/block/sprinkler/SprinklerTier.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/sprinkler/SprinklerTier.java
@@ -1,0 +1,39 @@
+package net.jeremy.gardenkingmod.block.sprinkler;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.minecraft.util.Identifier;
+
+public enum SprinklerTier {
+        IRON("iron", 8, 2),
+        GOLD("gold", 16, 3),
+        DIAMOND("diamond", 32, 4),
+        EMERALD("emerald", 64, 5);
+
+        private final String name;
+        private final int horizontalRadius;
+        private final int verticalRadius;
+        private final Identifier texture;
+
+        SprinklerTier(String name, int horizontalRadius, int verticalRadius) {
+                this.name = name;
+                this.horizontalRadius = horizontalRadius;
+                this.verticalRadius = verticalRadius;
+                this.texture = new Identifier(GardenKingMod.MOD_ID, "textures/entity/sprinkler/sprinkler.png");
+        }
+
+        public String getName() {
+                return this.name;
+        }
+
+        public int getHorizontalRadius() {
+                return this.horizontalRadius;
+        }
+
+        public int getVerticalRadius() {
+                return this.verticalRadius;
+        }
+
+        public Identifier getTexture() {
+                return this.texture;
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/client/model/SprinklerModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/SprinklerModel.java
@@ -1,77 +1,123 @@
 package net.jeremy.gardenkingmod.client.model;
 
-// Made with Blockbench 5.0.1
-// Exported for Minecraft version 1.17+ for Yarn
-// Paste this class into your mod and generate all required imports
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.minecraft.client.model.Dilation;
+import net.minecraft.client.model.ModelData;
+import net.minecraft.client.model.ModelPart;
+import net.minecraft.client.model.ModelPartBuilder;
+import net.minecraft.client.model.ModelPartData;
+import net.minecraft.client.model.ModelTransform;
+import net.minecraft.client.model.TexturedModelData;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.entity.model.EntityModelLayer;
+import net.minecraft.client.render.entity.model.EntityModel;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.Identifier;
+
 public class SprinklerModel extends EntityModel<Entity> {
-	private final ModelPart rotation;
-	private final ModelPart cap3;
-	private final ModelPart cap2;
-	private final ModelPart cap4;
-	private final ModelPart bb_main;
-	public SprinklerModel(ModelPart root) {
-		this.rotation = root.getChild("rotation");
-		this.cap3 = this.rotation.getChild("cap3");
-		this.cap2 = this.rotation.getChild("cap2");
-		this.cap4 = root.getChild("cap4");
-		this.bb_main = root.getChild("bb_main");
-	}
-	public static TexturedModelData getTexturedModelData() {
-		ModelData modelData = new ModelData();
-		ModelPartData modelPartData = modelData.getRoot();
-		ModelPartData rotation = modelPartData.addChild("rotation", ModelPartBuilder.create().uv(8, 31).cuboid(-9.0F, -6.0F, -1.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
-		.uv(12, 31).cuboid(11.0F, -3.0F, -1.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
-		.uv(0, 27).cuboid(1.0F, -6.0F, -1.0F, 1.0F, 5.0F, 1.0F, new Dilation(0.0F)), ModelTransform.pivot(-1.5F, -4.0F, 0.5F));
+        public static final EntityModelLayer LAYER_LOCATION = new EntityModelLayer(
+                        new Identifier(GardenKingMod.MOD_ID, "sprinkler"), "main");
+        /**
+         * Place future animation keyframes at
+         * {@code assets/gardenkingmod/animations/sprinkler.animation.json}.
+         */
 
-		ModelPartData cube_r1 = rotation.addChild("cube_r1", ModelPartBuilder.create().uv(24, 11).cuboid(0.0F, -8.0F, 0.0F, 1.0F, 10.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(10.0F, -3.0F, -1.0F, 0.0F, 0.0F, -1.5708F));
+        private final ModelPart rotation;
+        private final ModelPart cap4;
+        private final ModelPart bbMain;
 
-		ModelPartData cube_r2 = rotation.addChild("cube_r2", ModelPartBuilder.create().uv(24, 0).cuboid(0.0F, -10.0F, 0.0F, 1.0F, 10.0F, 1.0F, new Dilation(0.0F)), ModelTransform.of(1.0F, -3.0F, -1.0F, 0.0F, 0.0F, -1.5708F));
+        public SprinklerModel(ModelPart root) {
+                this.rotation = root.getChild("rotation");
+                this.cap4 = root.getChild("cap4");
+                this.bbMain = root.getChild("bb_main");
+        }
 
-		ModelPartData cap3 = rotation.addChild("cap3", ModelPartBuilder.create().uv(22, 28).cuboid(-1.0F, -2.0F, -1.0F, 2.0F, 1.0F, 1.0F, new Dilation(0.0F))
-		.uv(28, 10).cuboid(0.5F, -2.0F, 0.0F, 1.0F, 1.0F, 2.0F, new Dilation(0.0F))
-		.uv(28, 28).cuboid(2.0F, -2.0F, -1.0F, 2.0F, 1.0F, 1.0F, new Dilation(0.0F))
-		.uv(28, 13).cuboid(1.5F, -2.0F, 0.0F, 1.0F, 1.0F, 2.0F, new Dilation(0.0F))
-		.uv(28, 16).cuboid(1.5F, -2.0F, -3.0F, 1.0F, 1.0F, 2.0F, new Dilation(0.0F))
-		.uv(20, 33).cuboid(2.5F, -2.0F, -2.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
-		.uv(24, 33).cuboid(-0.5F, -2.0F, -2.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
-		.uv(28, 33).cuboid(2.5F, -2.0F, 0.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
-		.uv(32, 33).cuboid(-0.5F, -2.0F, 0.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
-		.uv(28, 19).cuboid(0.5F, -2.0F, -3.0F, 1.0F, 1.0F, 2.0F, new Dilation(0.0F)), ModelTransform.pivot(0.0F, 0.0F, 0.0F));
+        public static TexturedModelData getTexturedModelData() {
+                ModelData modelData = new ModelData();
+                ModelPartData modelPartData = modelData.getRoot();
+                ModelPartData rotation = modelPartData.addChild("rotation",
+                                ModelPartBuilder.create().uv(8, 31).cuboid(-9.0F, -6.0F, -1.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(12, 31).cuboid(11.0F, -3.0F, -1.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(0, 27).cuboid(1.0F, -6.0F, -1.0F, 1.0F, 5.0F, 1.0F, new Dilation(0.0F)),
+                                ModelTransform.pivot(-1.5F, -4.0F, 0.5F));
 
-		ModelPartData cap2 = rotation.addChild("cap2", ModelPartBuilder.create().uv(16, 31).cuboid(0.0F, -1.0F, -1.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
-		.uv(32, 22).cuboid(0.5F, -1.0F, 0.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
-		.uv(32, 24).cuboid(2.0F, -1.0F, -1.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
-		.uv(32, 26).cuboid(1.5F, -1.0F, 0.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
-		.uv(0, 33).cuboid(1.5F, -1.0F, -2.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
-		.uv(16, 33).cuboid(0.5F, -1.0F, -2.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F)), ModelTransform.pivot(0.0F, -5.0F, 0.0F));
+                rotation.addChild("cube_r1", ModelPartBuilder.create().uv(24, 11).cuboid(0.0F, -8.0F, 0.0F, 1.0F, 10.0F, 1.0F,
+                                new Dilation(0.0F)), ModelTransform.of(10.0F, -3.0F, -1.0F, 0.0F, 0.0F, -1.5708F));
 
-		ModelPartData cap4 = modelPartData.addChild("cap4", ModelPartBuilder.create().uv(28, 4).cuboid(-1.0F, -2.0F, -1.0F, 2.0F, 2.0F, 1.0F, new Dilation(0.0F))
-		.uv(4, 27).cuboid(0.5F, -2.0F, 0.0F, 1.0F, 2.0F, 2.0F, new Dilation(0.0F))
-		.uv(28, 7).cuboid(2.0F, -2.0F, -1.0F, 2.0F, 2.0F, 1.0F, new Dilation(0.0F))
-		.uv(10, 27).cuboid(1.5F, -2.0F, 0.0F, 1.0F, 2.0F, 2.0F, new Dilation(0.0F))
-		.uv(16, 27).cuboid(1.5F, -2.0F, -3.0F, 1.0F, 2.0F, 2.0F, new Dilation(0.0F))
-		.uv(22, 30).cuboid(2.5F, -2.0F, -2.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
-		.uv(26, 30).cuboid(-0.5F, -2.0F, -2.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
-		.uv(30, 30).cuboid(2.5F, -2.0F, 0.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
-		.uv(4, 31).cuboid(-0.5F, -2.0F, 0.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
-		.uv(28, 0).cuboid(0.5F, -2.0F, -3.0F, 1.0F, 2.0F, 2.0F, new Dilation(0.0F)), ModelTransform.pivot(-1.5F, 1.0F, 0.5F));
+                rotation.addChild("cube_r2", ModelPartBuilder.create().uv(24, 0).cuboid(0.0F, -10.0F, 0.0F, 1.0F, 10.0F, 1.0F,
+                                new Dilation(0.0F)), ModelTransform.of(1.0F, -3.0F, -1.0F, 0.0F, 0.0F, -1.5708F));
 
-		ModelPartData bb_main = modelPartData.addChild("bb_main", ModelPartBuilder.create().uv(24, 22).cuboid(-1.0F, -29.0F, -1.0F, 2.0F, 4.0F, 2.0F, new Dilation(0.0F)), ModelTransform.pivot(0.0F, 24.0F, 0.0F));
+                rotation.addChild("cap3",
+                                ModelPartBuilder.create().uv(22, 28).cuboid(-1.0F, -2.0F, -1.0F, 2.0F, 1.0F, 1.0F,
+                                                new Dilation(0.0F))
+                                                .uv(28, 10).cuboid(0.5F, -2.0F, 0.0F, 1.0F, 1.0F, 2.0F, new Dilation(0.0F))
+                                                .uv(28, 28).cuboid(2.0F, -2.0F, -1.0F, 2.0F, 1.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(28, 13).cuboid(1.5F, -2.0F, 0.0F, 1.0F, 1.0F, 2.0F, new Dilation(0.0F))
+                                                .uv(28, 16).cuboid(1.5F, -2.0F, -3.0F, 1.0F, 1.0F, 2.0F, new Dilation(0.0F))
+                                                .uv(20, 33).cuboid(2.5F, -2.0F, -2.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(24, 33).cuboid(-0.5F, -2.0F, -2.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(28, 33).cuboid(2.5F, -2.0F, 0.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(32, 33).cuboid(-0.5F, -2.0F, 0.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(28, 19).cuboid(0.5F, -2.0F, -3.0F, 1.0F, 1.0F, 2.0F, new Dilation(0.0F)),
+                                ModelTransform.pivot(0.0F, 0.0F, 0.0F));
 
-		ModelPartData cube_r3 = bb_main.addChild("cube_r3", ModelPartBuilder.create().uv(16, 0).cuboid(-1.0F, -24.0F, -1.0F, 2.0F, 25.0F, 2.0F, new Dilation(0.0F)), ModelTransform.of(6.0F, 0.0F, -6.0F, -0.3054F, -0.7854F, 0.0F));
+                rotation.addChild("cap2",
+                                ModelPartBuilder.create().uv(16, 31).cuboid(0.0F, -1.0F, -1.0F, 1.0F, 1.0F, 1.0F,
+                                                new Dilation(0.0F))
+                                                .uv(32, 22).cuboid(0.5F, -1.0F, 0.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(32, 24).cuboid(2.0F, -1.0F, -1.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(32, 26).cuboid(1.5F, -1.0F, 0.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(0, 33).cuboid(1.5F, -1.0F, -2.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(16, 33).cuboid(0.5F, -1.0F, -2.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F)),
+                                ModelTransform.pivot(0.0F, -5.0F, 0.0F));
 
-		ModelPartData cube_r4 = bb_main.addChild("cube_r4", ModelPartBuilder.create().uv(8, 0).cuboid(-1.0F, -24.0F, -1.0F, 2.0F, 25.0F, 2.0F, new Dilation(0.0F)), ModelTransform.of(-6.0F, 0.0F, -6.0F, -0.3054F, 0.7854F, 0.0F));
+                modelPartData.addChild("cap4",
+                                ModelPartBuilder.create().uv(28, 4).cuboid(-1.0F, -2.0F, -1.0F, 2.0F, 2.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(4, 27).cuboid(0.5F, -2.0F, 0.0F, 1.0F, 2.0F, 2.0F, new Dilation(0.0F))
+                                                .uv(28, 7).cuboid(2.0F, -2.0F, -1.0F, 2.0F, 2.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(10, 27).cuboid(1.5F, -2.0F, 0.0F, 1.0F, 2.0F, 2.0F, new Dilation(0.0F))
+                                                .uv(16, 27).cuboid(1.5F, -2.0F, -3.0F, 1.0F, 2.0F, 2.0F, new Dilation(0.0F))
+                                                .uv(22, 30).cuboid(2.5F, -2.0F, -2.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(26, 30).cuboid(-0.5F, -2.0F, -2.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(30, 30).cuboid(2.5F, -2.0F, 0.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(4, 31).cuboid(-0.5F, -2.0F, 0.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
+                                                .uv(28, 0).cuboid(0.5F, -2.0F, -3.0F, 1.0F, 2.0F, 2.0F, new Dilation(0.0F)),
+                                ModelTransform.pivot(-1.5F, 1.0F, 0.5F));
 
-		ModelPartData cube_r5 = bb_main.addChild("cube_r5", ModelPartBuilder.create().uv(0, 0).cuboid(-1.0F, -24.0F, -1.0F, 2.0F, 25.0F, 2.0F, new Dilation(0.0F)), ModelTransform.of(0.0F, 0.0F, 7.0F, 0.2618F, 0.0F, 0.0F));
-		return TexturedModelData.of(modelData, 64, 64);
-	}
-	@Override
-	public void setAngles(Entity entity, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch) {
-	}
-	@Override
-	public void render(MatrixStack matrices, VertexConsumer vertexConsumer, int light, int overlay, float red, float green, float blue, float alpha) {
-		rotation.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
-		cap4.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
-		bb_main.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
-	}
+                ModelPartData bbMain = modelPartData.addChild("bb_main",
+                                ModelPartBuilder.create().uv(24, 22).cuboid(-1.0F, -29.0F, -1.0F, 2.0F, 4.0F, 2.0F,
+                                                new Dilation(0.0F)),
+                                ModelTransform.pivot(0.0F, 24.0F, 0.0F));
+
+                bbMain.addChild("cube_r3",
+                                ModelPartBuilder.create().uv(16, 0).cuboid(-1.0F, -24.0F, -1.0F, 2.0F, 25.0F, 2.0F,
+                                                new Dilation(0.0F)),
+                                ModelTransform.of(6.0F, 0.0F, -6.0F, -0.3054F, -0.7854F, 0.0F));
+
+                bbMain.addChild("cube_r4",
+                                ModelPartBuilder.create().uv(8, 0).cuboid(-1.0F, -24.0F, -1.0F, 2.0F, 25.0F, 2.0F,
+                                                new Dilation(0.0F)),
+                                ModelTransform.of(-6.0F, 0.0F, -6.0F, -0.3054F, 0.7854F, 0.0F));
+
+                bbMain.addChild("cube_r5",
+                                ModelPartBuilder.create().uv(0, 0).cuboid(-1.0F, -24.0F, -1.0F, 2.0F, 25.0F, 2.0F,
+                                                new Dilation(0.0F)),
+                                ModelTransform.of(0.0F, 0.0F, 7.0F, 0.2618F, 0.0F, 0.0F));
+
+                return TexturedModelData.of(modelData, 64, 64);
+        }
+
+        @Override
+        public void setAngles(Entity entity, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw,
+                        float headPitch) {
+        }
+
+        @Override
+        public void render(MatrixStack matrices, VertexConsumer vertexConsumer, int light, int overlay, float red, float green,
+                        float blue, float alpha) {
+                this.rotation.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
+                this.cap4.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
+                this.bbMain.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
+        }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/SprinklerBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/SprinklerBlockEntityRenderer.java
@@ -1,0 +1,30 @@
+package net.jeremy.gardenkingmod.client.render;
+
+import net.jeremy.gardenkingmod.block.sprinkler.SprinklerBlockEntity;
+import net.jeremy.gardenkingmod.client.model.SprinklerModel;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.block.entity.BlockEntityRenderer;
+import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
+import net.minecraft.client.util.math.MatrixStack;
+
+public class SprinklerBlockEntityRenderer implements BlockEntityRenderer<SprinklerBlockEntity> {
+        private final SprinklerModel model;
+
+        public SprinklerBlockEntityRenderer(BlockEntityRendererFactory.Context context) {
+                this.model = new SprinklerModel(context.getLayerModelPart(SprinklerModel.LAYER_LOCATION));
+        }
+
+        @Override
+        public void render(SprinklerBlockEntity entity, float tickDelta, MatrixStack matrices,
+                        VertexConsumerProvider vertexConsumers, int light, int overlay) {
+                matrices.push();
+                matrices.translate(0.5D, 1.5D, 0.5D);
+                matrices.scale(-1.0F, -1.0F, 1.0F);
+                VertexConsumer vertexConsumer = vertexConsumers
+                                .getBuffer(RenderLayer.getEntityCutoutNoCull(entity.getTier().getTexture()));
+                this.model.render(matrices, vertexConsumer, light, overlay, 1.0F, 1.0F, 1.0F, 1.0F);
+                matrices.pop();
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/item/SprinklerItemRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/item/SprinklerItemRenderer.java
@@ -1,0 +1,50 @@
+package net.jeremy.gardenkingmod.client.render.item;
+
+import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
+import net.jeremy.gardenkingmod.block.sprinkler.SprinklerBlock;
+import net.jeremy.gardenkingmod.block.sprinkler.SprinklerTier;
+import net.jeremy.gardenkingmod.client.model.SprinklerModel;
+import net.minecraft.block.Block;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.model.json.ModelTransformationMode;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
+
+public class SprinklerItemRenderer implements BuiltinItemRendererRegistry.DynamicItemRenderer {
+        private SprinklerModel model;
+
+        @Override
+        public void render(ItemStack stack, ModelTransformationMode mode, MatrixStack matrices,
+                        VertexConsumerProvider vertexConsumers, int light, int overlay) {
+                if (this.model == null) {
+                        this.model = new SprinklerModel(
+                                        MinecraftClient.getInstance().getEntityModelLoader()
+                                                        .getModelPart(SprinklerModel.LAYER_LOCATION));
+                }
+
+                matrices.push();
+                matrices.translate(0.5D, 1.5D, 0.5D);
+                matrices.scale(-1.0F, -1.0F, 1.0F);
+
+                SprinklerTier tier = getTier(stack);
+                VertexConsumer vertexConsumer = vertexConsumers
+                                .getBuffer(RenderLayer.getEntityCutoutNoCull(tier.getTexture()));
+                this.model.render(matrices, vertexConsumer, light, overlay, 1.0F, 1.0F, 1.0F, 1.0F);
+                matrices.pop();
+        }
+
+        private static SprinklerTier getTier(ItemStack stack) {
+                Block block = Block.getBlockFromItem(stack.getItem());
+                if (block instanceof SprinklerBlock sprinklerBlock) {
+                        return sprinklerBlock.getTier();
+                }
+                if (stack.getItem() instanceof BlockItem blockItem && blockItem.getBlock() instanceof SprinklerBlock sprinkler) {
+                        return sprinkler.getTier();
+                }
+                return SprinklerTier.IRON;
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/mixin/FarmlandBlockMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/FarmlandBlockMixin.java
@@ -1,0 +1,24 @@
+package net.jeremy.gardenkingmod.mixin;
+
+import net.jeremy.gardenkingmod.block.sprinkler.SprinklerHydrationManager;
+import net.minecraft.block.FarmlandBlock;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.WorldView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(FarmlandBlock.class)
+public abstract class FarmlandBlockMixin {
+        @Inject(method = "isWaterNearby", at = @At("RETURN"), cancellable = true)
+        private static void gardenkingmod$extendMoisture(WorldView world, BlockPos pos,
+                        CallbackInfoReturnable<Boolean> cir) {
+                if (!cir.getReturnValue() && world instanceof ServerWorld serverWorld) {
+                        if (SprinklerHydrationManager.keepsFarmlandWet(serverWorld, pos)) {
+                                cir.setReturnValue(true);
+                        }
+                }
+        }
+}

--- a/src/main/resources/assets/gardenkingmod/blockstates/diamond_sprinkler.json
+++ b/src/main/resources/assets/gardenkingmod/blockstates/diamond_sprinkler.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": { "model": "gardenkingmod:block/diamond_sprinkler" }
+  }
+}

--- a/src/main/resources/assets/gardenkingmod/blockstates/emerald_sprinkler.json
+++ b/src/main/resources/assets/gardenkingmod/blockstates/emerald_sprinkler.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": { "model": "gardenkingmod:block/emerald_sprinkler" }
+  }
+}

--- a/src/main/resources/assets/gardenkingmod/blockstates/gold_sprinkler.json
+++ b/src/main/resources/assets/gardenkingmod/blockstates/gold_sprinkler.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": { "model": "gardenkingmod:block/gold_sprinkler" }
+  }
+}

--- a/src/main/resources/assets/gardenkingmod/blockstates/iron_sprinkler.json
+++ b/src/main/resources/assets/gardenkingmod/blockstates/iron_sprinkler.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": { "model": "gardenkingmod:block/iron_sprinkler" }
+  }
+}

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -211,7 +211,15 @@
 
   "entity.gardenkingmod.crow": "Crow",
   "block.gardenkingmod.scarecrow": "Field Scarecrow",
+  "block.gardenkingmod.iron_sprinkler": "Iron Sprinkler",
+  "block.gardenkingmod.gold_sprinkler": "Gold Sprinkler",
+  "block.gardenkingmod.diamond_sprinkler": "Diamond Sprinkler",
+  "block.gardenkingmod.emerald_sprinkler": "Emerald Sprinkler",
   "item.gardenkingmod.scarecrow": "Field Scarecrow",
+  "item.gardenkingmod.iron_sprinkler": "Iron Sprinkler",
+  "item.gardenkingmod.gold_sprinkler": "Gold Sprinkler",
+  "item.gardenkingmod.diamond_sprinkler": "Diamond Sprinkler",
+  "item.gardenkingmod.emerald_sprinkler": "Emerald Sprinkler",
   "item.gardenkingmod.crow_spawn_egg": "Crow Spawn Egg",
 
   "tooltip.gardenkingmod.scarecrow.ward_radius": "Wards crows within %s blocks.",

--- a/src/main/resources/assets/gardenkingmod/models/block/diamond_sprinkler.json
+++ b/src/main/resources/assets/gardenkingmod/models/block/diamond_sprinkler.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/block",
+  "textures": {
+    "particle": "minecraft:block/diamond_block"
+  }
+}

--- a/src/main/resources/assets/gardenkingmod/models/block/emerald_sprinkler.json
+++ b/src/main/resources/assets/gardenkingmod/models/block/emerald_sprinkler.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/block",
+  "textures": {
+    "particle": "minecraft:block/emerald_block"
+  }
+}

--- a/src/main/resources/assets/gardenkingmod/models/block/gold_sprinkler.json
+++ b/src/main/resources/assets/gardenkingmod/models/block/gold_sprinkler.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/block",
+  "textures": {
+    "particle": "minecraft:block/gold_block"
+  }
+}

--- a/src/main/resources/assets/gardenkingmod/models/block/iron_sprinkler.json
+++ b/src/main/resources/assets/gardenkingmod/models/block/iron_sprinkler.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/block",
+  "textures": {
+    "particle": "minecraft:block/iron_block"
+  }
+}

--- a/src/main/resources/assets/gardenkingmod/models/item/diamond_sprinkler.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/diamond_sprinkler.json
@@ -1,0 +1,3 @@
+{
+  "parent": "minecraft:builtin/entity"
+}

--- a/src/main/resources/assets/gardenkingmod/models/item/emerald_sprinkler.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/emerald_sprinkler.json
@@ -1,0 +1,3 @@
+{
+  "parent": "minecraft:builtin/entity"
+}

--- a/src/main/resources/assets/gardenkingmod/models/item/gold_sprinkler.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/gold_sprinkler.json
@@ -1,0 +1,3 @@
+{
+  "parent": "minecraft:builtin/entity"
+}

--- a/src/main/resources/assets/gardenkingmod/models/item/iron_sprinkler.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/iron_sprinkler.json
@@ -1,0 +1,3 @@
+{
+  "parent": "minecraft:builtin/entity"
+}

--- a/src/main/resources/data/gardenkingmod/loot_tables/blocks/diamond_sprinkler.json
+++ b/src/main/resources/data/gardenkingmod/loot_tables/blocks/diamond_sprinkler.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "gardenkingmod:diamond_sprinkler"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/loot_tables/blocks/emerald_sprinkler.json
+++ b/src/main/resources/data/gardenkingmod/loot_tables/blocks/emerald_sprinkler.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "gardenkingmod:emerald_sprinkler"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/loot_tables/blocks/gold_sprinkler.json
+++ b/src/main/resources/data/gardenkingmod/loot_tables/blocks/gold_sprinkler.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "gardenkingmod:gold_sprinkler"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/gardenkingmod/loot_tables/blocks/iron_sprinkler.json
+++ b/src/main/resources/data/gardenkingmod/loot_tables/blocks/iron_sprinkler.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "gardenkingmod:iron_sprinkler"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/gardenkingmod.mixins.json
+++ b/src/main/resources/gardenkingmod.mixins.json
@@ -12,6 +12,7 @@
                 "EnchantmentHelperMixin",
                 "BoneMealItemMixin",
                 "ComposterBlockMixin",
+                "FarmlandBlockMixin",
                 "SlotAccessor"
         ],
         "injectors": {


### PR DESCRIPTION
## Summary
- add four sprinkler block variants with block entities and client rendering hooks
- extend farmland hydration with sprinkler radius checks and supporting resources
- register assets, loot tables, and localization for the new sprinkler tiers

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68ecab9ae5208321a7e77090ae99f309