### PR TITLE
Honor root-level show_all_offers and refresh active offers

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferManager.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferManager.java
@@ -180,7 +180,8 @@ public final class GardenMarketOfferManager implements SimpleSynchronousResource
         if (rootObject.has("settings") && rootObject.get("settings").isJsonObject()) {
             applySettings(rootObject.getAsJsonObject("settings"));
         }
-        if (rootObject.has("min_offers") || rootObject.has("max_offers") || rootObject.has("refresh_minutes")) {
+        if (rootObject.has("min_offers") || rootObject.has("max_offers") || rootObject.has("refresh_minutes")
+                || rootObject.has("show_all_offers")) {
             applySettings(rootObject);
         }
     }

--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferState.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferState.java
@@ -71,7 +71,10 @@ public final class GardenMarketOfferState extends PersistentState {
     }
 
     private void ensureOffers(ServerWorld world) {
-        if (needsRefresh(world)) {
+        GardenMarketOfferManager manager = GardenMarketOfferManager.getInstance();
+        List<GearShopOffer> master = manager.getMasterOffers();
+        boolean showAllMismatch = manager.shouldShowAllOffers() && offerIndices.size() < master.size();
+        if (needsRefresh(world) || showAllMismatch) {
             refreshOffers(world);
         }
     }


### PR DESCRIPTION
### Motivation
- Root-level `show_all_offers` in `garden_market_offers.json` was not always applied because `parseSettings` only applied root settings when other keys were present, causing the setting to be ignored. 
- Even when `show_all_offers` was enabled, previously persisted active offer indices could remain smaller than the master list and not show all offers until the next scheduled refresh.

### Description
- Add `rootObject.has("show_all_offers")` to the guard in `parseSettings` so `applySettings` is called when a root-level `show_all_offers` is present (file: `src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferManager.java`).
- Update `GardenMarketOfferState.ensureOffers` to refresh offers when `manager.shouldShowAllOffers()` is true but the active `offerIndices` list is smaller than the master offer list, forcing an immediate refresh to reveal all offers (file: `src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferState.java`).
- Preserve existing behavior for randomized selection when `show_all_offers` is false.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e34e5c8988321973874aa65bee814)