### PR TITLE
Honor empty market offer selections from server

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java
@@ -158,7 +158,7 @@ public class MarketScreenHandler extends ScreenHandler {
                         return new ArrayList<>(state.getActiveOffers(serverWorld));
                 }
 
-                if (offerIndices != null && !offerIndices.isEmpty()) {
+                if (offerIndices != null) {
                         return new ArrayList<>(GardenMarketOfferManager.getInstance().getOffersByIndices(offerIndices));
                 }
 


### PR DESCRIPTION
### Motivation
- Fix a client-server desync where an explicit empty offer index list sent by the server (intentional `min_offers = 0`/`max_offers = 0`) was treated as “no indices”, causing the client to fall back to master offers and allow selection of server-disabled offers.

### Description
- Update `MarketScreenHandler.resolveBuyOffers(...)` to treat `offerIndices != null` (instead of `offerIndices != null && !offerIndices.isEmpty()`) as authoritative and pass the list to `GardenMarketOfferManager.getOffersByIndices(...)`, so an explicit empty list results in an empty client buy-offer list; change made in `src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dad0fd0f8832195cd8a316e539290)