### PR TITLE
Fix XP award for right-click harvesting - address Codex review

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/crop/RightClickHarvestHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/RightClickHarvestHandler.java
@@ -1,5 +1,7 @@
 package net.jeremy.gardenkingmod.crop;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.jeremy.gardenkingmod.ModItems;
@@ -13,6 +15,7 @@ import net.minecraft.block.CropBlock;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.HoeItem;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.loot.LootTable;
 import net.minecraft.loot.context.LootContextParameterSet;
@@ -90,8 +93,8 @@ public final class RightClickHarvestHandler {
                 Identifier blockId = Registries.BLOCK.getId(state.getBlock());
                 Identifier tierId = CropTierRegistry.get(state).map(CropTier::id).orElse(null);
 
-                ItemStack enchantedCandidate = ItemStack.EMPTY;
-                ItemStack normalCandidate = ItemStack.EMPTY;
+                AtomicReference<ItemStack> enchantedCandidate = new AtomicReference<>(ItemStack.EMPTY);
+                AtomicReference<ItemStack> normalCandidate = new AtomicReference<>(ItemStack.EMPTY);
 
                 lootTable.generateLoot(parameters, stack -> {
                         if (stack.isEmpty()) {
@@ -100,17 +103,17 @@ public final class RightClickHarvestHandler {
 
                         Item item = stack.getItem();
                         if (ModItems.isEnchantedItem(item)) {
-                                if (enchantedCandidate.isEmpty()) {
-                                        enchantedCandidate = stack.copy();
+                                if (enchantedCandidate.get().isEmpty()) {
+                                        enchantedCandidate.set(stack.copy());
                                 }
-                        } else if (!ModItems.isRottenItem(item) && normalCandidate.isEmpty()) {
-                                normalCandidate = stack.copy();
+                        } else if (!ModItems.isRottenItem(item) && normalCandidate.get().isEmpty()) {
+                                normalCandidate.set(stack.copy());
                         }
 
                         Block.dropStack(world, pos, stack);
                 });
 
-                ItemStack xpStack = enchantedCandidate.isEmpty() ? normalCandidate : enchantedCandidate;
+                ItemStack xpStack = enchantedCandidate.get().isEmpty() ? normalCandidate.get() : enchantedCandidate.get();
                 if (!xpStack.isEmpty()) {
                         HarvestXpService.awardHarvestXp(player, blockId, tierId, xpStack);
                 }


### PR DESCRIPTION
## Summary
- make the candidate drop stacks lambda-safe by storing them in AtomicReferences
- add the missing Item import required by the lambda refactor

## Testing
- not run (network-restricted environment)


------
https://chatgpt.com/codex/tasks/task_e_68f31d11b03c8321af3fe2ed13c04966