### PR TITLE
Fix player glow hook to avoid missing ServerPlayerEvents

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/ServerPlayerEntityMixin.java
@@ -24,5 +24,7 @@ public abstract class ServerPlayerEntityMixin {
                 newSkillHolder.gardenkingmod$setUnspentSkillPoints(oldSkillHolder.gardenkingmod$getUnspentSkillPoints());
                 newSkillHolder.gardenkingmod$setChefMasteryLevel(oldSkillHolder.gardenkingmod$getChefMasteryLevel());
                 newSkillHolder.gardenkingmod$setEnchanterLevel(oldSkillHolder.gardenkingmod$getEnchanterLevel());
+
+                ((ServerPlayerEntity) (Object) this).setGlowing(true);
         }
 }

--- a/src/main/java/net/jeremy/gardenkingmod/network/ModServerNetworking.java
+++ b/src/main/java/net/jeremy/gardenkingmod/network/ModServerNetworking.java
@@ -69,7 +69,15 @@ public final class ModServerNetworking {
 
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server1) -> {
             SkillProgressNetworking.sync(handler.player);
+            applyPlayerGlow(handler.player);
         });
+    }
+
+    private static void applyPlayerGlow(ServerPlayerEntity player) {
+        if (player == null) {
+            return;
+        }
+        player.setGlowing(true);
     }
 
     private static boolean applySkillUpgrade(SkillProgressHolder skillHolder, Identifier skillId, int pointsToSpend) {


### PR DESCRIPTION
### Motivation
- Ensure players are set glowing on join and after respawn while avoiding a compile error caused by using a Fabric API class that isn't present (`ServerPlayerEvents`).

### Description
- Remove usage of the unavailable `ServerPlayerEvents.AFTER_RESPAWN` hook and its import from `ModServerNetworking` and keep the existing join-time handling via `ServerPlayConnectionEvents.JOIN`.
- Add a small helper `applyPlayerGlow(ServerPlayerEntity)` that safely sets `player.setGlowing(true)` and call it from the join handler.
- Apply the glowing flag on respawn by setting `((ServerPlayerEntity)(Object)this).setGlowing(true)` in the `copyFrom` mixin injection in `ServerPlayerEntityMixin` so the flag persists across player respawn.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69768b9dc77c83219733801c95562be0)