### PR TITLE
Update Croptopia dependency coordinates and mixin targets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,9 +61,9 @@ dependencies {
         // Fabric API. This is technically optional, but you probably want it anyway.
         modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-        modImplementation "curse.maven:croptopia-415438:4997461"
+        modImplementation "com.epherical.croptopia:croptopia-fabric-1.20.1:${project.croptopia_version}"
 
-        modImplementation "curse.maven:epherolib-885449:4949797"
+        modImplementation "com.epherical.croptopia:epherolib:${project.epherolib_version}"
 
         modImplementation "curse.maven:jei-238222:6600309"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@ archives_base_name=gardenkingmod
 
 # Dependencies
 fabric_version=0.92.6+1.20.1
+croptopia_version=3.0.3
+epherolib_version=1.2.0

--- a/src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java
@@ -17,7 +17,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Pseudo
 @Mixin(targets = { "com.epherical.croptopia.blocks.CropBlock",
-                "com.epherical.croptopia.blocks.CroptopiaCropBlock" }, remap = false)
+                "com.epherical.croptopia.blocks.CroptopiaCropBlock",
+                "com.epherical.croptopia.block.CropBlock",
+                "com.epherical.croptopia.block.CroptopiaCropBlock" }, remap = false)
 public abstract class CroptopiaCropBlockMixin {
 
         @Inject(method = "onUse(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;",


### PR DESCRIPTION
### Motivation

- Fix runtime mixin/ClassNotFound problems caused by Croptopia's package/layout differences so Croptopia crop classes are found at runtime.
- Replace fragile `curse.maven` coordinates with the official Maven coordinates for Croptopia and EpheroLib so dependency resolution is more reliable.
- Centralize Croptopia and EpheroLib versions for easier upgrades by adding properties to `gradle.properties`.

### Description

- Added `croptopia_version` and `epherolib_version` properties to `gradle.properties` to centralize versioning.
- Switched the Croptopia/EpheroLib dependency lines in `build.gradle` to use `com.epherical.croptopia:croptopia-fabric-1.20.1:${project.croptopia_version}` and `com.epherical.croptopia:epherolib:${project.epherolib_version}` respectively.
- Broadened mixin targets in `src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java` to include alternate package names (`com.epherical.croptopia.block.*`) so the mixin applies across different Croptopia builds.

### Testing

- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69765e95343c83218d6efdffe6c56697)