### PR TITLE
Add HUD overlay for skill experience

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -11,6 +11,8 @@ import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
+import net.jeremy.gardenkingmod.client.hud.SkillHudOverlay;
 import net.jeremy.gardenkingmod.client.model.BankBlockModel;
 import net.jeremy.gardenkingmod.client.model.CrowEntityModel;
 import net.jeremy.gardenkingmod.client.model.GearShopModel;
@@ -32,6 +34,7 @@ import net.jeremy.gardenkingmod.client.render.item.SprinklerItemRenderer;
 import net.jeremy.gardenkingmod.registry.ModEntities;
 import net.jeremy.gardenkingmod.ModBlockEntities;
 import net.jeremy.gardenkingmod.ModBlocks;
+import net.jeremy.gardenkingmod.ModScreenHandlers;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.item.FortuneProvidingItem;
 import net.jeremy.gardenkingmod.network.ModPackets;
@@ -84,6 +87,7 @@ public class GardenKingModClient implements ClientModInitializer {
         BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.DIAMOND_SPRINKLER_BLOCK, sprinklerItemRenderer);
         BuiltinItemRendererRegistry.INSTANCE.register(ModBlocks.EMERALD_SPRINKLER_BLOCK, sprinklerItemRenderer);
         BlockRenderLayerMap.INSTANCE.putBlock(ModBlocks.SCARECROW_BLOCK, RenderLayer.getCutout());
+        HudRenderCallback.EVENT.register(SkillHudOverlay.INSTANCE);
 
         ClientPlayNetworking.registerGlobalReceiver(ModPackets.MARKET_SALE_RESULT_PACKET,
                 (client, handler, buf, responseSender) -> {

--- a/src/main/java/net/jeremy/gardenkingmod/client/hud/SkillHudOverlay.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/hud/SkillHudOverlay.java
@@ -1,0 +1,91 @@
+package net.jeremy.gardenkingmod.client.hud;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+
+import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.jeremy.gardenkingmod.client.skill.SkillState;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+
+/**
+ * Renders the Garden King skill progress bar directly above the vanilla
+ * experience bar.
+ */
+public final class SkillHudOverlay implements HudRenderCallback {
+    private static final Identifier TEXTURE = new Identifier(GardenKingMod.MOD_ID,
+            "textures/gui/skill_xp_bar.png");
+    // The texture should contain three horizontal stripes, each BAR_WIDTH pixels wide:
+    // 1) Background slice at V=0 with height BAR_HEIGHT
+    // 2) Filled slice at V=BAR_HEIGHT with height BAR_HEIGHT
+    // 3) Highlight slice at V=BAR_HEIGHT*2 with height BAR_HEIGHT+2 for the glow effect
+    private static final int BAR_WIDTH = 182;
+    private static final int BAR_HEIGHT = 5;
+    private static final int BACKGROUND_V = 0;
+    private static final int FILL_V = BAR_HEIGHT;
+    private static final int HIGHLIGHT_V = BAR_HEIGHT * 2;
+
+    private float displayedProgress;
+
+    public static final SkillHudOverlay INSTANCE = new SkillHudOverlay();
+
+    private SkillHudOverlay() {
+    }
+
+    @Override
+    public void onHudRender(DrawContext context, float tickDelta) {
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client == null || client.options.hudHidden) {
+            return;
+        }
+
+        ClientPlayerEntity player = client.player;
+        if (player == null || player.isSpectator()) {
+            return;
+        }
+
+        SkillState skillState = SkillState.getInstance();
+        float targetProgress = MathHelper.clamp(skillState.getProgressPercentage(), 0.0f, 1.0f);
+        // Smooth animation towards the target progress to avoid abrupt jumps.
+        displayedProgress = MathHelper.lerp(0.15f, displayedProgress, targetProgress);
+        if (Math.abs(displayedProgress - targetProgress) < 0.003f) {
+            displayedProgress = targetProgress;
+        }
+
+        int scaledWidth = client.getWindow().getScaledWidth();
+        int scaledHeight = client.getWindow().getScaledHeight();
+        int barX = scaledWidth / 2 - BAR_WIDTH / 2;
+        int vanillaXpBarY = scaledHeight - 32 + 3;
+        int barY = vanillaXpBarY - BAR_HEIGHT - 4;
+
+        context.drawTexture(TEXTURE, barX, barY, 0, BACKGROUND_V, BAR_WIDTH, BAR_HEIGHT);
+
+        int filledWidth = MathHelper.ceil(displayedProgress * BAR_WIDTH);
+        if (filledWidth > 0) {
+            context.drawTexture(TEXTURE, barX, barY, 0, FILL_V, filledWidth, BAR_HEIGHT);
+        }
+
+        int unspentSkillPoints = skillState.getUnspentSkillPoints();
+        if (unspentSkillPoints > 0) {
+            float flashStrength = 0.55f + 0.45f
+                    * MathHelper.sin((player.age + tickDelta) * 0.3f * MathHelper.PI);
+            RenderSystem.enableBlend();
+            RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, MathHelper.clamp(flashStrength, 0.0f, 1.0f));
+            context.drawTexture(TEXTURE, barX, barY - 1, 0, HIGHLIGHT_V, BAR_WIDTH, BAR_HEIGHT + 2);
+            RenderSystem.disableBlend();
+            RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
+        }
+
+        int level = Math.max(0, skillState.getLevel());
+        Text levelText = Text.translatable("hud." + GardenKingMod.MOD_ID + ".skill_level", level);
+        int textWidth = client.textRenderer.getWidth(levelText);
+        int textX = scaledWidth / 2 - textWidth / 2;
+        int textY = barY - 10;
+
+        context.drawText(client.textRenderer, levelText, textX, textY, 0x80FF20, true);
+    }
+}

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -93,6 +93,7 @@
   "message.gardenkingmod.bank.not_owner": "Only the account owner may use this bank.",
   "scoreboard.gardenkingmod.garden_currency": "Garden Dollars",
   "scoreboard.gardenkingmod.garden_currency_bank": "Bank Dollars",
+  "hud.gardenkingmod.skill_level": "%s",
   "screen.gardenkingmod.market.sale_result_sold": "Sold: %1$s crops",
   "screen.gardenkingmod.market.sale_result_sold_detailed": "Sold: %1$s",
   "screen.gardenkingmod.market.sale_result_earned": "Earned: %1$s dollars",


### PR DESCRIPTION
## Summary
- register a HUD render callback that displays the client skill bar above the vanilla experience bar and animates its fill ratio
- highlight the bar when unspent skill points are available and render the localized skill level indicator text

## Testing
- ./gradlew build *(fails: 403 Forbidden retrieving curse.maven:jei-238222:6600309)*

------
https://chatgpt.com/codex/tasks/task_e_68f2cde89be88321a88081c6c87e375b