### PR TITLE
Add Garden Oven recipes for Croptopia meals

### DIFF
--- a/docs/garden_oven_recipes.md
+++ b/docs/garden_oven_recipes.md
@@ -1,0 +1,75 @@
+# Garden Oven recipe overrides
+
+The mod now overrides a wide range of Croptopia "meal" recipes so they must be prepared in the Garden Oven instead of a crafting grid. Each override keeps the original ingredients and outputs while switching the recipe type to `gardenkingmod:garden_oven`, which lets JEI and the oven screen show matching inputs.
+
+## Converted Croptopia meals
+
+The following Croptopia foods are now Garden Oven recipes:
+
+- beef_stew
+- beef_stir_fry
+- beef_wellington
+- blt
+- burrito
+- buttered_green_beans
+- carnitas
+- cashew_chicken
+- cheese_pizza
+- cheeseburger
+- cheesy_asparagus
+- chicken_and_dumplings
+- chicken_and_noodles
+- chicken_and_rice
+- chili_relleno
+- chimichanga
+- cornish_pasty
+- crema
+- egg_roll
+- eggplant_parmesan
+- enchilada
+- fajitas
+- fish_and_chips
+- fried_chicken
+- grilled_cheese
+- grilled_eggplant
+- hamburger
+- lemon_chicken
+- nether_wart_stew
+- peanut_butter_and_jam
+- pineapple_pepperoni_pizza
+- pizza
+- potato_soup
+- quesadilla
+- ratatouille
+- refried_beans
+- roasted_asparagus
+- roasted_radishes
+- roasted_squash
+- roasted_turnips
+- shepherds_pie
+- spaghetti_squash
+- steamed_broccoli
+- steamed_green_beans
+- stir_fry
+- stuffed_artichoke
+- stuffed_poblanos
+- supreme_pizza
+- sushi
+- taco
+- tamales
+- toast_sandwich
+- tofuburger
+- tostada
+
+*(Croptopia does not ship recipes for baked_sweet_potato, baked_yam, or tofu_and_noodles, so those remain unchanged.)*
+
+## Adding or editing Garden Oven recipes yourself
+
+1. Place each recipe JSON inside `src/main/resources/data/<namespace>/recipes/`. To override an existing Croptopia recipe use `namespace = croptopia` and match the filename to the item id (for example, `data/croptopia/recipes/enchilada.json`).
+2. Set the JSON `type` field to `"gardenkingmod:garden_oven"` so Fabric loads it with the custom serializer.
+3. Provide an `ingredients` array that lists every required input. When converting shaped crafting recipes you can flatten the pattern so each occupied slot becomes one entry in the array. Use `{ "item": "namespace:item" }` or `{ "tag": "namespace:tag" }` for each ingredient, and include tools that should be consumed via their `recipe_remainder`.
+4. Copy the `result` object from the source recipe so the oven produces the same output and stack size.
+5. Optionally add a `group` string for JEI grouping and include an `experience` number if the oven should grant XP when the output is collected.
+6. Control cook duration with the `cookingtime` field (in ticks). If you omit it the oven falls back to the configurable default from `config/gardenkingmod/garden_oven.json` (200 ticks by default). Use larger values for longer dishes.
+
+Remember to store any new food textures at `assets/<your_namespace>/textures/item/` (for example `assets/croptopia/textures/item/your_food.png`) so Minecraft can render the output properly.

