### PR TITLE
Fix RightClickHarvestHandler loot generation loop

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/crop/RightClickHarvestHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/crop/RightClickHarvestHandler.java
@@ -1,5 +1,7 @@
 package net.jeremy.gardenkingmod.crop;
 
+import java.util.List;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.jeremy.gardenkingmod.ModItems;
@@ -94,9 +96,10 @@ public final class RightClickHarvestHandler {
                 ItemStack enchantedCandidate = ItemStack.EMPTY;
                 ItemStack normalCandidate = ItemStack.EMPTY;
 
-                lootTable.generateLoot(parameters, stack -> {
+                List<ItemStack> generatedLoot = lootTable.generateLoot(parameters);
+                for (ItemStack stack : generatedLoot) {
                         if (stack.isEmpty()) {
-                                return;
+                                continue;
                         }
 
                         Item item = stack.getItem();
@@ -109,7 +112,7 @@ public final class RightClickHarvestHandler {
                         }
 
                         Block.dropStack(world, pos, stack);
-                });
+                }
 
                 ItemStack xpStack = enchantedCandidate.isEmpty() ? normalCandidate : enchantedCandidate;
                 if (!xpStack.isEmpty()) {


### PR DESCRIPTION
## Summary
- replace the loot table consumer lambda with explicit iteration so item candidates can be tracked outside the callback
- add the required List import for the new collection usage

## Testing
- ./gradlew build *(fails: Could not resolve curse.maven:jei-238222:6600309 due to 403 responses from multiple repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68f3a45ae92483219fa44fc93dc9e187