### PR TITLE
Restore Croptopia mixin target runtime name

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
                 "com.epherical.croptopia.blocks.CroptopiaCropBlock" }, remap = false)
 public abstract class CroptopiaCropBlockMixin {
 
-        @Inject(method = "onUse(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;",
+        @Inject(method = "method_9534(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;",
                         at = @At("HEAD"), cancellable = true, remap = false)
         private void gardenkingmod$harvestCrops(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand,
                         BlockHitResult hit, CallbackInfoReturnable<ActionResult> cir) {


### PR DESCRIPTION
## Summary
- restore the Croptopia crop mixin injection target to the runtime `method_9534` name so it resolves when remap=false

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3b8fbe7cc832193e3b8170b4ccbb2