### PR TITLE
Center sprinkler rotation pivot

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/SprinklerModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/SprinklerModel.java
@@ -27,6 +27,8 @@ public class SprinklerModel extends EntityModel<Entity> {
         private final ModelPart cap4;
         private final ModelPart bbMain;
 
+        private float rotationAngle;
+
         public SprinklerModel(ModelPart root) {
                 this.rotation = root.getChild("rotation");
                 this.cap4 = root.getChild("cap4");
@@ -36,19 +38,22 @@ public class SprinklerModel extends EntityModel<Entity> {
         public static TexturedModelData getTexturedModelData() {
                 ModelData modelData = new ModelData();
                 ModelPartData modelPartData = modelData.getRoot();
-                ModelPartData rotation = modelPartData.addChild("rotation",
+                ModelPartData rotation = modelPartData.addChild("rotation", ModelPartBuilder.create(),
+                                ModelTransform.pivot(1.5F, -4.0F, -0.5F));
+
+                ModelPartData rotationAssembly = rotation.addChild("rotation_assembly",
                                 ModelPartBuilder.create().uv(8, 31).cuboid(-9.0F, -6.0F, -1.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
                                                 .uv(12, 31).cuboid(11.0F, -3.0F, -1.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
                                                 .uv(0, 27).cuboid(1.0F, -6.0F, -1.0F, 1.0F, 5.0F, 1.0F, new Dilation(0.0F)),
-                                ModelTransform.pivot(-1.5F, -4.0F, 0.5F));
+                                ModelTransform.pivot(-3.0F, 0.0F, 1.0F));
 
-                rotation.addChild("cube_r1", ModelPartBuilder.create().uv(24, 11).cuboid(0.0F, -8.0F, 0.0F, 1.0F, 10.0F, 1.0F,
+                rotationAssembly.addChild("cube_r1", ModelPartBuilder.create().uv(24, 11).cuboid(0.0F, -8.0F, 0.0F, 1.0F, 10.0F, 1.0F,
                                 new Dilation(0.0F)), ModelTransform.of(10.0F, -3.0F, -1.0F, 0.0F, 0.0F, -1.5708F));
 
-                rotation.addChild("cube_r2", ModelPartBuilder.create().uv(24, 0).cuboid(0.0F, -10.0F, 0.0F, 1.0F, 10.0F, 1.0F,
+                rotationAssembly.addChild("cube_r2", ModelPartBuilder.create().uv(24, 0).cuboid(0.0F, -10.0F, 0.0F, 1.0F, 10.0F, 1.0F,
                                 new Dilation(0.0F)), ModelTransform.of(1.0F, -3.0F, -1.0F, 0.0F, 0.0F, -1.5708F));
 
-                rotation.addChild("cap3",
+                rotationAssembly.addChild("cap3",
                                 ModelPartBuilder.create().uv(22, 28).cuboid(-1.0F, -2.0F, -1.0F, 2.0F, 1.0F, 1.0F,
                                                 new Dilation(0.0F))
                                                 .uv(28, 10).cuboid(0.5F, -2.0F, 0.0F, 1.0F, 1.0F, 2.0F, new Dilation(0.0F))
@@ -62,7 +67,7 @@ public class SprinklerModel extends EntityModel<Entity> {
                                                 .uv(28, 19).cuboid(0.5F, -2.0F, -3.0F, 1.0F, 1.0F, 2.0F, new Dilation(0.0F)),
                                 ModelTransform.pivot(0.0F, 0.0F, 0.0F));
 
-                rotation.addChild("cap2",
+                rotationAssembly.addChild("cap2",
                                 ModelPartBuilder.create().uv(16, 31).cuboid(0.0F, -1.0F, -1.0F, 1.0F, 1.0F, 1.0F,
                                                 new Dilation(0.0F))
                                                 .uv(32, 22).cuboid(0.5F, -1.0F, 0.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
@@ -113,9 +118,14 @@ public class SprinklerModel extends EntityModel<Entity> {
                         float headPitch) {
         }
 
+        public void setAnimationProgress(float animationProgress) {
+                this.rotationAngle = animationProgress * ((float) Math.PI * 2.0F);
+        }
+
         @Override
         public void render(MatrixStack matrices, VertexConsumer vertexConsumer, int light, int overlay, float red, float green,
                         float blue, float alpha) {
+                this.rotation.yaw = this.rotationAngle;
                 this.rotation.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
                 this.cap4.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
                 this.bbMain.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);

--- a/src/main/java/net/jeremy/gardenkingmod/client/render/SprinklerBlockEntityRenderer.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/render/SprinklerBlockEntityRenderer.java
@@ -22,6 +22,7 @@ public class SprinklerBlockEntityRenderer implements BlockEntityRenderer<Sprinkl
                 matrices.push();
                 matrices.translate(0.5D, 1.5D, 0.5D);
                 matrices.scale(-1.0F, -1.0F, 1.0F);
+                this.model.setAnimationProgress(entity.getAnimationProgress(tickDelta));
                 VertexConsumer vertexConsumer = vertexConsumers
                                 .getBuffer(RenderLayer.getEntityCutoutNoCull(entity.getTier().getTexture()));
                 this.model.render(matrices, vertexConsumer, light, overlay, 1.0F, 1.0F, 1.0F, 1.0F);


### PR DESCRIPTION
## Summary
- re-center the sprinkler model's rotating assembly so it spins around the head's axis
- nest the rotating geometry under a new pivoted parent model part and continue using the renderer-driven rotation

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68ef36db2ca88321a8dd4b3227333a0b