### PR TITLE
Add JEI dependency for testing environment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ dependencies {
 
         modImplementation "curse.maven:epherolib-885449:4949797"
 
+        modImplementation "curse.maven:jei-238222:6600309"
+
 }
 
 processResources {


### PR DESCRIPTION
## Summary
- include the JEI CurseForge artifact in the Fabric Loom test runtime dependencies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f27619e37c83219ddd142e534ef973