### PR TITLE
Add market refresh countdown to Buy screen with adjustable position

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -71,6 +71,11 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         private static final int BUY_HEADER_COLOR = 0x404040;
         private static final int BUY_OFFERS_LABEL_X = 6;
         private static final int BUY_OFFERS_LABEL_Y = 22;
+        private static final int BUY_REFRESH_TIMER_ANCHOR_X = 211;
+        private static final int BUY_REFRESH_LABEL_Y = 112;
+        private static final int BUY_REFRESH_TIME_Y = 123;
+        private static final int BUY_REFRESH_LABEL_COLOR = 0x404040;
+        private static final int BUY_REFRESH_TIME_COLOR = 0x404040;
 
         private static final int BUY_OFFER_LIST_X = 5;
         private static final int BUY_OFFER_LIST_Y = 32;
@@ -186,6 +191,8 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         private float lastRenderDelta;
         private float resultSlotAnimationStartTicks = Float.NaN;
         private ItemStack lastAnimatedResultSlotStack = ItemStack.EMPTY;
+        private int refreshTimerOffsetX;
+        private int refreshTimerOffsetY;
 
         public MarketScreen(MarketScreenHandler handler, PlayerInventory inventory, Text title) {
                 super(handler, inventory, title);
@@ -198,6 +205,8 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
                 this.lastLifetimeTotal = -1;
                 this.saleResultLine = Text.empty();
                 this.lifetimeResultLine = Text.empty();
+                this.refreshTimerOffsetX = 0;
+                this.refreshTimerOffsetY = 0;
         }
 
         @Override
@@ -569,6 +578,40 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         private void drawBuyLabels(DrawContext context) {
                 context.drawText(textRenderer, Text.translatable("screen.gardenkingmod.market.offers"),
                                 BUY_OFFERS_LABEL_X, BUY_OFFERS_LABEL_Y, BUY_HEADER_COLOR, false);
+                drawBuyRefreshTimer(context);
+        }
+
+        private void drawBuyRefreshTimer(DrawContext context) {
+                if (handler == null || client == null || client.world == null) {
+                        return;
+                }
+
+                long refreshTime = handler.getOfferRefreshTime();
+                if (refreshTime <= 0L) {
+                        return;
+                }
+
+                long currentTime = client.world.getTime();
+                long ticksRemaining = Math.max(0L, refreshTime - currentTime);
+                int totalSeconds = MathHelper.floor(ticksRemaining / 20.0);
+                int minutes = totalSeconds / 60;
+                int seconds = totalSeconds % 60;
+                String timerText = String.format(Locale.ROOT, "%d:%02d", minutes, seconds);
+
+                Text labelText = Text.translatable("screen.gardenkingmod.market.refresh_time");
+                int anchorX = BUY_REFRESH_TIMER_ANCHOR_X + refreshTimerOffsetX;
+                int labelX = anchorX - textRenderer.getWidth(labelText) / 2;
+                int labelY = BUY_REFRESH_LABEL_Y + refreshTimerOffsetY;
+                context.drawText(textRenderer, labelText, labelX, labelY, BUY_REFRESH_LABEL_COLOR, false);
+
+                int timeX = anchorX - textRenderer.getWidth(timerText) / 2;
+                int timeY = BUY_REFRESH_TIME_Y + refreshTimerOffsetY;
+                context.drawText(textRenderer, timerText, timeX, timeY, BUY_REFRESH_TIME_COLOR, false);
+        }
+
+        public void setRefreshTimerOffset(int offsetX, int offsetY) {
+                this.refreshTimerOffsetX = offsetX;
+                this.refreshTimerOffsetY = offsetY;
         }
 
         private void drawBuyOfferList(DrawContext context, int originX, int originY, int mouseX, int mouseY) {

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -105,6 +105,7 @@
   "screen.gardenkingmod.market.tab.sell": "Sell",
   "screen.gardenkingmod.market.tab.buy": "Buy",
   "screen.gardenkingmod.market.offers": "OFFERS",
+  "screen.gardenkingmod.market.refresh_time": "Refresh Time",
   "screen.gardenkingmod.bank.title": "%s's Bank",
   "screen.gardenkingmod.bank.total": "Total Balance: %s dollars",
   "screen.gardenkingmod.bank.slot.dollar": "Dollars",


### PR DESCRIPTION
### Motivation
- Provide a visible countdown and label showing how long until the Garden Market buy offers refresh, positioned inside the buy-panel area so players can see when offers will update.
- Allow the timer widget position to be adjusted like other GUI elements so the placement can be easily tuned to fit the blue-box region on the buy UI.

### Description
- Added constants `BUY_REFRESH_TIMER_ANCHOR_X`, `BUY_REFRESH_LABEL_Y`, `BUY_REFRESH_TIME_Y`, and color constants to `MarketScreen.java` to define the default placement and styling of the refresh label and timer. 
- Implemented `refreshTimerOffsetX` and `refreshTimerOffsetY` fields, initialized them in the constructor, and exposed `setRefreshTimerOffset(int offsetX, int offsetY)` to let callers tweak the widget position. 
- Added `drawBuyRefreshTimer(DrawContext)` which reads the refresh time from the handler (`handler.getOfferRefreshTime()`), computes remaining minutes and seconds, and draws the localized label and countdown text; it is invoked from `drawBuyLabels`. 
- Added the localization key `screen.gardenkingmod.market.refresh_time` with the value `Refresh Time` to `src/main/resources/assets/gardenkingmod/lang/en_us.json`.

### Testing
- No automated tests were executed as part of this change (no unit or integration tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dadd0d0188321bf2a33ce4affb84d)