### PR TITLE
Persistent rotating Garden Market offers with configurable selection & refresh

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
@@ -18,6 +18,7 @@ import net.jeremy.gardenkingmod.crop.CropTier;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.item.WalletItem;
 import net.jeremy.gardenkingmod.screen.MarketScreenHandler;
+import net.jeremy.gardenkingmod.shop.GardenMarketOfferState;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
@@ -34,6 +35,7 @@ import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.Text;
@@ -81,6 +83,21 @@ public class MarketBlockEntity extends BlockEntity implements ExtendedScreenHand
         @Override
         public void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf) {
                 buf.writeBlockPos(getPos());
+                ServerWorld serverWorld = player.getServerWorld();
+                if (serverWorld != null) {
+                        GardenMarketOfferState state = GardenMarketOfferState.get(serverWorld);
+                        var offerIndices = state.getActiveOfferIndices(serverWorld);
+                        buf.writeVarInt(offerIndices.size());
+                        for (Integer index : offerIndices) {
+                                if (index != null) {
+                                        buf.writeVarInt(index);
+                                }
+                        }
+                        buf.writeLong(state.getNextRefreshTime(serverWorld));
+                } else {
+                        buf.writeVarInt(0);
+                        buf.writeLong(0L);
+                }
         }
 
         @Override

--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -12,7 +12,6 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import net.jeremy.gardenkingmod.GardenKingMod;
 import net.jeremy.gardenkingmod.client.gui.toast.SaleResultToast;
 import net.jeremy.gardenkingmod.shop.GearShopOffer;
-import net.jeremy.gardenkingmod.shop.GardenMarketOfferManager;
 import net.jeremy.gardenkingmod.shop.GearShopStackHelper;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
