### PR TITLE
Add unspent points indicator to skill screen title

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/gui/SkillScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/gui/SkillScreen.java
@@ -32,8 +32,9 @@ public class SkillScreen extends Screen {
         private static final int XP_BAR_FILL_V = XP_BAR_HEIGHT;
         private static final int XP_BAR_X_OFFSET_FROM_TITLE = 30;
         private static final int XP_BAR_Y_OFFSET = 2;
-        private static final int XP_LEVEL_TEXT_X_OFFSET = 2;
         private static final int XP_LEVEL_TEXT_COLOR = 0x55FF55;
+        private static final int UNSPENT_POINTS_X_OFFSET = 10;
+        private static final int UNSPENT_POINTS_TEXT_COLOR = 0x404040;
 
         private static final int BACKGROUND_WIDTH = 428;
         private static final int BACKGROUND_HEIGHT = 246;
@@ -90,6 +91,7 @@ public class SkillScreen extends Screen {
                 SkillState skillState = SkillState.getInstance();
                 float progress = MathHelper.clamp(skillState.getProgressPercentage(), 0.0f, 1.0f);
                 int level = skillState.getLevel();
+                int unspentPoints = Math.max(0, skillState.getUnspentSkillPoints());
 
                 int titleWidth = this.textRenderer.getWidth(this.title);
                 int barX = this.backgroundX + TITLE_X + titleWidth + XP_BAR_X_OFFSET_FROM_TITLE;
@@ -106,9 +108,17 @@ public class SkillScreen extends Screen {
 
                 if (this.textRenderer != null) {
                         String levelText = Integer.toString(Math.max(0, level));
-                        int textX = barX + XP_BAR_WIDTH + XP_LEVEL_TEXT_X_OFFSET;
-                        int textY = barY + Math.max(0, (XP_BAR_HEIGHT - this.textRenderer.fontHeight) / 2);
-                        context.drawText(this.textRenderer, levelText, textX, textY, XP_LEVEL_TEXT_COLOR, false);
+                        int levelTextWidth = this.textRenderer.getWidth(levelText);
+                        int levelTextX = barX + Math.max(0, (XP_BAR_WIDTH - levelTextWidth) / 2);
+                        int levelTextY = barY + Math.max(0, (XP_BAR_HEIGHT - this.textRenderer.fontHeight) / 2);
+                        context.drawText(this.textRenderer, levelText, levelTextX, levelTextY, XP_LEVEL_TEXT_COLOR, false);
+
+                        Text unspentPointsText = Text.translatable("screen.gardenkingmod.skills.unspent_points",
+                                        unspentPoints);
+                        int unspentTextX = barX + XP_BAR_WIDTH + UNSPENT_POINTS_X_OFFSET;
+                        int unspentTextY = this.backgroundY + TITLE_Y;
+                        context.drawText(this.textRenderer, unspentPointsText, unspentTextX, unspentTextY,
+                                        UNSPENT_POINTS_TEXT_COLOR, false);
                 }
         }
 


### PR DESCRIPTION
## Summary
- display the unspent points label beside the skill XP bar on the skills screen
- center the level value within the XP bar to keep the title area readable

## Testing
- ./gradlew check *(fails: could not download curse.maven:jei-238222:6600309 due to HTTP 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68f6b08f52388321a01c897905405a1f