### PR TITLE
Fix gkmarket refresh feedback lambda

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/command/GardenMarketCommands.java
+++ b/src/main/java/net/jeremy/gardenkingmod/command/GardenMarketCommands.java
@@ -36,8 +36,10 @@ public final class GardenMarketCommands {
             nextRefreshTime = Math.max(nextRefreshTime, state.forceRefresh(world));
             refreshed++;
         }
+        final int refreshedCount = refreshed;
+        final long nextRefreshTick = nextRefreshTime;
         source.sendFeedback(() -> Text.literal("Refreshed garden market offers and reset the timer in "
-                + refreshed + " world(s). Next refresh tick: " + nextRefreshTime + "."), false);
+                + refreshedCount + " world(s). Next refresh tick: " + nextRefreshTick + "."), false);
         return refreshed;
     }
 }


### PR DESCRIPTION
### Motivation
- The `sendFeedback` lambda referenced local variables that were not final or effectively final, causing a Java compile error when building the command feedback.

### Description
- Capture `refreshed` and `nextRefreshTime` into `final` locals (`refreshedCount` and `nextRefreshTick`) and use those in the `source.sendFeedback` message to satisfy the lambda's effectively-final requirement.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dbea95d34832183f11418672f59ab)