### PR TITLE
Add Modrinth fallback for Croptopia dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
         // See https://docs.gradle.org/current/userguide/declaring_repositories.html
         // for more information about repositories.
         maven { url "https://cursemaven.com" }
+        maven { url "https://api.modrinth.com/maven" }
         maven { url "https://maven.croptopia.com" }
 }
 
@@ -63,9 +64,14 @@ dependencies {
                 exclude module: "fabric-convention-tags-v1"
         }
 
-        modImplementation "com.epherical.croptopia:croptopia-fabric-1.20.1:${project.croptopia_version}"
-
-        modImplementation "com.epherical.croptopia:epherolib:${project.epherolib_version}"
+        def useCroptopiaMaven = project.findProperty("useCroptopiaMaven")?.toBoolean() ?: false
+        if (useCroptopiaMaven) {
+                modImplementation "com.epherical.croptopia:croptopia-fabric-1.20.1:${project.croptopia_version}"
+                modImplementation "com.epherical.croptopia:epherolib:${project.epherolib_version}"
+        } else {
+                modImplementation "maven.modrinth:croptopia:${project.croptopia_version}"
+                modImplementation "maven.modrinth:epherolib:${project.epherolib_version}"
+        }
 
         modImplementation "curse.maven:jei-238222:6600309"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,6 @@ archives_base_name=gardenkingmod
 fabric_version=0.92.6+1.20.1
 croptopia_version=3.0.3
 epherolib_version=1.2.0
+
+# Set to true to use the Croptopia Maven (https://maven.croptopia.com) instead of Modrinth Maven.
+# useCroptopiaMaven=false


### PR DESCRIPTION
### Motivation
- Gradle fails to resolve Croptopia artifacts when `maven.croptopia.com` is unreachable, preventing the Minecraft client from launching in IntelliJ.

### Description
- Add the Modrinth Maven repository `https://api.modrinth.com/maven` to `repositories` in `build.gradle` as a fallback.
- Make Croptopia and Epherolib dependencies conditional via a new Gradle property `useCroptopiaMaven` and switch between `com.epherical` coordinates and `maven.modrinth` coordinates based on that flag.
- Document the `useCroptopiaMaven` property as a commented entry in `gradle.properties` so users can opt back into the Croptopia Maven if desired.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976651050c48321af0adaaa08cb5cca)