### PR TITLE
Add sprinkler radius tooltip

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/ModBlocks.java
+++ b/src/main/java/net/jeremy/gardenkingmod/ModBlocks.java
@@ -10,6 +10,7 @@ import net.jeremy.gardenkingmod.block.MarketBlock;
 import net.jeremy.gardenkingmod.block.MarketBlockPart;
 import net.jeremy.gardenkingmod.block.sprinkler.SprinklerBlock;
 import net.jeremy.gardenkingmod.block.sprinkler.SprinklerTier;
+import net.jeremy.gardenkingmod.item.SprinklerBlockItem;
 import net.jeremy.gardenkingmod.block.ward.ScarecrowBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
@@ -70,7 +71,10 @@ public final class ModBlocks {
         }
 
         private static Item registerBlockItem(String name, Block block) {
-                return Registry.register(Registries.ITEM, new Identifier(GardenKingMod.MOD_ID, name), new BlockItem(block, new FabricItemSettings()));
+                BlockItem blockItem = block instanceof SprinklerBlock sprinklerBlock
+                                ? new SprinklerBlockItem(sprinklerBlock, new FabricItemSettings())
+                                : new BlockItem(block, new FabricItemSettings());
+                return Registry.register(Registries.ITEM, new Identifier(GardenKingMod.MOD_ID, name), blockItem);
         }
 
         private static Block registerBlockWithoutItem(String name, Block block) {

--- a/src/main/java/net/jeremy/gardenkingmod/item/SprinklerBlockItem.java
+++ b/src/main/java/net/jeremy/gardenkingmod/item/SprinklerBlockItem.java
@@ -1,0 +1,30 @@
+package net.jeremy.gardenkingmod.item;
+
+import java.util.List;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.jeremy.gardenkingmod.block.sprinkler.SprinklerBlock;
+import net.jeremy.gardenkingmod.block.sprinkler.SprinklerTier;
+import net.minecraft.client.item.TooltipContext;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.world.World;
+
+public class SprinklerBlockItem extends BlockItem {
+        private final SprinklerTier tier;
+
+        public SprinklerBlockItem(SprinklerBlock block, Settings settings) {
+                super(block, settings);
+                this.tier = block.getTier();
+        }
+
+        @Override
+        public void appendTooltip(ItemStack stack, @Nullable World world, List<Text> tooltip, TooltipContext context) {
+                super.appendTooltip(stack, world, tooltip, context);
+                tooltip.add(Text.translatable("tooltip.gardenkingmod.sprinkler.radius", this.tier.getHorizontalRadius(),
+                                this.tier.getVerticalRadius()).formatted(Formatting.GRAY));
+        }
+}

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -220,6 +220,7 @@
   "item.gardenkingmod.gold_sprinkler": "Gold Sprinkler",
   "item.gardenkingmod.diamond_sprinkler": "Diamond Sprinkler",
   "item.gardenkingmod.emerald_sprinkler": "Emerald Sprinkler",
+  "tooltip.gardenkingmod.sprinkler.radius": "Waters a %s block radius (%s blocks vertically)",
   "item.gardenkingmod.crow_spawn_egg": "Crow Spawn Egg",
 
   "tooltip.gardenkingmod.scarecrow.ward_radius": "Wards crows within %s blocks.",


### PR DESCRIPTION
## Summary
- add a custom sprinkler block item that provides the sprinkler radius tooltip
- register sprinkler blocks with the new item to expose their coverage
- add a translation string describing the sprinkler radius

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68ef2df097948321b5fdec3afa404658