### PR TITLE
Adjust garden oven item display transforms

### DIFF
--- a/src/main/resources/assets/gardenkingmod/models/item/garden_oven.json
+++ b/src/main/resources/assets/gardenkingmod/models/item/garden_oven.json
@@ -1,3 +1,40 @@
 {
-  "parent": "gardenkingmod:block/garden_oven"
+  "parent": "gardenkingmod:block/garden_oven",
+  "display": {
+    "gui": {
+      "rotation": [30, 225, 0],
+      "translation": [0, 0, 0],
+      "scale": [0.625, 0.625, 0.625]
+    },
+    "ground": {
+      "rotation": [0, 0, 0],
+      "translation": [0, 3, 0],
+      "scale": [0.25, 0.25, 0.25]
+    },
+    "firstperson_righthand": {
+      "rotation": [0, 45, 0],
+      "translation": [0, 0, 0],
+      "scale": [0.4, 0.4, 0.4]
+    },
+    "firstperson_lefthand": {
+      "rotation": [0, 225, 0],
+      "translation": [0, 0, 0],
+      "scale": [0.4, 0.4, 0.4]
+    },
+    "thirdperson_righthand": {
+      "rotation": [75, 45, 0],
+      "translation": [0, 2.5, 0],
+      "scale": [0.375, 0.375, 0.375]
+    },
+    "thirdperson_lefthand": {
+      "rotation": [75, 315, 0],
+      "translation": [0, 2.5, 0],
+      "scale": [0.375, 0.375, 0.375]
+    },
+    "fixed": {
+      "rotation": [0, 0, 0],
+      "translation": [0, 0, 0],
+      "scale": [0.5, 0.5, 0.5]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add display transforms to the garden oven item model so its GUI, ground, and in-hand poses can be tuned like other block items

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe702360008321b9fbb505cbcfda2d