### PR TITLE
Expose all garden market offers via new `show_all_offers` setting

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferManager.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferManager.java
@@ -38,11 +38,13 @@ public final class GardenMarketOfferManager implements SimpleSynchronousResource
     private static final int DEFAULT_MIN_OFFERS = 5;
     private static final int DEFAULT_MAX_OFFERS = 8;
     private static final int DEFAULT_REFRESH_MINUTES = 30;
+    private static final boolean DEFAULT_SHOW_ALL_OFFERS = false;
 
     private volatile List<GearShopOffer> offers = List.of();
     private volatile int minOffers = DEFAULT_MIN_OFFERS;
     private volatile int maxOffers = DEFAULT_MAX_OFFERS;
     private volatile int refreshMinutes = DEFAULT_REFRESH_MINUTES;
+    private volatile boolean showAllOffers = DEFAULT_SHOW_ALL_OFFERS;
 
     private GardenMarketOfferManager() {
     }
@@ -91,6 +93,10 @@ public final class GardenMarketOfferManager implements SimpleSynchronousResource
         return minutes * 60L * 20L;
     }
 
+    public boolean shouldShowAllOffers() {
+        return showAllOffers;
+    }
+
     @Override
     public Identifier getFabricId() {
         return RELOAD_ID;
@@ -105,6 +111,7 @@ public final class GardenMarketOfferManager implements SimpleSynchronousResource
         minOffers = DEFAULT_MIN_OFFERS;
         maxOffers = DEFAULT_MAX_OFFERS;
         refreshMinutes = DEFAULT_REFRESH_MINUTES;
+        showAllOffers = DEFAULT_SHOW_ALL_OFFERS;
 
         Optional<Resource> resourceOptional = manager.getResource(OFFERS_FILE);
         if (resourceOptional.isEmpty()) {
@@ -182,6 +189,7 @@ public final class GardenMarketOfferManager implements SimpleSynchronousResource
         minOffers = JsonHelper.getInt(object, "min_offers", minOffers);
         maxOffers = JsonHelper.getInt(object, "max_offers", maxOffers);
         refreshMinutes = JsonHelper.getInt(object, "refresh_minutes", refreshMinutes);
+        showAllOffers = JsonHelper.getBoolean(object, "show_all_offers", showAllOffers);
         if (maxOffers < minOffers) {
             maxOffers = minOffers;
         }

--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferState.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferState.java
@@ -92,12 +92,17 @@ public final class GardenMarketOfferState extends PersistentState {
 
         if (!master.isEmpty()) {
             int available = master.size();
-            int minOffers = MathHelper.clamp(manager.getMinOffers(), 0, available);
-            int maxOffers = MathHelper.clamp(manager.getMaxOffers(), minOffers, available);
-            int count = minOffers;
-            if (maxOffers > minOffers) {
-                Random javaRandom = new Random(world.getRandom().nextLong());
-                count = minOffers + javaRandom.nextInt(maxOffers - minOffers + 1);
+            int count;
+            if (manager.shouldShowAllOffers()) {
+                count = available;
+            } else {
+                int minOffers = MathHelper.clamp(manager.getMinOffers(), 0, available);
+                int maxOffers = MathHelper.clamp(manager.getMaxOffers(), minOffers, available);
+                count = minOffers;
+                if (maxOffers > minOffers) {
+                    Random javaRandom = new Random(world.getRandom().nextLong());
+                    count = minOffers + javaRandom.nextInt(maxOffers - minOffers + 1);
+                }
             }
 
             if (count > 0) {

--- a/src/main/resources/data/gardenkingmod/garden_market_offers.json
+++ b/src/main/resources/data/gardenkingmod/garden_market_offers.json
@@ -3,7 +3,8 @@
   "settings": {
     "min_offers": 50,
     "max_offers": 105,
-    "refresh_minutes": 30
+    "refresh_minutes": 30,
+    "show_all_offers": true
   },
   "offers": [
     {


### PR DESCRIPTION
### Motivation
- Tests require the Garden Market to display every configured offer rather than a random subset controlled by `min_offers`/`max_offers`, so add a toggle to force-all-offers behavior for debugging.

### Description
- Added a new manager-level setting `show_all_offers` with `DEFAULT_SHOW_ALL_OFFERS` and a `showAllOffers` field in `GardenMarketOfferManager` and a public accessor `shouldShowAllOffers()`.
- Reset and parse the `show_all_offers` setting during offer reload in `GardenMarketOfferManager::loadOffers` and `applySettings` using `JsonHelper.getBoolean`.
- Updated `GardenMarketOfferState::refreshOffers` to honor `manager.shouldShowAllOffers()` and select all available offers when enabled instead of choosing a randomized subset.
- Enabled the flag in the default data file by adding `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dc67729e48321a13a4786e25160bc)