### PR TITLE
Fix sprinkler rotation pivot

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/model/SprinklerModel.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/model/SprinklerModel.java
@@ -129,8 +129,9 @@ public class SprinklerModel extends EntityModel<Entity> {
         @Override
         public void render(MatrixStack matrices, VertexConsumer vertexConsumer, int light, int overlay, float red, float green,
                         float blue, float alpha) {
+                this.rotationRoot.resetTransform();
                 this.rotation.resetTransform();
-                this.rotation.yaw = this.rotationAngle;
+                this.rotationRoot.yaw = this.rotationAngle;
                 this.rotationRoot.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
                 this.cap4.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
                 this.bbMain.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);


### PR DESCRIPTION
## Summary
- reset the sprinkler rotation root before rendering so its pivot stays in place
- rotate the root model part instead of the child to prevent the spinner cubes from translating while animating

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efd1e046bc83219f40410d883e7ab2