### PR TITLE
Escape dollar sign in gear shop language entry

### DIFF
--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -115,7 +115,7 @@
   "screen.gardenkingmod.gear_shop.offers": "OFFERS",
   "screen.gardenkingmod.gear_shop.buy_button": "BUY",
   "screen.gardenkingmod.gear_shop.cost_label": "COST:",
-  "screen.gardenkingmod.gear_shop.price": "$%s",
+  "screen.gardenkingmod.gear_shop.price": "\\$%s",
   "screen.gardenkingmod.gear_shop.cost_count": "%s required",
   "tooltip.gardenkingmod.crop_tier": "Tier: %s",
   "tooltip.gardenkingmod.built_in_fortune": "Built-in %s %s",


### PR DESCRIPTION
### Motivation
- Gradle's resource templating treated the `$` in the gear shop price localization as a Groovy template token, causing `:processResources` to fail when running the client.

### Description
- Update the localization entry in `src/main/resources/assets/gardenkingmod/lang/en_us.json` from `"$%s"` to `"\\$%s"` to escape the dollar sign so Gradle's `expand` step won't parse it as a template expression.

### Testing
- No automated tests were executed for this change; the edit is a small resource-only fix intended to resolve the template parsing error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d8c6f85708321ae0f91bb1f0b1260)