### PR TITLE
Implement player skill progress tracking interface and manager

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/mixin/PlayerEntityMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/PlayerEntityMixin.java
@@ -1,6 +1,7 @@
 package net.jeremy.gardenkingmod.mixin;
 
 import net.jeremy.gardenkingmod.currency.GardenCurrencyHolder;
+import net.jeremy.gardenkingmod.skill.SkillProgressHolder;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
@@ -11,12 +12,24 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(PlayerEntity.class)
-public abstract class PlayerEntityMixin implements GardenCurrencyHolder {
+public abstract class PlayerEntityMixin implements GardenCurrencyHolder, SkillProgressHolder {
         @Unique
         private int gardenkingmod$lifetimeCurrency;
 
         @Unique
         private long gardenkingmod$bankBalance;
+
+        @Unique
+        private long gardenkingmod$skillExperience;
+
+        @Unique
+        private int gardenkingmod$skillLevel;
+
+        @Unique
+        private int gardenkingmod$unspentSkillPoints;
+
+        @Unique
+        private int gardenkingmod$chefMasteryLevel;
 
         @Override
         public int gardenkingmod$getLifetimeCurrency() {
@@ -38,6 +51,46 @@ public abstract class PlayerEntityMixin implements GardenCurrencyHolder {
                 this.gardenkingmod$bankBalance = Math.max(0L, amount);
         }
 
+        @Override
+        public long gardenkingmod$getSkillExperience() {
+                return this.gardenkingmod$skillExperience;
+        }
+
+        @Override
+        public void gardenkingmod$setSkillExperience(long experience) {
+                this.gardenkingmod$skillExperience = Math.max(0L, experience);
+        }
+
+        @Override
+        public int gardenkingmod$getSkillLevel() {
+                return this.gardenkingmod$skillLevel;
+        }
+
+        @Override
+        public void gardenkingmod$setSkillLevel(int level) {
+                this.gardenkingmod$skillLevel = Math.max(0, level);
+        }
+
+        @Override
+        public int gardenkingmod$getUnspentSkillPoints() {
+                return this.gardenkingmod$unspentSkillPoints;
+        }
+
+        @Override
+        public void gardenkingmod$setUnspentSkillPoints(int points) {
+                this.gardenkingmod$unspentSkillPoints = Math.max(0, points);
+        }
+
+        @Override
+        public int gardenkingmod$getChefMasteryLevel() {
+                return this.gardenkingmod$chefMasteryLevel;
+        }
+
+        @Override
+        public void gardenkingmod$setChefMasteryLevel(int level) {
+                this.gardenkingmod$chefMasteryLevel = Math.max(0, level);
+        }
+
         @Inject(method = "readCustomDataFromNbt", at = @At("RETURN"))
         private void gardenkingmod$readLifetimeCurrency(NbtCompound nbt, CallbackInfo ci) {
                 if (nbt.contains(LIFETIME_CURRENCY_KEY, NbtElement.NUMBER_TYPE)) {
@@ -46,6 +99,22 @@ public abstract class PlayerEntityMixin implements GardenCurrencyHolder {
 
                 if (nbt.contains(BANK_CURRENCY_KEY, NbtElement.NUMBER_TYPE)) {
                         gardenkingmod$setBankBalance(nbt.getLong(BANK_CURRENCY_KEY));
+                }
+
+                if (nbt.contains(SKILL_XP_KEY, NbtElement.NUMBER_TYPE)) {
+                        gardenkingmod$setSkillExperience(nbt.getLong(SKILL_XP_KEY));
+                }
+
+                if (nbt.contains(SKILL_LEVEL_KEY, NbtElement.NUMBER_TYPE)) {
+                        gardenkingmod$setSkillLevel(nbt.getInt(SKILL_LEVEL_KEY));
+                }
+
+                if (nbt.contains(SKILL_POINTS_KEY, NbtElement.NUMBER_TYPE)) {
+                        gardenkingmod$setUnspentSkillPoints(nbt.getInt(SKILL_POINTS_KEY));
+                }
+
+                if (nbt.contains(CHEF_MASTERY_KEY, NbtElement.NUMBER_TYPE)) {
+                        gardenkingmod$setChefMasteryLevel(nbt.getInt(CHEF_MASTERY_KEY));
                 }
         }
 
@@ -61,6 +130,30 @@ public abstract class PlayerEntityMixin implements GardenCurrencyHolder {
                         nbt.putLong(BANK_CURRENCY_KEY, gardenkingmod$getBankBalance());
                 } else {
                         nbt.remove(BANK_CURRENCY_KEY);
+                }
+
+                if (gardenkingmod$getSkillExperience() > 0) {
+                        nbt.putLong(SKILL_XP_KEY, gardenkingmod$getSkillExperience());
+                } else {
+                        nbt.remove(SKILL_XP_KEY);
+                }
+
+                if (gardenkingmod$getSkillLevel() > 0) {
+                        nbt.putInt(SKILL_LEVEL_KEY, gardenkingmod$getSkillLevel());
+                } else {
+                        nbt.remove(SKILL_LEVEL_KEY);
+                }
+
+                if (gardenkingmod$getUnspentSkillPoints() > 0) {
+                        nbt.putInt(SKILL_POINTS_KEY, gardenkingmod$getUnspentSkillPoints());
+                } else {
+                        nbt.remove(SKILL_POINTS_KEY);
+                }
+
+                if (gardenkingmod$getChefMasteryLevel() > 0) {
+                        nbt.putInt(CHEF_MASTERY_KEY, gardenkingmod$getChefMasteryLevel());
+                } else {
+                        nbt.remove(CHEF_MASTERY_KEY);
                 }
         }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/ServerPlayerEntityMixin.java
@@ -1,6 +1,7 @@
 package net.jeremy.gardenkingmod.mixin;
 
 import net.jeremy.gardenkingmod.currency.GardenCurrencyHolder;
+import net.jeremy.gardenkingmod.skill.SkillProgressHolder;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,9 +12,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class ServerPlayerEntityMixin {
         @Inject(method = "copyFrom", at = @At("TAIL"))
         private void gardenkingmod$copyLifetimeCurrency(ServerPlayerEntity oldPlayer, boolean alive, CallbackInfo ci) {
-                GardenCurrencyHolder newHolder = (GardenCurrencyHolder) this;
-                GardenCurrencyHolder oldHolder = (GardenCurrencyHolder) oldPlayer;
-                newHolder.gardenkingmod$setLifetimeCurrency(oldHolder.gardenkingmod$getLifetimeCurrency());
-                newHolder.gardenkingmod$setBankBalance(oldHolder.gardenkingmod$getBankBalance());
+                GardenCurrencyHolder newCurrencyHolder = (GardenCurrencyHolder) this;
+                GardenCurrencyHolder oldCurrencyHolder = (GardenCurrencyHolder) oldPlayer;
+                newCurrencyHolder.gardenkingmod$setLifetimeCurrency(oldCurrencyHolder.gardenkingmod$getLifetimeCurrency());
+                newCurrencyHolder.gardenkingmod$setBankBalance(oldCurrencyHolder.gardenkingmod$getBankBalance());
+
+                SkillProgressHolder newSkillHolder = (SkillProgressHolder) this;
+                SkillProgressHolder oldSkillHolder = (SkillProgressHolder) oldPlayer;
+                newSkillHolder.gardenkingmod$setSkillExperience(oldSkillHolder.gardenkingmod$getSkillExperience());
+                newSkillHolder.gardenkingmod$setSkillLevel(oldSkillHolder.gardenkingmod$getSkillLevel());
+                newSkillHolder.gardenkingmod$setUnspentSkillPoints(oldSkillHolder.gardenkingmod$getUnspentSkillPoints());
+                newSkillHolder.gardenkingmod$setChefMasteryLevel(oldSkillHolder.gardenkingmod$getChefMasteryLevel());
         }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/skill/SkillProgressHolder.java
+++ b/src/main/java/net/jeremy/gardenkingmod/skill/SkillProgressHolder.java
@@ -1,0 +1,72 @@
+package net.jeremy.gardenkingmod.skill;
+
+import net.minecraft.util.math.MathHelper;
+
+/**
+ * Capability-style contract injected into {@link net.minecraft.entity.player.PlayerEntity}
+ * for tracking Garden King skill progress, level, and spendable skill points.
+ */
+public interface SkillProgressHolder {
+        String SKILL_XP_KEY = "GardenKingSkillXp";
+        String SKILL_LEVEL_KEY = "GardenKingSkillLevel";
+        String SKILL_POINTS_KEY = "GardenKingSkillPoints";
+        String CHEF_MASTERY_KEY = "GardenKingChefMastery";
+
+        long gardenkingmod$getSkillExperience();
+
+        void gardenkingmod$setSkillExperience(long experience);
+
+        int gardenkingmod$getSkillLevel();
+
+        void gardenkingmod$setSkillLevel(int level);
+
+        int gardenkingmod$getUnspentSkillPoints();
+
+        void gardenkingmod$setUnspentSkillPoints(int points);
+
+        int gardenkingmod$getChefMasteryLevel();
+
+        void gardenkingmod$setChefMasteryLevel(int level);
+
+        default int gardenkingmod$addSkillExperience(long experience) {
+                if (experience <= 0) {
+                        return gardenkingmod$getSkillLevel();
+                }
+
+                long currentExperience = Math.max(0L, gardenkingmod$getSkillExperience());
+                long updatedExperience;
+                try {
+                        updatedExperience = Math.addExact(currentExperience, experience);
+                } catch (ArithmeticException overflow) {
+                        updatedExperience = Long.MAX_VALUE;
+                }
+                gardenkingmod$setSkillExperience(updatedExperience);
+
+                int previousLevel = Math.max(0, gardenkingmod$getSkillLevel());
+                int newLevel = SkillProgressManager.getLevelForExperience(updatedExperience);
+                if (newLevel > previousLevel) {
+                        gardenkingmod$setSkillLevel(newLevel);
+                        int awardedPoints = MathHelper.clamp(newLevel - previousLevel, 0, Integer.MAX_VALUE);
+                        if (awardedPoints > 0) {
+                                gardenkingmod$setUnspentSkillPoints(MathHelper.clamp(
+                                                gardenkingmod$getUnspentSkillPoints() + awardedPoints, 0, Integer.MAX_VALUE));
+                        }
+                }
+
+                return gardenkingmod$getSkillLevel();
+        }
+
+        default boolean gardenkingmod$spendSkillPoints(int amount) {
+                if (amount <= 0) {
+                        return true;
+                }
+
+                int currentPoints = gardenkingmod$getUnspentSkillPoints();
+                if (currentPoints < amount) {
+                        return false;
+                }
+
+                gardenkingmod$setUnspentSkillPoints(currentPoints - amount);
+                return true;
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/skill/SkillProgressManager.java
+++ b/src/main/java/net/jeremy/gardenkingmod/skill/SkillProgressManager.java
@@ -1,0 +1,76 @@
+package net.jeremy.gardenkingmod.skill;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.minecraft.util.Identifier;
+
+/**
+ * Central registry for Garden King skills, their display information, and the
+ * XP requirements for each level. Server logic and client UI should query this
+ * class to keep skill progression consistent.
+ */
+public final class SkillProgressManager {
+        public static final Identifier CHEF_SKILL = new Identifier("gardenkingmod", "chef");
+
+        private static final Map<Identifier, SkillDefinition> SKILL_DEFINITIONS = new LinkedHashMap<>();
+        private static final List<Long> LEVEL_THRESHOLDS = List.of(
+                        0L,   // Level 0
+                        100L, // Level 1
+                        250L, // Level 2
+                        500L, // Level 3
+                        900L, // Level 4
+                        1400L, // Level 5
+                        2000L, // Level 6
+                        2700L, // Level 7
+                        3500L, // Level 8
+                        4400L, // Level 9
+                        5400L  // Level 10
+        );
+
+        static {
+                registerSkill(new SkillDefinition(CHEF_SKILL, "Chef Mastery", "Improve your cooking prowess."));
+        }
+
+        private SkillProgressManager() {
+        }
+
+        public static void registerSkill(SkillDefinition definition) {
+                SKILL_DEFINITIONS.put(definition.id(), definition);
+        }
+
+        public static Map<Identifier, SkillDefinition> getSkillDefinitions() {
+                return Collections.unmodifiableMap(SKILL_DEFINITIONS);
+        }
+
+        public static int getLevelForExperience(long experience) {
+                int level = 0;
+                for (int i = 0; i < LEVEL_THRESHOLDS.size(); i++) {
+                        long threshold = LEVEL_THRESHOLDS.get(i);
+                        if (experience < threshold) {
+                                break;
+                        }
+                        level = i;
+                }
+                return level;
+        }
+
+        public static long getExperienceForLevel(int level) {
+                if (level < 0) {
+                        return 0L;
+                }
+                if (level >= LEVEL_THRESHOLDS.size()) {
+                        return LEVEL_THRESHOLDS.get(LEVEL_THRESHOLDS.size() - 1);
+                }
+                return LEVEL_THRESHOLDS.get(level);
+        }
+
+        public static int getMaxDefinedLevel() {
+                return LEVEL_THRESHOLDS.size() - 1;
+        }
+
+        public record SkillDefinition(Identifier id, String displayName, String description) {
+        }
+}


### PR DESCRIPTION
## Summary
- add a SkillProgressHolder interface that tracks experience, levels, and spendable points for Garden King skills
- persist player skill fields via PlayerEntityMixin and copy them across respawns
- introduce a SkillProgressManager utility to define XP thresholds and skill metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2b9fd222483218bb3a3089a22a546