### PR TITLE
Fix sprinkler head rotation pivot

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/SprinklerModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/SprinklerModel.java
@@ -23,6 +23,7 @@ public class SprinklerModel extends EntityModel<Entity> {
          * {@code assets/gardenkingmod/animations/sprinkler.animation.json}.
          */
 
+        private final ModelPart rotationRoot;
         private final ModelPart rotation;
         private final ModelPart cap4;
         private final ModelPart bbMain;
@@ -30,7 +31,8 @@ public class SprinklerModel extends EntityModel<Entity> {
         private float rotationAngle;
 
         public SprinklerModel(ModelPart root) {
-                this.rotation = root.getChild("rotation");
+                this.rotationRoot = root.getChild("rotation_root");
+                this.rotation = this.rotationRoot.getChild("rotation");
                 this.cap4 = root.getChild("cap4");
                 this.bbMain = root.getChild("bb_main");
         }
@@ -38,22 +40,22 @@ public class SprinklerModel extends EntityModel<Entity> {
         public static TexturedModelData getTexturedModelData() {
                 ModelData modelData = new ModelData();
                 ModelPartData modelPartData = modelData.getRoot();
-                ModelPartData rotation = modelPartData.addChild("rotation", ModelPartBuilder.create(),
+                ModelPartData rotationRoot = modelPartData.addChild("rotation_root", ModelPartBuilder.create(),
                                 ModelTransform.pivot(-1.5F, -4.0F, 0.5F));
 
-                ModelPartData rotationAssembly = rotation.addChild("rotation_assembly",
+                ModelPartData rotation = rotationRoot.addChild("rotation",
                                 ModelPartBuilder.create().uv(8, 31).cuboid(-9.0F, -6.0F, -1.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
                                                 .uv(12, 31).cuboid(11.0F, -3.0F, -1.0F, 1.0F, 2.0F, 1.0F, new Dilation(0.0F))
                                                 .uv(0, 27).cuboid(1.0F, -6.0F, -1.0F, 1.0F, 5.0F, 1.0F, new Dilation(0.0F)),
                                 ModelTransform.pivot(0.0F, 0.0F, 0.0F));
 
-                rotationAssembly.addChild("cube_r1", ModelPartBuilder.create().uv(24, 11).cuboid(0.0F, -8.0F, 0.0F, 1.0F, 10.0F, 1.0F,
+                rotation.addChild("cube_r1", ModelPartBuilder.create().uv(24, 11).cuboid(0.0F, -8.0F, 0.0F, 1.0F, 10.0F, 1.0F,
                                 new Dilation(0.0F)), ModelTransform.of(10.0F, -3.0F, -1.0F, 0.0F, 0.0F, -1.5708F));
 
-                rotationAssembly.addChild("cube_r2", ModelPartBuilder.create().uv(24, 0).cuboid(0.0F, -10.0F, 0.0F, 1.0F, 10.0F, 1.0F,
+                rotation.addChild("cube_r2", ModelPartBuilder.create().uv(24, 0).cuboid(0.0F, -10.0F, 0.0F, 1.0F, 10.0F, 1.0F,
                                 new Dilation(0.0F)), ModelTransform.of(1.0F, -3.0F, -1.0F, 0.0F, 0.0F, -1.5708F));
 
-                rotationAssembly.addChild("cap3",
+                rotation.addChild("cap3",
                                 ModelPartBuilder.create().uv(22, 28).cuboid(-1.0F, -2.0F, -1.0F, 2.0F, 1.0F, 1.0F,
                                                 new Dilation(0.0F))
                                                 .uv(28, 10).cuboid(0.5F, -2.0F, 0.0F, 1.0F, 1.0F, 2.0F, new Dilation(0.0F))
@@ -67,7 +69,7 @@ public class SprinklerModel extends EntityModel<Entity> {
                                                 .uv(28, 19).cuboid(0.5F, -2.0F, -3.0F, 1.0F, 1.0F, 2.0F, new Dilation(0.0F)),
                                 ModelTransform.pivot(0.0F, 0.0F, 0.0F));
 
-                rotationAssembly.addChild("cap2",
+                rotation.addChild("cap2",
                                 ModelPartBuilder.create().uv(16, 31).cuboid(0.0F, -1.0F, -1.0F, 1.0F, 1.0F, 1.0F,
                                                 new Dilation(0.0F))
                                                 .uv(32, 22).cuboid(0.5F, -1.0F, 0.0F, 1.0F, 1.0F, 1.0F, new Dilation(0.0F))
@@ -126,7 +128,7 @@ public class SprinklerModel extends EntityModel<Entity> {
         public void render(MatrixStack matrices, VertexConsumer vertexConsumer, int light, int overlay, float red, float green,
                         float blue, float alpha) {
                 this.rotation.yaw = this.rotationAngle;
-                this.rotation.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
+                this.rotationRoot.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
                 this.cap4.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
                 this.bbMain.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
         }


### PR DESCRIPTION
## Summary
- introduce a dedicated rotation root model part so the spinning assembly keeps its offset from the pole
- rotate the sprinkler head around its own center by rendering the translated parent instead of the rotating child

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68efbaa0b4548321a37bd8ace6a147df