### PR TITLE
Include Fabric convention tags module to fix invalid tag parsing and world-creation crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,9 +68,7 @@ dependencies {
 
 
 // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}") {
-        exclude module: "fabric-convention-tags-v1"
-    }
+    modImplementation("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}")
 
 
 // Croptopia (1.20.1 Fabric 3.0.3, via CurseMaven)


### PR DESCRIPTION
### Motivation
- Fix a crash when creating a new world caused by invalid tag placeholders like `${dependent}` and non-[a-z0-9_.-] namespaces emitted when the Fabric convention tags module was excluded.

### Description
- Re-enable the Fabric API convention tags module by removing the `exclude module: "fabric-convention-tags-v1"` block in `build.gradle`, ensuring convention tag data is available at runtime.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d7a1558f08321a2d1cf7f2682d55e)