### PR TITLE
Fix garden oven facing logic

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/GardenOvenBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/GardenOvenBlock.java
@@ -2,13 +2,10 @@ package net.jeremy.gardenkingmod.block;
 
 import net.jeremy.gardenkingmod.block.entity.GardenOvenBlockEntity;
 import net.minecraft.block.AbstractFurnaceBlock;
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemPlacementContext;
-import net.minecraft.item.ItemStack;
 import net.minecraft.screen.NamedScreenHandlerFactory;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -22,29 +19,15 @@ public class GardenOvenBlock extends AbstractFurnaceBlock {
                                 .with(LIT, Boolean.FALSE));
         }
 
-	@Override
-	public BlockState getPlacementState(ItemPlacementContext ctx) {
-		Direction facing = ctx.getHorizontalPlayerFacing().getOpposite();
-		return this.getDefaultState().with(FACING, facing).with(LIT, Boolean.FALSE);
-	}
+        @Override
+        public BlockState getPlacementState(ItemPlacementContext ctx) {
+                Direction facing = ctx.getHorizontalPlayerFacing().getOpposite();
+                if (ctx.getPlayer() == null) {
+                        facing = ctx.getHorizontalFacing().getOpposite();
+                }
 
-	@Override
-	public void onPlaced(World world, BlockPos pos, BlockState state, LivingEntity placer, ItemStack itemStack) {
-		super.onPlaced(world, pos, state, placer, itemStack);
-		if (world.isClient) {
-			return;
-		}
-
-		Direction facing = state.get(FACING);
-		if (placer instanceof PlayerEntity player) {
-			facing = player.getHorizontalFacing().getOpposite();
-		}
-
-		BlockState updatedState = state.with(FACING, facing);
-		if (!updatedState.equals(state)) {
-			world.setBlockState(pos, updatedState, Block.NOTIFY_ALL);
-		}
-	}
+                return this.getDefaultState().with(FACING, facing).with(LIT, Boolean.FALSE);
+        }
 
 	@Override
 	protected void openScreen(World world, BlockPos pos, PlayerEntity player) {


### PR DESCRIPTION
## Summary
- keep the garden oven facing toward the placer by relying on placement context data
- fall back to the clicked face when the block is placed without a player to avoid north-only orientation

## Testing
- `./gradlew build` *(fails: dependency download blocked with HTTP 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68fd66846ca88321948860936695a738