### PR TITLE
Add adjustable header XP bar offset

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/client/gui/SkillScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/client/gui/SkillScreen.java
@@ -47,6 +47,7 @@ public class SkillScreen extends Screen {
         private static final int HEADER_LINE_SPACING = 1;
         private static final int HEADER_LABEL_VALUE_GAP = 4;
         private static final int HEADER_PROGRESS_BAR_VERTICAL_GAP = 2;
+        private static final int HEADER_PROGRESS_BAR_Y_OFFSET = 3;
 
         private static final int UNSPENT_POINTS_X_OFFSET_FROM_TITLE = 100;
         private static final int UNSPENT_POINTS_Y_OFFSET = 0;
@@ -154,7 +155,8 @@ public class SkillScreen extends Screen {
                                 - HEADER_CONTENT_PADDING_RIGHT;
                 int xpBarWidth = Math.min(XP_BAR_DISPLAY_WIDTH, availableContentWidth);
                 int xpBarX = contentX;
-                int xpBarY = progressY + lineHeight + HEADER_PROGRESS_BAR_VERTICAL_GAP;
+                int xpBarY = progressY + lineHeight + HEADER_PROGRESS_BAR_VERTICAL_GAP
+                                + HEADER_PROGRESS_BAR_Y_OFFSET;
 
                 int minXpBarY = contentY;
                 int maxXpBarY = headerY + HEADER_AREA_HEIGHT - HEADER_CONTENT_PADDING_Y - XP_BAR_HEIGHT;


### PR DESCRIPTION
## Summary
- add a dedicated vertical offset for the header XP bar so it renders lower in the skill screen header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7cc7de3f88321a135d0d4ae9fe93f