### PR TITLE
Use oven GUI texture for progress animations

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenOvenScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenOvenScreen.java
@@ -30,9 +30,15 @@ public class GardenOvenScreen extends HandledScreen<GardenOvenScreenHandler> {
                 int y = this.y;
                 context.drawTexture(TEXTURE, x, y, 0, 0, this.backgroundWidth, this.backgroundHeight);
 
-                int progress = this.handler.getCookProgress();
-                if (progress > 0) {
-                        context.drawTexture(TEXTURE, x + 90, y + 35, 176, 0, progress + 1, 17);
+                int arrowProgress = this.handler.getCookProgressScaled(24);
+                if (arrowProgress > 0) {
+                        context.drawTexture(TEXTURE, x + 89, y + 35, 176, 14, arrowProgress, 17);
+                }
+
+                int fireProgress = this.handler.getCookProgressScaled(14);
+                if (fireProgress > 0) {
+                        int offset = 14 - fireProgress;
+                        context.drawTexture(TEXTURE, x + 129, y + 59 + offset, 176, offset, 14, fireProgress);
                 }
         }
 

--- a/src/main/java/net/jeremy/gardenkingmod/screen/GardenOvenScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/GardenOvenScreenHandler.java
@@ -142,14 +142,18 @@ public class GardenOvenScreenHandler extends ScreenHandler {
                 this.inventory.onClose(player);
         }
 
-        public int getCookProgress() {
+        public int getCookProgressScaled(int size) {
                 int cookTime = this.propertyDelegate.get(0);
                 int cookTimeTotal = this.propertyDelegate.get(1);
                 if (cookTimeTotal <= 0 || cookTime <= 0) {
                         return 0;
                 }
 
-                return cookTime * 24 / cookTimeTotal;
+                int scaled = cookTime * size / cookTimeTotal;
+                if (scaled <= 0) {
+                        return 1;
+                }
+                return Math.min(scaled, size);
         }
 
         public boolean isCooking() {


### PR DESCRIPTION
## Summary
- render the oven screen background exclusively from `oven_gui.png`
- animate the arrow and fire progress indicators using the atlas regions inside the GUI texture

## Testing
- `./gradlew build` *(fails: Curse Maven dependency `jei-238222` returns HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fe65d6ed208321ae8538666a947689