### PR TITLE
Fix ServerPlayerEvents import and consolidate player glow handling

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/network/ModServerNetworking.java
+++ b/src/main/java/net/jeremy/gardenkingmod/network/ModServerNetworking.java
@@ -2,10 +2,11 @@ package net.jeremy.gardenkingmod.network;
 
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerPlayerEvents;
+import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 import net.jeremy.gardenkingmod.screen.BankScreenHandler;
 import net.jeremy.gardenkingmod.skill.SkillProgressHolder;
 import net.jeremy.gardenkingmod.skill.SkillProgressManager;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 
@@ -65,19 +66,12 @@ public final class ModServerNetworking {
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server1) -> {
             SkillProgressNetworking.sync(handler.player);
             // Glow on join; respawn glow is handled in ServerPlayerEntityMixin.copyFrom.
-            handler.player.setGlowing(true);
+            applyPlayerGlow(handler.player);
         });
 
         ServerPlayerEvents.AFTER_RESPAWN.register((oldPlayer, newPlayer, alive) -> {
             applyPlayerGlow(newPlayer);
         });
-    }
-
-    private static void applyPlayerGlow(ServerPlayerEntity player) {
-        if (player == null) {
-            return;
-        }
-        player.setGlowing(true);
     }
 
     private static void applyPlayerGlow(ServerPlayerEntity player) {


### PR DESCRIPTION
### Motivation
- Resolve runtime/compile errors caused by importing the wrong `ServerPlayerEvents` package and duplicated glow logic.
- Ensure join and respawn glow behavior is handled consistently through a single helper to avoid duplicate code.
- Make the networking class reference the correct server player type for applying glow state.

### Description
- Updated `src/main/java/net/jeremy/gardenkingmod/network/ModServerNetworking.java` to import the correct Fabric events package via `net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents`.
- Added `import net.minecraft.server.network.ServerPlayerEntity;` and replaced the direct `handler.player.setGlowing(true)` call with the shared helper `applyPlayerGlow(handler.player)` on join.
- Removed the duplicate `applyPlayerGlow` method and consolidated join/respawn glow handling to the single helper implementation.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69769f8179148321813ede1127bccd98)