--- a/src/main/resources/data/croptopia/recipes/beef_stew.json
+++ b/src/main/resources/data/croptopia/recipes/beef_stew.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:carrot"
+    },
+    {
+      "item": "minecraft:carrot"
+    },
+    {
+      "item": "minecraft:beef"
+    },
+    {
+      "tag": "c:flour"
+    },
+    {
+      "item": "minecraft:potato"
+    }
+  ],
+  "result": {
+    "item": "croptopia:beef_stew",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/beef_stir_fry.json
+++ b/src/main/resources/data/croptopia/recipes/beef_stir_fry.json
@@ -1,0 +1,29 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:broccoli"
+    },
+    {
+      "item": "minecraft:carrot"
+    },
+    {
+      "item": "minecraft:beef"
+    },
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "c:soy_sauces"
+    },
+    {
+      "tag": "c:garlic"
+    }
+  ],
+  "result": {
+    "item": "croptopia:beef_stir_fry",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/beef_wellington.json
+++ b/src/main/resources/data/croptopia/recipes/beef_wellington.json
@@ -1,0 +1,35 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:flour"
+    },
+    {
+      "tag": "c:onions"
+    },
+    {
+      "tag": "c:mustard"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    },
+    {
+      "item": "croptopia:pepper"
+    },
+    {
+      "item": "minecraft:egg"
+    },
+    {
+      "item": "minecraft:beef"
+    },
+    {
+      "item": "minecraft:brown_mushroom"
+    }
+  ],
+  "result": {
+    "item": "croptopia:beef_wellington",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/blt.json
+++ b/src/main/resources/data/croptopia/recipes/blt.json
@@ -1,0 +1,23 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:bread"
+    },
+    {
+      "item": "croptopia:cooked_bacon"
+    },
+    {
+      "tag": "c:lettuce"
+    },
+    {
+      "tag": "c:tomatoes"
+    }
+  ],
+  "result": {
+    "item": "croptopia:blt",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/burrito.json
+++ b/src/main/resources/data/croptopia/recipes/burrito.json
@@ -1,0 +1,23 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:blackbeans"
+    },
+    {
+      "tag": "c:rice"
+    },
+    {
+      "tag": "c:tomatoes"
+    },
+    {
+      "tag": "c:tortillas"
+    }
+  ],
+  "result": {
+    "item": "croptopia:burrito",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/buttered_green_beans.json
+++ b/src/main/resources/data/croptopia/recipes/buttered_green_beans.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:salts"
+    },
+    {
+      "item": "croptopia:pepper"
+    },
+    {
+      "tag": "c:butters"
+    },
+    {
+      "tag": "c:greenbeans"
+    },
+    {
+      "tag": "c:gingers"
+    }
+  ],
+  "result": {
+    "item": "croptopia:buttered_green_beans",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/carnitas.json
+++ b/src/main/resources/data/croptopia/recipes/carnitas.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:porkchop"
+    },
+    {
+      "tag": "c:tortillas"
+    },
+    {
+      "tag": "c:cabbage"
+    },
+    {
+      "tag": "c:onions"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:carnitas",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/cashew_chicken.json
+++ b/src/main/resources/data/croptopia/recipes/cashew_chicken.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:cashews"
+    },
+    {
+      "item": "minecraft:cooked_chicken"
+    },
+    {
+      "tag": "c:soy_sauces"
+    },
+    {
+      "tag": "c:cabbage"
+    },
+    {
+      "item": "minecraft:carrot"
+    }
+  ],
+  "result": {
+    "item": "croptopia:cashew_chicken",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/cheese_pizza.json
+++ b/src/main/resources/data/croptopia/recipes/cheese_pizza.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:doughs"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "tag": "c:tomatoes"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:cheese_pizza",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/cheeseburger.json
+++ b/src/main/resources/data/croptopia/recipes/cheeseburger.json
@@ -1,0 +1,23 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:bread"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    },
+    {
+      "tag": "croptopia:beef_replacements"
+    }
+  ],
+  "result": {
+    "item": "croptopia:cheeseburger",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/cheesy_asparagus.json
+++ b/src/main/resources/data/croptopia/recipes/cheesy_asparagus.json
@@ -1,0 +1,23 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:asparagus"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "item": "croptopia:pepper"
+    }
+  ],
+  "result": {
+    "item": "croptopia:cheesy_asparagus",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/chicken_and_dumplings.json
+++ b/src/main/resources/data/croptopia/recipes/chicken_and_dumplings.json
@@ -1,0 +1,23 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:doughs"
+    },
+    {
+      "tag": "c:chile_peppers"
+    },
+    {
+      "item": "minecraft:chicken"
+    },
+    {
+      "item": "croptopia:cooking_pot"
+    }
+  ],
+  "result": {
+    "item": "croptopia:chicken_and_dumplings",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/chicken_and_noodles.json
+++ b/src/main/resources/data/croptopia/recipes/chicken_and_noodles.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:noodles"
+    },
+    {
+      "tag": "c:chile_peppers"
+    },
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "croptopia:chicken_replacements"
+    },
+    {
+      "item": "croptopia:cooking_pot"
+    }
+  ],
+  "result": {
+    "item": "croptopia:chicken_and_noodles",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/chicken_and_rice.json
+++ b/src/main/resources/data/croptopia/recipes/chicken_and_rice.json
@@ -1,0 +1,23 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:rice"
+    },
+    {
+      "tag": "c:chile_peppers"
+    },
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "croptopia:chicken_replacements"
+    }
+  ],
+  "result": {
+    "item": "croptopia:chicken_and_rice",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/chili_relleno.json
+++ b/src/main/resources/data/croptopia/recipes/chili_relleno.json
@@ -1,0 +1,29 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:egg"
+    },
+    {
+      "tag": "c:chile_peppers"
+    },
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "c:flour"
+    },
+    {
+      "tag": "c:salts"
+    },
+    {
+      "item": "croptopia:cooking_pot"
+    }
+  ],
+  "result": {
+    "item": "croptopia:chili_relleno",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/chimichanga.json
+++ b/src/main/resources/data/croptopia/recipes/chimichanga.json
@@ -1,0 +1,20 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "croptopia:burrito"
+    },
+    {
+      "tag": "c:flour"
+    },
+    {
+      "item": "croptopia:cooking_pot"
+    }
+  ],
+  "result": {
+    "item": "croptopia:chimichanga",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/cornish_pasty.json
+++ b/src/main/resources/data/croptopia/recipes/cornish_pasty.json
@@ -1,0 +1,32 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:onions"
+    },
+    {
+      "tag": "c:rutabagas"
+    },
+    {
+      "item": "croptopia:pepper"
+    },
+    {
+      "tag": "c:flour"
+    },
+    {
+      "item": "minecraft:beef"
+    },
+    {
+      "item": "minecraft:potato"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:cornish_pasty",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/crema.json
+++ b/src/main/resources/data/croptopia/recipes/crema.json
@@ -1,0 +1,20 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:milks"
+    },
+    {
+      "tag": "c:limes"
+    },
+    {
+      "tag": "c:salts"
+    }
+  ],
+  "result": {
+    "item": "croptopia:crema",
+    "count": 4
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/egg_roll.json
+++ b/src/main/resources/data/croptopia/recipes/egg_roll.json
@@ -1,0 +1,23 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:doughs"
+    },
+    {
+      "tag": "c:lettuce"
+    },
+    {
+      "item": "minecraft:egg"
+    },
+    {
+      "tag": "croptopia:meat_replacements"
+    }
+  ],
+  "result": {
+    "item": "croptopia:egg_roll",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/eggplant_parmesan.json
+++ b/src/main/resources/data/croptopia/recipes/eggplant_parmesan.json
@@ -1,0 +1,32 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:basil"
+    },
+    {
+      "item": "minecraft:egg"
+    },
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "c:eggplants"
+    },
+    {
+      "item": "croptopia:pepper"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "item": "minecraft:bread"
+    }
+  ],
+  "result": {
+    "item": "croptopia:eggplant_parmesan",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/enchilada.json
+++ b/src/main/resources/data/croptopia/recipes/enchilada.json
@@ -1,0 +1,23 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "croptopia:meat_replacements"
+    },
+    {
+      "tag": "c:tomatoes"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "tag": "c:tortillas"
+    }
+  ],
+  "result": {
+    "item": "croptopia:enchilada",
+    "count": 2
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/fajitas.json
+++ b/src/main/resources/data/croptopia/recipes/fajitas.json
@@ -1,0 +1,29 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "croptopia:meat_replacements"
+    },
+    {
+      "tag": "c:bellpeppers"
+    },
+    {
+      "tag": "c:onions"
+    },
+    {
+      "tag": "c:tomatoes"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:fajitas",
+    "count": 2
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/fish_and_chips.json
+++ b/src/main/resources/data/croptopia/recipes/fish_and_chips.json
@@ -1,0 +1,29 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:flour"
+    },
+    {
+      "tag": "c:salts"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    },
+    {
+      "item": "croptopia:pepper"
+    },
+    {
+      "tag": "minecraft:fishes"
+    },
+    {
+      "item": "minecraft:potato"
+    }
+  ],
+  "result": {
+    "item": "croptopia:fish_and_chips",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/fried_chicken.json
+++ b/src/main/resources/data/croptopia/recipes/fried_chicken.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:flour"
+    },
+    {
+      "tag": "c:chile_peppers"
+    },
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "croptopia:chicken_replacements"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:fried_chicken",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/grilled_cheese.json
+++ b/src/main/resources/data/croptopia/recipes/grilled_cheese.json
@@ -1,0 +1,20 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:bread"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:grilled_cheese",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/grilled_eggplant.json
+++ b/src/main/resources/data/croptopia/recipes/grilled_eggplant.json
@@ -1,0 +1,29 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:paprika"
+    },
+    {
+      "tag": "c:salts"
+    },
+    {
+      "item": "croptopia:pepper"
+    },
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "c:eggplants"
+    },
+    {
+      "tag": "c:garlic"
+    }
+  ],
+  "result": {
+    "item": "croptopia:grilled_eggplant",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/hamburger.json
+++ b/src/main/resources/data/croptopia/recipes/hamburger.json
@@ -1,0 +1,20 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:bread"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    },
+    {
+      "item": "minecraft:beef"
+    }
+  ],
+  "result": {
+    "item": "croptopia:hamburger",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/lemon_chicken.json
+++ b/src/main/resources/data/croptopia/recipes/lemon_chicken.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:lemons"
+    },
+    {
+      "tag": "c:chile_peppers"
+    },
+    {
+      "tag": "c:tomatoes"
+    },
+    {
+      "tag": "croptopia:chicken_replacements"
+    },
+    {
+      "item": "croptopia:cooking_pot"
+    }
+  ],
+  "result": {
+    "item": "croptopia:lemon_chicken",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/nether_wart_stew.json
+++ b/src/main/resources/data/croptopia/recipes/nether_wart_stew.json
@@ -1,0 +1,23 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:flour"
+    },
+    {
+      "item": "minecraft:nether_wart"
+    },
+    {
+      "item": "minecraft:crimson_fungus"
+    },
+    {
+      "item": "minecraft:warped_fungus"
+    }
+  ],
+  "result": {
+    "item": "croptopia:nether_wart_stew",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/peanut_butter_and_jam.json
+++ b/src/main/resources/data/croptopia/recipes/peanut_butter_and_jam.json
@@ -1,0 +1,20 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:bread"
+    },
+    {
+      "item": "croptopia:peanut_butter"
+    },
+    {
+      "tag": "c:jams"
+    }
+  ],
+  "result": {
+    "item": "croptopia:peanut_butter_and_jam",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/pineapple_pepperoni_pizza.json
+++ b/src/main/resources/data/croptopia/recipes/pineapple_pepperoni_pizza.json
@@ -1,0 +1,32 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:doughs"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "tag": "c:tomatoes"
+    },
+    {
+      "tag": "c:pineapples"
+    },
+    {
+      "tag": "c:pepperoni"
+    },
+    {
+      "tag": "c:pineapples"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:pineapple_pepperoni_pizza",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/pizza.json
+++ b/src/main/resources/data/croptopia/recipes/pizza.json
@@ -1,0 +1,23 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:doughs"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "tag": "c:tomatoes"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:pizza",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/potato_soup.json
+++ b/src/main/resources/data/croptopia/recipes/potato_soup.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:potato"
+    },
+    {
+      "tag": "c:flour"
+    },
+    {
+      "tag": "c:greenonions"
+    },
+    {
+      "item": "croptopia:bacon"
+    },
+    {
+      "tag": "c:water_bottles"
+    }
+  ],
+  "result": {
+    "item": "croptopia:potato_soup",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/quesadilla.json
+++ b/src/main/resources/data/croptopia/recipes/quesadilla.json
@@ -1,0 +1,29 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:tortillas"
+    },
+    {
+      "tag": "c:tortillas"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "tag": "c:avocados"
+    },
+    {
+      "tag": "croptopia:chicken_replacements"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:quesadilla",
+    "count": 2
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/ratatouille.json
+++ b/src/main/resources/data/croptopia/recipes/ratatouille.json
@@ -1,0 +1,38 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:tomatoes"
+    },
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "c:squashes"
+    },
+    {
+      "tag": "c:zucchini"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    },
+    {
+      "tag": "c:eggplants"
+    },
+    {
+      "tag": "c:onions"
+    },
+    {
+      "tag": "c:bellpeppers"
+    },
+    {
+      "tag": "c:basil"
+    }
+  ],
+  "result": {
+    "item": "croptopia:ratatouille",
+    "count": 2
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/refried_beans.json
+++ b/src/main/resources/data/croptopia/recipes/refried_beans.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:blackbeans"
+    },
+    {
+      "tag": "c:blackbeans"
+    },
+    {
+      "tag": "c:chile_peppers"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:refried_beans",
+    "count": 2
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/roasted_asparagus.json
+++ b/src/main/resources/data/croptopia/recipes/roasted_asparagus.json
@@ -1,0 +1,29 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "c:asparagus"
+    },
+    {
+      "tag": "c:garlic"
+    },
+    {
+      "tag": "c:salts"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    },
+    {
+      "item": "croptopia:pepper"
+    }
+  ],
+  "result": {
+    "item": "croptopia:roasted_asparagus",
+    "count": 2
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/roasted_radishes.json
+++ b/src/main/resources/data/croptopia/recipes/roasted_radishes.json
@@ -1,0 +1,29 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "c:radishes"
+    },
+    {
+      "tag": "c:garlic"
+    },
+    {
+      "tag": "c:salts"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    },
+    {
+      "item": "croptopia:pepper"
+    }
+  ],
+  "result": {
+    "item": "croptopia:roasted_radishes",
+    "count": 2
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/roasted_squash.json
+++ b/src/main/resources/data/croptopia/recipes/roasted_squash.json
@@ -1,0 +1,29 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "c:squashes"
+    },
+    {
+      "tag": "c:garlic"
+    },
+    {
+      "tag": "c:salts"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    },
+    {
+      "item": "croptopia:pepper"
+    }
+  ],
+  "result": {
+    "item": "croptopia:roasted_squash",
+    "count": 2
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/roasted_turnips.json
+++ b/src/main/resources/data/croptopia/recipes/roasted_turnips.json
@@ -1,0 +1,29 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "c:turnips"
+    },
+    {
+      "tag": "c:garlic"
+    },
+    {
+      "tag": "c:salts"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    },
+    {
+      "item": "croptopia:pepper"
+    }
+  ],
+  "result": {
+    "item": "croptopia:roasted_turnips",
+    "count": 2
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/shepherds_pie.json
+++ b/src/main/resources/data/croptopia/recipes/shepherds_pie.json
@@ -1,0 +1,38 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:salts"
+    },
+    {
+      "tag": "croptopia:beef_mutton"
+    },
+    {
+      "item": "croptopia:pepper"
+    },
+    {
+      "item": "minecraft:potato"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    },
+    {
+      "tag": "c:tomatoes"
+    },
+    {
+      "tag": "c:corn"
+    },
+    {
+      "tag": "c:garlic"
+    },
+    {
+      "tag": "c:onions"
+    }
+  ],
+  "result": {
+    "item": "croptopia:shepherds_pie",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/spaghetti_squash.json
+++ b/src/main/resources/data/croptopia/recipes/spaghetti_squash.json
@@ -1,0 +1,23 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:squashes"
+    },
+    {
+      "tag": "c:chile_peppers"
+    },
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:spaghetti_squash",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/steamed_broccoli.json
+++ b/src/main/resources/data/croptopia/recipes/steamed_broccoli.json
@@ -1,0 +1,20 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:broccoli"
+    },
+    {
+      "tag": "c:water_bottles"
+    },
+    {
+      "tag": "c:broccoli"
+    }
+  ],
+  "result": {
+    "item": "croptopia:steamed_broccoli",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/steamed_green_beans.json
+++ b/src/main/resources/data/croptopia/recipes/steamed_green_beans.json
@@ -1,0 +1,20 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:greenbeans"
+    },
+    {
+      "tag": "c:water_bottles"
+    },
+    {
+      "tag": "c:greenbeans"
+    }
+  ],
+  "result": {
+    "item": "croptopia:steamed_green_beans",
+    "count": 2
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/stir_fry.json
+++ b/src/main/resources/data/croptopia/recipes/stir_fry.json
@@ -1,0 +1,29 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:garlic"
+    },
+    {
+      "tag": "c:broccoli"
+    },
+    {
+      "tag": "c:greenonions"
+    },
+    {
+      "tag": "c:bellpeppers"
+    },
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "item": "minecraft:carrot"
+    }
+  ],
+  "result": {
+    "item": "croptopia:stir_fry",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/stuffed_artichoke.json
+++ b/src/main/resources/data/croptopia/recipes/stuffed_artichoke.json
@@ -1,0 +1,35 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:bread"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "tag": "c:olive_oils"
+    },
+    {
+      "tag": "c:artichokes"
+    },
+    {
+      "item": "croptopia:pepper"
+    },
+    {
+      "tag": "c:lemons"
+    },
+    {
+      "tag": "c:salts"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:stuffed_artichoke",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/stuffed_poblanos.json
+++ b/src/main/resources/data/croptopia/recipes/stuffed_poblanos.json
@@ -1,0 +1,32 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "croptopia:beef_replacements"
+    },
+    {
+      "tag": "c:chile_peppers"
+    },
+    {
+      "tag": "c:blackbeans"
+    },
+    {
+      "tag": "c:corn"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "tag": "c:rice"
+    },
+    {
+      "item": "croptopia:cooking_pot"
+    }
+  ],
+  "result": {
+    "item": "croptopia:stuffed_poblanos",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/supreme_pizza.json
+++ b/src/main/resources/data/croptopia/recipes/supreme_pizza.json
@@ -1,0 +1,32 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:doughs"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "tag": "c:tomatoes"
+    },
+    {
+      "tag": "c:bellpeppers"
+    },
+    {
+      "tag": "c:olives"
+    },
+    {
+      "tag": "croptopia:meat_replacements"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    }
+  ],
+  "result": {
+    "item": "croptopia:supreme_pizza",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/sushi.json
+++ b/src/main/resources/data/croptopia/recipes/sushi.json
@@ -1,0 +1,20 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:seagrass"
+    },
+    {
+      "tag": "croptopia:fishes"
+    },
+    {
+      "tag": "c:rice"
+    }
+  ],
+  "result": {
+    "item": "croptopia:sushi",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/taco.json
+++ b/src/main/resources/data/croptopia/recipes/taco.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:tortillas"
+    },
+    {
+      "tag": "c:cheeses"
+    },
+    {
+      "tag": "c:lettuce"
+    },
+    {
+      "item": "croptopia:salsa"
+    },
+    {
+      "tag": "croptopia:meat_replacements"
+    }
+  ],
+  "result": {
+    "item": "croptopia:taco",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/tamales.json
+++ b/src/main/resources/data/croptopia/recipes/tamales.json
@@ -1,0 +1,32 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:chicken"
+    },
+    {
+      "tag": "c:onions"
+    },
+    {
+      "item": "croptopia:corn_husk"
+    },
+    {
+      "tag": "c:flour"
+    },
+    {
+      "tag": "c:salts"
+    },
+    {
+      "tag": "c:chile_peppers"
+    },
+    {
+      "item": "croptopia:cooking_pot"
+    }
+  ],
+  "result": {
+    "item": "croptopia:tamales",
+    "count": 2
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/toast_sandwich.json
+++ b/src/main/resources/data/croptopia/recipes/toast_sandwich.json
@@ -1,0 +1,20 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:bread"
+    },
+    {
+      "item": "croptopia:buttered_toast"
+    },
+    {
+      "item": "minecraft:bread"
+    }
+  ],
+  "result": {
+    "item": "croptopia:toast_sandwich",
+    "count": 2
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/tofuburger.json
+++ b/src/main/resources/data/croptopia/recipes/tofuburger.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "item": "minecraft:bread"
+    },
+    {
+      "tag": "c:lettuce"
+    },
+    {
+      "item": "croptopia:frying_pan"
+    },
+    {
+      "tag": "c:tofu"
+    },
+    {
+      "tag": "c:onions"
+    }
+  ],
+  "result": {
+    "item": "croptopia:tofuburger",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}

--- a/src/main/resources/data/croptopia/recipes/tostada.json
+++ b/src/main/resources/data/croptopia/recipes/tostada.json
@@ -1,0 +1,26 @@
+{
+  "type": "gardenkingmod:garden_oven",
+  "ingredients": [
+    {
+      "tag": "c:blackbeans"
+    },
+    {
+      "tag": "c:blackbeans"
+    },
+    {
+      "tag": "c:tomatoes"
+    },
+    {
+      "tag": "c:lettuce"
+    },
+    {
+      "tag": "c:tortillas"
+    }
+  ],
+  "result": {
+    "item": "croptopia:tostada",
+    "count": 1
+  },
+  "group": "garden_oven",
+  "cookingtime": 200
+}


### PR DESCRIPTION
## Summary
- override 54 Croptopia meal recipes so they use the custom garden_oven serializer
- document how to add additional oven recipes and control cook times

## Testing
- ./gradlew build *(fails: unable to download curse.maven:jei-238222:6600309 due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5aa522a88321bd774e93897a93b0