### PR TITLE
Expand `${dependent}` placeholder in data JSON resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,8 +87,13 @@ processResources {
 	inputs.property "version", project.version
 	inputs.property "dependent", "croptopia"
 
-	filesMatching("fabric.mod.json") {
-		expand "version": inputs.properties.version
+	def expandProperties = [
+		version: inputs.properties.version,
+		dependent: inputs.properties.dependent
+	]
+
+	filesMatching(["fabric.mod.json", "data/**/*.json"]) {
+		expand expandProperties
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Data JSON files contained unresolved `${dependent}` placeholders that caused a runtime `InvalidIdentifierException` (for example ` ${dependent}:rutabagas`) during resource loading, so the placeholder needs to be substituted at build time.

### Description
- Update `processResources` in `build.gradle` to expand both `version` and `dependent` by adding an `expandProperties` map and applying `expand` to `fabric.mod.json` and all `data/**/*.json` files.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d90c3797083218d52744d675db41c)