### PR TITLE
Ensure garden oven faces player on placement

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/GardenOvenBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/GardenOvenBlock.java
@@ -2,10 +2,13 @@ package net.jeremy.gardenkingmod.block;
 
 import net.jeremy.gardenkingmod.block.entity.GardenOvenBlockEntity;
 import net.minecraft.block.AbstractFurnaceBlock;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemPlacementContext;
+import net.minecraft.item.ItemStack;
 import net.minecraft.screen.NamedScreenHandlerFactory;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -19,17 +22,35 @@ public class GardenOvenBlock extends AbstractFurnaceBlock {
                                 .with(LIT, Boolean.FALSE));
         }
 
-        @Override
-        public BlockState getPlacementState(ItemPlacementContext ctx) {
-                Direction facing = ctx.getHorizontalPlayerFacing().getOpposite();
-                return this.getDefaultState().with(FACING, facing).with(LIT, Boolean.FALSE);
-        }
+	@Override
+	public BlockState getPlacementState(ItemPlacementContext ctx) {
+		Direction facing = ctx.getHorizontalPlayerFacing().getOpposite();
+		return this.getDefaultState().with(FACING, facing).with(LIT, Boolean.FALSE);
+	}
 
-        @Override
-        protected void openScreen(World world, BlockPos pos, PlayerEntity player) {
-                if (world.isClient) {
-                        return;
-                }
+	@Override
+	public void onPlaced(World world, BlockPos pos, BlockState state, LivingEntity placer, ItemStack itemStack) {
+		super.onPlaced(world, pos, state, placer, itemStack);
+		if (world.isClient) {
+			return;
+		}
+
+		Direction facing = state.get(FACING);
+		if (placer instanceof PlayerEntity player) {
+			facing = player.getHorizontalFacing().getOpposite();
+		}
+
+		BlockState updatedState = state.with(FACING, facing);
+		if (!updatedState.equals(state)) {
+			world.setBlockState(pos, updatedState, Block.NOTIFY_ALL);
+		}
+	}
+
+	@Override
+	protected void openScreen(World world, BlockPos pos, PlayerEntity player) {
+		if (world.isClient) {
+			return;
+		}
 
                 BlockEntity blockEntity = world.getBlockEntity(pos);
                 if (blockEntity instanceof GardenOvenBlockEntity oven) {


### PR DESCRIPTION
## Summary
- update the garden oven placement logic to mirror the bank block so the model faces the placing player
- adjust placement handling to resync the block state on the server when a player places the oven

## Testing
- ./gradlew build *(fails: unable to download curse.maven:jei-238222:6600309 due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fd63f074f883219d20040e4073fc9d