### PR TITLE
Guard optional generated resources in build configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,10 +10,14 @@ base {
         archivesName = project.archives_base_name
 }
 
+def includeGeneratedResources = project.findProperty("includeGeneratedResources")?.toString()?.toBoolean() ?: false
+
 sourceSets {
         main {
                 resources {
-                        srcDir "src/main/generated"
+                        if (includeGeneratedResources) {
+                                srcDir "src/main/generated"
+                        }
                 }
         }
 }


### PR DESCRIPTION
### Motivation
- Prevent generated datapack JSON with unresolved placeholders (e.g. `${dependent}`) from being loaded by default and causing `InvalidIdentifierException` crashes when creating a world by avoiding automatic inclusion of `src/main/generated`.

### Description
- Add a Gradle property `includeGeneratedResources` (defaults to `false`) and conditionally include `src/main/generated` into `sourceSets.main.resources` only when opt-in via `-PincludeGeneratedResources=true`.

### Testing
- No automated tests were run for this build-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d817da1048321a816309394415b3b)