### PR TITLE
Fix server API usage for loot tables and networking compatibility

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/crop/RightClickHarvestHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/RightClickHarvestHandler.java
@@ -74,7 +74,7 @@ public final class RightClickHarvestHandler {
         private static void dropStacksWithXp(BlockState state, ServerWorld world, BlockPos pos,
                         @Nullable BlockEntity blockEntity, PlayerEntity player, ItemStack toolForDrops) {
                 Identifier lootTableId = state.getBlock().getLootTableId();
-                LootTable lootTable = world.getServer().getReloadableRegistries().getLootTable(lootTableId);
+                LootTable lootTable = world.getServer().getLootManager().getLootTable(lootTableId);
 
                 LootContextParameterSet.Builder builder = new LootContextParameterSet.Builder(world)
                                 .add(LootContextParameters.ORIGIN, Vec3d.ofCenter(pos))

--- a/src/main/java/net/jeremy/gardenkingmod/network/ModServerNetworking.java
+++ b/src/main/java/net/jeremy/gardenkingmod/network/ModServerNetworking.java
@@ -33,13 +33,15 @@ public final class ModServerNetworking {
                     int pointsToSpend = buf.readVarInt();
 
                     server.execute(() -> {
-                        if (!(player instanceof ServerPlayerEntity serverPlayer)) {
+                        if (!(player instanceof ServerPlayerEntity)) {
                             return;
                         }
+                        ServerPlayerEntity serverPlayer = (ServerPlayerEntity) player;
 
-                        if (!(serverPlayer instanceof SkillProgressHolder skillHolder)) {
+                        if (!(serverPlayer instanceof SkillProgressHolder)) {
                             return;
                         }
+                        SkillProgressHolder skillHolder = (SkillProgressHolder) serverPlayer;
 
                         if (pointsToSpend <= 0) {
                             SkillProgressNetworking.sync(serverPlayer);


### PR DESCRIPTION
## Summary
- update crop harvest handler to use the server loot manager instead of the removed reloadable registries accessor
- replace pattern matching instanceof usages in the networking handler so the project compiles under Java 17

## Testing
- `./gradlew build` *(fails: cannot download curse.maven:jei-238222:6600309 due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f2ddc7cfd88321bd9e92583f9cacc3