### PR TITLE
Remove shared chef skill scale helper

### DIFF
--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -340,6 +340,7 @@
   "screen.gardenkingmod.skills.header.level_label": "Level:",
   "screen.gardenkingmod.skills.header.total_xp_label": "Total XP:",
   "screen.gardenkingmod.skills.header.progress_label": "Progress:",
+  "screen.gardenkingmod.skills.chef.current_level_label": "Current Level:",
   "screen.gardenkingmod.skills.allocate": "Allocate",
   "screen.gardenkingmod.skills.points_spent": "Points Spent: %s",
   "key.gardenkingmod.open_skills": "Open Skill Screen",


### PR DESCRIPTION
## Summary
- remove the shared text-scaling helper so the chef skill title, label, and value each retain independent scaling controls

## Testing
- `./gradlew build` *(fails: Could not resolve curse.maven:jei-238222:6600309 due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f8015947688321bc8f64edce5449e1