### PR TITLE
Honor root-level show_all_offers setting

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferManager.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferManager.java
@@ -180,7 +180,8 @@ public final class GardenMarketOfferManager implements SimpleSynchronousResource
         if (rootObject.has("settings") && rootObject.get("settings").isJsonObject()) {
             applySettings(rootObject.getAsJsonObject("settings"));
         }
-        if (rootObject.has("min_offers") || rootObject.has("max_offers") || rootObject.has("refresh_minutes")) {
+        if (rootObject.has("min_offers") || rootObject.has("max_offers") || rootObject.has("refresh_minutes")
+                || rootObject.has("show_all_offers")) {
             applySettings(rootObject);
         }
     }


### PR DESCRIPTION
### Motivation
- Legacy root-level configs that only set `show_all_offers` were ignored because `parseSettings` only applied `applySettings` when `min_offers`, `max_offers`, or `refresh_minutes` were present, which caused surprising randomized offers.

### Description
- Add `rootObject.has("show_all_offers")` to the guard in `parseSettings` so `applySettings(rootObject)` is invoked when a root-level `show_all_offers` is present; change made in `src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferManager.java`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e34e5c8988321973874aa65bee814)