@@ -1154,7 +1153,10 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         }
 
         private List<GearShopOffer> getBuyOffers() {
-                return GardenMarketOfferManager.getInstance().getOffers();
+                if (handler == null) {
+                        return List.of();
+                }
+                return handler.getBuyOffers();
         }
 
         private void playClickSound() {

--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferState.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferState.java
@@ -1,0 +1,111 @@
+package net.jeremy.gardenkingmod.shop;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtInt;
+import net.minecraft.nbt.NbtList;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.PersistentState;
+
+public final class GardenMarketOfferState extends PersistentState {
+    private static final String DATA_NAME = GardenKingMod.MOD_ID + "_garden_market_offers";
+    private static final String TAG_OFFERS = "OfferIndices";
+    private static final String TAG_NEXT_REFRESH = "NextRefresh";
+
+    private final List<Integer> offerIndices = new ArrayList<>();
+    private long nextRefreshTime;
+
+    public static GardenMarketOfferState get(ServerWorld world) {
+        return world.getPersistentStateManager().getOrCreate(GardenMarketOfferState::fromNbt,
+                GardenMarketOfferState::new, DATA_NAME);
+    }
+
+    public static GardenMarketOfferState fromNbt(NbtCompound nbt) {
+        GardenMarketOfferState state = new GardenMarketOfferState();
+        state.readNbt(nbt);
+        return state;
+    }
+
+    public List<Integer> getActiveOfferIndices(ServerWorld world) {
+        ensureOffers(world);
+        return List.copyOf(offerIndices);
+    }
+
+    public List<GearShopOffer> getActiveOffers(ServerWorld world) {
+        ensureOffers(world);
+        return GardenMarketOfferManager.getInstance().getOffersByIndices(offerIndices);
+    }
+
+    public long getNextRefreshTime(ServerWorld world) {
+        ensureOffers(world);
+        return nextRefreshTime;
+    }
+
+    @Override
+    public NbtCompound writeNbt(NbtCompound nbt) {
+        NbtList list = new NbtList();
+        for (Integer index : offerIndices) {
+            if (index != null) {
+                list.add(NbtInt.of(index));
+            }
+        }
+        nbt.put(TAG_OFFERS, list);
+        nbt.putLong(TAG_NEXT_REFRESH, nextRefreshTime);
+        return nbt;
+    }
+
+    private void readNbt(NbtCompound nbt) {
+        offerIndices.clear();
+        NbtList list = nbt.getList(TAG_OFFERS, NbtElement.INT_TYPE);
+        for (int i = 0; i < list.size(); i++) {
+            offerIndices.add(list.getInt(i));
+        }
+        nextRefreshTime = nbt.getLong(TAG_NEXT_REFRESH);
+    }
+
+    private void ensureOffers(ServerWorld world) {
+        if (needsRefresh(world)) {
+            refreshOffers(world);
+        }
+    }
+
+    private boolean needsRefresh(ServerWorld world) {
+        return offerIndices.isEmpty() || nextRefreshTime <= 0L || world.getTime() >= nextRefreshTime;
+    }
+
+    private void refreshOffers(ServerWorld world) {
+        GardenMarketOfferManager manager = GardenMarketOfferManager.getInstance();
+        List<GearShopOffer> master = manager.getMasterOffers();
+        offerIndices.clear();
+
+        if (!master.isEmpty()) {
+            int available = master.size();
+            int minOffers = MathHelper.clamp(manager.getMinOffers(), 0, available);
+            int maxOffers = MathHelper.clamp(manager.getMaxOffers(), minOffers, available);
+            int count = minOffers;
+            if (maxOffers > minOffers) {
+                Random javaRandom = new Random(world.getRandom().nextLong());
+                count = minOffers + javaRandom.nextInt(maxOffers - minOffers + 1);
+            }
+
+            if (count > 0) {
+                List<Integer> indices = new ArrayList<>(available);
+                for (int i = 0; i < available; i++) {
+                    indices.add(i);
+                }
+                Collections.shuffle(indices, new Random(world.getRandom().nextLong()));
+                offerIndices.addAll(indices.subList(0, Math.min(count, indices.size())));
+            }
+        }
+
+        nextRefreshTime = world.getTime() + manager.getRefreshIntervalTicks();
+        markDirty();
+    }
+}

--- a/src/main/resources/data/gardenkingmod/garden_market_offers.json
+++ b/src/main/resources/data/gardenkingmod/garden_market_offers.json
@@ -1,5 +1,11 @@
 {
   "_comment": "Default Garden Market offers. Adjust as needed for balancing.",
+  "settings": {
+    "_comment": "Market selects a random subset of offers between min_offers and max_offers for each refresh.",
+    "min_offers": 5,
+    "max_offers": 8,
+    "refresh_minutes": 30
+  },
   "offers": [
     {
       "offer": "minecraft:wheat_seeds*16",


### PR DESCRIPTION
### Motivation

- Provide a single maintainable master list of market offers and allow the market to present a random subset of those offers.
- Make offer selection count and refresh interval configurable from the data file so tuning does not require code changes.
- Ensure the chosen offers and refresh timing persist across world reloads so players see consistent offers until the next scheduled refresh.

### Description

- Add a persistent world state `GardenMarketOfferState` that stores selected offer indices and the next refresh timestamp and rotates the selection when expired.
- Extend `GardenMarketOfferManager` to parse optional `settings` (`min_offers`, `max_offers`, `refresh_minutes`) from `data/gardenkingmod/garden_market_offers.json` and expose the master offers via `getMasterOffers()` and a lookup via `getOffersByIndices()`; default selection bounds are `5..8` and refresh default is `30` minutes.
- Send the selected offer indices and the next refresh time from the server in `MarketBlockEntity.writeScreenOpeningData` so the client UI can show the correct subset.
- Make `MarketScreenHandler` accept server-sent offer indices and refresh timestamp, resolve the handler's `buyOffers` from either the server-side `GardenMarketOfferState` or the provided indices, and expose `getBuyOffers()` for the client screen.
- Update `MarketScreen` to use `handler.getBuyOffers()` instead of loading all offers directly from the manager so the UI shows the selected subset.
- Add the `settings` block to `src/main/resources/data/gardenkingmod/garden_market_offers.json` and keep the existing master `offers` array for easy editing and expansion.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da19a77e88321b432da422c1e8240)