### PR TITLE
Exclude fabric convention tags module to avoid invalid c: tag placeholders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,11 +59,13 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
         // Fabric API. This is technically optional, but you probably want it anyway.
-        modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+        modImplementation("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}") {
+                exclude module: "fabric-convention-tags-v1"
+        }
 
-        modImplementation "curse.maven:croptopia-415438:4997461"
+        modImplementation "com.epherical.croptopia:croptopia-fabric-1.20.1:${project.croptopia_version}"
 
-        modImplementation "curse.maven:epherolib-885449:4949797"
+        modImplementation "com.epherical.croptopia:epherolib:${project.epherolib_version}"
 
         modImplementation "curse.maven:jei-238222:6600309"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@ archives_base_name=gardenkingmod
 
 # Dependencies
 fabric_version=0.92.6+1.20.1
+croptopia_version=3.0.3
+epherolib_version=1.2.0

--- a/src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java
@@ -17,7 +17,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Pseudo
 @Mixin(targets = { "com.epherical.croptopia.blocks.CropBlock",
-                "com.epherical.croptopia.blocks.CroptopiaCropBlock" }, remap = false)
+                "com.epherical.croptopia.blocks.CroptopiaCropBlock",
+                "com.epherical.croptopia.block.CropBlock",
+                "com.epherical.croptopia.block.CroptopiaCropBlock" }, remap = false)
 public abstract class CroptopiaCropBlockMixin {
 
         @Inject(method = "onUse(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;",


### PR DESCRIPTION
### Motivation
- Prevent runtime/data issues caused by Fabric API's placeholder tag module `fabric-convention-tags-v1` which can load invalid `c:` tag JSON and break tag resolution.
- Ensure Croptopia and EpheroLib are resolved via official Maven coordinates and make mixin targets resilient to Croptopia package/layout variations.

### Description
- Exclude `fabric-convention-tags-v1` from the Fabric API dependency by changing the `modImplementation` entry in `build.gradle` to `modImplementation("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}") { exclude module: "fabric-convention-tags-v1" }`.
- Switch Croptopia/EpheroLib dependencies to official Maven coordinates (`com.epherical.croptopia:croptopia-fabric-1.20.1:${project.croptopia_version}` and `com.epherical.croptopia:epherolib:${project.epherolib_version}`) and add `croptopia_version` and `epherolib_version` properties to `gradle.properties`.
- Broaden mixin targets in `src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java` to include alternate package names (`com.epherical.croptopia.block.*`) so the mixin applies across different Croptopia builds.
- Adjust dependency declaration formatting to allow the `exclude` closure to be applied.

### Testing
- Ran `./gradlew --no-daemon -q dependencies`, which failed with `Unsupported class file major version 69` and aborted dependency resolution.
- Ran `./gradlew --no-daemon test`, which failed with the same `Unsupported class file major version 69` error and could not complete the test run.
- The failures indicate a Gradle/Groovy vs JDK compatibility issue (installed JDK reports `openjdk version "25.0.1"`), so automated Gradle tasks could not be executed to completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69765e95343c83218d6efdffe6c56697)