### PR TITLE
Implement scrollable multi-skill screen interactions

### DIFF
--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -341,6 +341,8 @@
   "screen.gardenkingmod.skills.header.total_xp_label": "Total XP:",
   "screen.gardenkingmod.skills.header.progress_label": "Progress:",
   "screen.gardenkingmod.skills.chef.current_level_label": "Level:",
+  "screen.gardenkingmod.skills.upgrade_button": "Upgrade",
+  "screen.gardenkingmod.skills.description_placeholder": "Select a skill to view its details.",
   "screen.gardenkingmod.skills.allocate": "Allocate",
   "screen.gardenkingmod.skills.points_spent": "Points Spent: %s",
   "key.gardenkingmod.open_skills": "Open Skill Screen",


### PR DESCRIPTION
## Summary
- restructure the skill screen to render a scrollable list of skill entries with hover highlighting, selection, and detailed descriptions
- add client-side click handling for skill selection, upgrade button activation, scroll bar dragging, and upgrade packet dispatch with audio feedback
- extend localization with strings for the upgrade button and description placeholder

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68f90c2d35108321961b8ac6070c6268