### PR TITLE
Play level-up sound on skill level increase

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -54,6 +54,8 @@ import net.minecraft.client.render.block.entity.BlockEntityRendererFactories;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
@@ -169,8 +171,14 @@ public class GardenKingModClient implements ClientModInitializer {
 
                         client.execute(() -> {
                                 SkillState skillState = SkillState.getInstance();
+                                int previousLevel = skillState.getLevel();
                                 skillState.update(experience, level, progressIntoLevel, experienceToNextLevel,
                                                 unspentPoints, allocations);
+
+                                if (client.player != null && level > previousLevel) {
+                                        client.player.playSound(SoundEvents.ENTITY_PLAYER_LEVELUP, SoundCategory.PLAYERS,
+                                                        1.0f, 1.0f);
+                                }
 
                                 if (client.player instanceof SkillProgressHolder skillHolder) {
                                         skillHolder.gardenkingmod$setSkillExperience(experience);


### PR DESCRIPTION
## Summary
- play the vanilla experience level-up sound when the Garden King skill reaches a new level
- track the previous cached skill level on the client before applying incoming updates

## Testing
- ./gradlew build *(fails: dependency curse.maven:jei-238222:6600309 returns HTTP 403 from all configured repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68f3b935eb1883218f79eb11905e5148