### PR TITLE
Map sprinkler tiers to individual textures

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/sprinkler/SprinklerTier.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/sprinkler/SprinklerTier.java
@@ -18,7 +18,8 @@ public enum SprinklerTier {
                 this.name = name;
                 this.horizontalRadius = horizontalRadius;
                 this.verticalRadius = verticalRadius;
-                this.texture = new Identifier(GardenKingMod.MOD_ID, "textures/entity/sprinkler/sprinkler.png");
+                this.texture = new Identifier(GardenKingMod.MOD_ID,
+                                "textures/entity/sprinkler/" + name + "_sprinkler.png");
         }
 
         public String getName() {


### PR DESCRIPTION
## Summary
- update sprinkler tier metadata to point at tier-specific entity textures instead of the shared default

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f001ba12b083219508261ac437bc86