### PR TITLE
Add player glow on join and respawn

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/network/ModServerNetworking.java
+++ b/src/main/java/net/jeremy/gardenkingmod/network/ModServerNetworking.java
@@ -2,6 +2,7 @@ package net.jeremy.gardenkingmod.network;
 
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerPlayerEvents;
 import net.jeremy.gardenkingmod.screen.BankScreenHandler;
 import net.jeremy.gardenkingmod.skill.SkillProgressHolder;
 import net.jeremy.gardenkingmod.skill.SkillProgressManager;
@@ -69,7 +70,19 @@ public final class ModServerNetworking {
 
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server1) -> {
             SkillProgressNetworking.sync(handler.player);
+            applyPlayerGlow(handler.player);
         });
+
+        ServerPlayerEvents.AFTER_RESPAWN.register((oldPlayer, newPlayer, alive) -> {
+            applyPlayerGlow(newPlayer);
+        });
+    }
+
+    private static void applyPlayerGlow(ServerPlayerEntity player) {
+        if (player == null) {
+            return;
+        }
+        player.setGlowing(true);
     }
 
     private static boolean applySkillUpgrade(SkillProgressHolder skillHolder, Identifier skillId, int pointsToSpend) {


### PR DESCRIPTION
### Motivation
- Provide a simple vanilla-based visibility aid so players are set to glowing when they join or respawn to make tracking through walls easier.

### Description
- In `src/main/java/net/jeremy/gardenkingmod/network/ModServerNetworking.java` register `ServerPlayerEvents.AFTER_RESPAWN` and call `applyPlayerGlow` on join and after-respawn, and add `applyPlayerGlow(ServerPlayerEntity)` which calls `player.setGlowing(true)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69768b9dc77c83219733801c95562be0)