### PR TITLE
Handle malformed bank item config JSON

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/config/BankItemDisplayConfig.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/config/BankItemDisplayConfig.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.jeremy.gardenkingmod.GardenKingMod;
@@ -64,6 +65,9 @@ public final class BankItemDisplayConfig {
                 }
                 instance = loaded;
             }
+        } catch (JsonParseException exception) {
+            GardenKingMod.LOGGER.warn("Failed to parse bank item config; falling back to defaults", exception);
+            instance = defaults;
         } catch (IOException exception) {
             GardenKingMod.LOGGER.warn("Failed to read bank item config; falling back to defaults", exception);
             instance = defaults;


### PR DESCRIPTION
## Summary
- fall back to default bank item display configuration when the JSON cannot be parsed

## Testing
- ./gradlew check *(fails: existing SprinklerModel compilation errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_68ef074afb508321b38b6b5066f6c478