### PR TITLE
Avoid Gradle template expansion on JSON resources and escape gear price $

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,10 +90,6 @@ processResources {
 	filesMatching("fabric.mod.json") {
 		expand "version": inputs.properties.version
 	}
-
-	filesMatching("**/*.json") {
-		expand "dependent": inputs.properties.dependent
-	}
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -115,7 +115,7 @@
   "screen.gardenkingmod.gear_shop.offers": "OFFERS",
   "screen.gardenkingmod.gear_shop.buy_button": "BUY",
   "screen.gardenkingmod.gear_shop.cost_label": "COST:",
-  "screen.gardenkingmod.gear_shop.price": "$%s",
+  "screen.gardenkingmod.gear_shop.price": "\\$%s",
   "screen.gardenkingmod.gear_shop.cost_count": "%s required",
   "tooltip.gardenkingmod.crop_tier": "Tier: %s",
   "tooltip.gardenkingmod.built_in_fortune": "Built-in %s %s",


### PR DESCRIPTION
### Motivation
- Gradle's template expansion was being applied to all JSON resources which caused the Groovy template engine to choke on localization entries containing `%` formatting tokens and previously escaping the dollar sign alone did not prevent the `:processResources` failure. 

### Description
- Remove the blanket `filesMatching("**/*.json") { expand "dependent": ... }` expansion from `processResources` in `build.gradle` to stop feeding JSON files into the Groovy template engine. 
- Keep the localization fix by escaping the dollar sign in `src/main/resources/assets/gardenkingmod/lang/en_us.json` changing `"$%s"` to `"\\$%s"` for the gear shop price entry. 

### Testing
- No automated tests were executed for this change; the edits are a small build configuration and resource fix intended to prevent `:processResources` from parsing localization `%` tokens and to ensure the dollar sign is preserved in-game.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d8c6f85708321ae0f91bb1f0b1260)