### PR TITLE
Animate sprinkler block entity rotation

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/SprinklerModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/SprinklerModel.java
@@ -27,6 +27,8 @@ public class SprinklerModel extends EntityModel<Entity> {
         private final ModelPart cap4;
         private final ModelPart bbMain;
 
+        private float rotationAngle;
+
         public SprinklerModel(ModelPart root) {
                 this.rotation = root.getChild("rotation");
                 this.cap4 = root.getChild("cap4");
@@ -113,9 +115,14 @@ public class SprinklerModel extends EntityModel<Entity> {
                         float headPitch) {
         }
 
+        public void setAnimationProgress(float animationProgress) {
+                this.rotationAngle = animationProgress * ((float) Math.PI * 2.0F);
+        }
+
         @Override
         public void render(MatrixStack matrices, VertexConsumer vertexConsumer, int light, int overlay, float red, float green,
                         float blue, float alpha) {
+                this.rotation.yaw = this.rotationAngle;
                 this.rotation.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
                 this.cap4.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
                 this.bbMain.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/SprinklerBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/SprinklerBlockEntityRenderer.java
@@ -22,6 +22,7 @@ public class SprinklerBlockEntityRenderer implements BlockEntityRenderer<Sprinkl
                 matrices.push();
                 matrices.translate(0.5D, 1.5D, 0.5D);
                 matrices.scale(-1.0F, -1.0F, 1.0F);
+                this.model.setAnimationProgress(entity.getAnimationProgress(tickDelta));
                 VertexConsumer vertexConsumer = vertexConsumers
                                 .getBuffer(RenderLayer.getEntityCutoutNoCull(entity.getTier().getTexture()));
                 this.model.render(matrices, vertexConsumer, light, overlay, 1.0F, 1.0F, 1.0F, 1.0F);


### PR DESCRIPTION
## Summary
- rotate the sprinkler block entity model using its animation tick counter
- expose an animation progress hook on the sprinkler model to drive the rotation

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68ef36db2ca88321a8dd4b3227333a0b