### PR TITLE
Fix garden oven reset after breaking

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/GardenOvenBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/GardenOvenBlockEntity.java
@@ -259,7 +259,9 @@ public class GardenOvenBlockEntity extends BlockEntity implements NamedScreenHan
 
         public void dropContents(World world, BlockPos pos) {
                 ItemScatterer.spawn(world, pos, this.inventory);
-                this.inventory.clear();
+                resetInventoryState();
+                updateLitState(false);
+                this.markDirty();
         }
 
         public void onOutputTaken(ServerPlayerEntity player) {
@@ -396,7 +398,15 @@ public class GardenOvenBlockEntity extends BlockEntity implements NamedScreenHan
 
         @Override
         public void clear() {
-                this.inventory.clear();
+                resetInventoryState();
+                this.markDirty();
+        }
+
+        private void resetInventoryState() {
+                this.inventory = DefaultedList.ofSize(INVENTORY_SIZE, ItemStack.EMPTY);
+                this.cookTime = 0;
+                this.cookTimeTotal = GardenOvenBalanceConfig.get().cookTime();
+                this.storedExperience = 0.0F;
         }
 
         @Override


### PR DESCRIPTION
## Summary
- reset the garden oven inventory, timers, and experience when the block is broken or cleared so it can restart cooking
- ensure the oven turns off and re-synchronizes after being reset

## Testing
- `./gradlew check` *(fails: cannot download curse.maven:jei-238222:6600309 because the host returns HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fe9cc2743c83219c5c6fcad37b6db2