### PR TITLE
Add /gkmarket refresh command to force garden market refresh

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
@@ -5,6 +5,7 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 
 import net.jeremy.gardenkingmod.armor.ModArmorSetEffects;
+import net.jeremy.gardenkingmod.command.GardenMarketCommands;
 import net.jeremy.gardenkingmod.command.SkillDebugCommands;
 import net.jeremy.gardenkingmod.crop.BonusHarvestDropManager;
 import net.jeremy.gardenkingmod.crop.CropDropModifier;
@@ -44,6 +45,7 @@ public class GardenKingMod implements ModInitializer {
                 ModScoreboards.registerScoreboards();
                 ModArmorSetEffects.register();
                 ModServerNetworking.register();
+                GardenMarketCommands.register();
                 SkillDebugCommands.register();
 
                 ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(BonusHarvestDropManager.getInstance());

--- a/src/main/java/net/jeremy/gardenkingmod/command/GardenMarketCommands.java
+++ b/src/main/java/net/jeremy/gardenkingmod/command/GardenMarketCommands.java
@@ -1,0 +1,43 @@
+package net.jeremy.gardenkingmod.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.jeremy.gardenkingmod.shop.GardenMarketOfferState;
+import net.minecraft.command.CommandRegistryAccess;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
+
+public final class GardenMarketCommands {
+    private GardenMarketCommands() {
+    }
+
+    public static void register() {
+        CommandRegistrationCallback.EVENT.register(GardenMarketCommands::registerCommands);
+    }
+
+    private static void registerCommands(CommandDispatcher<ServerCommandSource> dispatcher,
+            CommandRegistryAccess registryAccess, CommandManager.RegistrationEnvironment environment) {
+        dispatcher.register(CommandManager.literal("gkmarket")
+                .requires(source -> source.hasPermissionLevel(2))
+                .then(CommandManager.literal("refresh")
+                        .executes(GardenMarketCommands::refreshMarket)));
+    }
+
+    private static int refreshMarket(CommandContext<ServerCommandSource> context) {
+        ServerCommandSource source = context.getSource();
+        int refreshed = 0;
+        long nextRefreshTime = 0L;
+        for (ServerWorld world : source.getServer().getWorlds()) {
+            GardenMarketOfferState state = GardenMarketOfferState.get(world);
+            nextRefreshTime = Math.max(nextRefreshTime, state.forceRefresh(world));
+            refreshed++;
+        }
+        source.sendFeedback(() -> Text.literal("Refreshed garden market offers and reset the timer in "
+                + refreshed + " world(s). Next refresh tick: " + nextRefreshTime + "."), false);
+        return refreshed;
+    }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferState.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferState.java
@@ -76,6 +76,11 @@ public final class GardenMarketOfferState extends PersistentState {
         }
     }
 
+    public long forceRefresh(ServerWorld world) {
+        refreshOffers(world);
+        return nextRefreshTime;
+    }
+
     private boolean needsRefresh(ServerWorld world) {
         return offerIndices.isEmpty() || nextRefreshTime <= 0L || world.getTime() >= nextRefreshTime;
     }


### PR DESCRIPTION
### Motivation
- Provide a way for server operators to immediately reload the Garden Market offers and reset the refresh timer to the value defined in the JSON, usable from the world or server console.
- Make the manual refresh operation affect all loaded server worlds consistently.

### Description
- Added a new command class `GardenMarketCommands` that registers the `/gkmarket refresh` command (requires permission level 2) and refreshes the market for every server world by calling the state helper.
- Exposed a `forceRefresh(ServerWorld)` helper on `GardenMarketOfferState` that calls `refreshOffers(...)`, marks state dirty, and returns the updated `nextRefreshTime`.
- Registered the new command during mod initialization by calling `GardenMarketCommands.register()` in `GardenKingMod.onInitialize()`.
- The command iterates all `ServerWorld`s, calls the force-refresh helper for each, and reports how many worlds were refreshed and the next refresh tick in feedback.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dbd0d323c832196c699856efea01d)