### PR TITLE
Fix Croptopia mixin injection target

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java
@@ -20,7 +20,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
                 "com.epherical.croptopia.blocks.CroptopiaCropBlock" }, remap = false)
 public abstract class CroptopiaCropBlockMixin {
 
-        @Inject(method = "method_9534", at = @At("HEAD"), cancellable = true, remap = false)
+        @Inject(method = "onUse(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;",
+                        at = @At("HEAD"), cancellable = true, remap = false)
         private void gardenkingmod$harvestCrops(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand,
                         BlockHitResult hit, CallbackInfoReturnable<ActionResult> cir) {
                 CropBlock crop = (CropBlock) (Object) this;


### PR DESCRIPTION
## Summary
- update the Croptopia crop mixin to target the named onUse method signature so injection can succeed even without intermediary mappings

## Testing
- ./gradlew build *(fails: unable to download curse.maven:jei-238222:6600309 due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f3b719e56483219bc8e3d7e06193ad