### PR TITLE
Fix skill bar texture dimensions for HUD overlay

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/hud/SkillHudOverlay.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/hud/SkillHudOverlay.java
@@ -25,8 +25,11 @@ public final class SkillHudOverlay implements HudRenderCallback {
     // 3) Highlight slice at V=BAR_HEIGHT*2 with height BAR_HEIGHT
     private static final int BAR_WIDTH = 81;
     private static final int BAR_HEIGHT = 5;
-    private static final int TEXTURE_WIDTH = BAR_WIDTH;
-    private static final int TEXTURE_HEIGHT = BAR_HEIGHT * 3;
+    // DrawContext#drawTexture requires the full dimensions of the underlying texture atlas
+    // to avoid stretching the UVs across the image. The skill bar sprites occupy the top
+    // left corner of a 128x128 texture file.
+    private static final int TEXTURE_WIDTH = 128;
+    private static final int TEXTURE_HEIGHT = 128;
     private static final int BACKGROUND_V = 0;
     private static final int FILL_V = BAR_HEIGHT;
     private static final int HIGHLIGHT_V = BAR_HEIGHT * 2;


### PR DESCRIPTION
## Summary
- ensure the skill bar overlay renders using the full 128x128 texture dimensions
- document why the full texture size must be supplied to DrawContext#drawTexture

## Testing
- `./gradlew test` *(fails: curse maven dependency curse.maven:jei-238222:6600309 returns HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f3136ab6a08321b5d5edcde477abf8