### PR TITLE
Fix garden oven facing direction

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/GardenOvenBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/GardenOvenBlock.java
@@ -24,7 +24,7 @@ public class GardenOvenBlock extends AbstractFurnaceBlock {
 
     @Override
     public BlockState getPlacementState(ItemPlacementContext ctx) {
-        Direction facing = ctx.getHorizontalPlayerFacing().getOpposite();
+        Direction facing = ctx.getHorizontalPlayerFacing();
         if (ctx.getPlayer() == null) {
             Direction side = ctx.getSide();
             if (side.getAxis().isHorizontal()) {
@@ -44,7 +44,7 @@ public class GardenOvenBlock extends AbstractFurnaceBlock {
 
         Direction facing = state.get(FACING);
         if (placer instanceof PlayerEntity player) {
-            facing = player.getHorizontalFacing().getOpposite();
+            facing = player.getHorizontalFacing();
         }
 
         BlockState updatedState = state.with(FACING, facing);


### PR DESCRIPTION
## Summary
- adjust the garden oven placement logic so the block faces the player instead of away from them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe54e952788321befa650279af89ec