### PR TITLE
Fix GardenOvenBlock merge errors

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/GardenOvenBlock.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/GardenOvenBlock.java
@@ -15,7 +15,6 @@ import net.minecraft.block.entity.BlockEntityTicker;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemPlacementContext;
-import net.minecraft.item.ItemStack;
 import net.minecraft.screen.NamedScreenHandlerFactory;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
@@ -33,94 +32,82 @@ import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 
 public class GardenOvenBlock extends BlockWithEntity {
-        public static final DirectionProperty FACING = HorizontalFacingBlock.FACING;
-        public static final BooleanProperty LIT = Properties.LIT;
-        private static final VoxelShape SHAPE = Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, 16.0, 16.0);
+    public static final DirectionProperty FACING = HorizontalFacingBlock.FACING;
+    public static final BooleanProperty LIT = Properties.LIT;
+    private static final VoxelShape SHAPE = Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, 16.0, 16.0);
 
-        public GardenOvenBlock(Settings settings) {
-                super(settings);
-                this.setDefaultState(this.stateManager.getDefaultState().with(FACING, Direction.NORTH).with(LIT, Boolean.FALSE));
-        }
-
-        @Override
-        public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
-                return new GardenOvenBlockEntity(pos, state);
-        }
-
-        @Override
-        public BlockRenderType getRenderType(BlockState state) {
-                return BlockRenderType.MODEL;
-        }
-
-        @Override
-        public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
-                return SHAPE;
-        }
-
-        @Override
-        public BlockState getPlacementState(ItemPlacementContext ctx) {
-                Direction facing = ctx.getHorizontalPlayerFacing().getOpposite();
-                return this.getDefaultState().with(FACING, facing).with(LIT, Boolean.FALSE);
-        }
-
-        @Override
-        protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-                builder.add(FACING, LIT);
-        }
-
-        @Override
-        public BlockState rotate(BlockState state, BlockRotation rotation) {
-                return state.with(FACING, rotation.rotate(state.get(FACING)));
-        }
-
-        @Override
-        public BlockState mirror(BlockState state, BlockMirror mirror) {
-                return state.rotate(mirror.getRotation(state.get(FACING)));
-        }
-
-        @Override
-        public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
-                if (world.isClient) {
-                        return ActionResult.SUCCESS;
-                }
-
-                BlockEntity blockEntity = world.getBlockEntity(pos);
-                if (blockEntity instanceof GardenOvenBlockEntity oven) {
-                        player.openHandledScreen((NamedScreenHandlerFactory) oven);
-                }
-
-                return ActionResult.CONSUME;
-        }
+    public GardenOvenBlock(Settings settings) {
+        super(settings);
+        this.setDefaultState(this.stateManager.getDefaultState().with(FACING, Direction.NORTH).with(LIT, Boolean.FALSE));
     }
 
-        @Override
-        public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
-                if (state.isOf(newState.getBlock())) {
-                        super.onStateReplaced(state, world, pos, newState, moved);
-                        return;
-                }
+    @Override
+    public BlockRenderType getRenderType(BlockState state) {
+        return BlockRenderType.MODEL;
+    }
 
-                BlockEntity blockEntity = world.getBlockEntity(pos);
-                if (blockEntity instanceof GardenOvenBlockEntity oven) {
-                        oven.dropContents(world, pos);
-                }
+    @Override
+    public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+        return SHAPE;
+    }
 
-                super.onStateReplaced(state, world, pos, newState, moved);
-        }
+    @Override
+    public BlockState getPlacementState(ItemPlacementContext ctx) {
+        Direction facing = ctx.getHorizontalPlayerFacing().getOpposite();
+        return this.getDefaultState().with(FACING, facing).with(LIT, Boolean.FALSE);
+    }
 
-        @Nullable
-        @Override
-        public <T extends BlockEntity> BlockEntityTicker<T> getTicker(World world, BlockState state, BlockEntityType<T> type) {
-                if (world.isClient) {
-                        return null;
-                }
-                return checkType(type, ModBlockEntities.GARDEN_OVEN_BLOCK_ENTITY, GardenOvenBlockEntity::tick);
+    @Override
+    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+        builder.add(FACING, LIT);
+    }
+
+    @Override
+    public BlockState rotate(BlockState state, BlockRotation rotation) {
+        return state.with(FACING, rotation.rotate(state.get(FACING)));
+    }
+
+    @Override
+    public BlockState mirror(BlockState state, BlockMirror mirror) {
+        return state.rotate(mirror.getRotation(state.get(FACING)));
+    }
+
+    @Override
+    public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
+        if (world.isClient) {
+            return ActionResult.SUCCESS;
         }
 
         BlockEntity blockEntity = world.getBlockEntity(pos);
         if (blockEntity instanceof GardenOvenBlockEntity oven) {
             player.openHandledScreen((NamedScreenHandlerFactory) oven);
         }
+
+        return ActionResult.CONSUME;
+    }
+
+    @Override
+    public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
+        if (state.isOf(newState.getBlock())) {
+            super.onStateReplaced(state, world, pos, newState, moved);
+            return;
+        }
+
+        BlockEntity blockEntity = world.getBlockEntity(pos);
+        if (blockEntity instanceof GardenOvenBlockEntity oven) {
+            oven.dropContents(world, pos);
+        }
+
+        super.onStateReplaced(state, world, pos, newState, moved);
+    }
+
+    @Nullable
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(World world, BlockState state, BlockEntityType<T> type) {
+        if (world.isClient) {
+            return null;
+        }
+        return checkType(type, ModBlockEntities.GARDEN_OVEN_BLOCK_ENTITY, GardenOvenBlockEntity::tick);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- restore GardenOvenBlock class structure after the broken merge
- ensure the block correctly handles placement, GUI opening, inventory drops, and ticking

## Testing
- ./gradlew build *(fails: dependency download for curse.maven:jei-238222:6600309 returns HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5860bca48321a3dfc5dd0546e4c1