### PR TITLE
Resolve Croptopia crop IDs when loading market offers

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferManager.java
+++ b/src/main/java/net/jeremy/gardenkingmod/shop/GardenMarketOfferManager.java
@@ -309,7 +309,7 @@ public final class GardenMarketOfferManager implements SimpleSynchronousResource
             return ItemStack.EMPTY;
         }
 
-        Optional<Item> itemOptional = Registries.ITEM.getOrEmpty(id);
+        Optional<Item> itemOptional = resolveItem(id);
         if (itemOptional.isEmpty()) {
             GardenKingMod.LOGGER.warn("Garden market {} entry references unknown item '{}'", fieldName, id);
             return ItemStack.EMPTY;
@@ -327,5 +327,23 @@ public final class GardenMarketOfferManager implements SimpleSynchronousResource
     private static String describeStack(ItemStack stack) {
         Identifier id = Registries.ITEM.getId(stack.getItem());
         return stack.getCount() + "x " + (id != null ? id.toString() : stack.getName().getString());
+    }
+
+    private Optional<Item> resolveItem(Identifier id) {
+        Optional<Item> itemOptional = Registries.ITEM.getOrEmpty(id);
+        if (itemOptional.isPresent()) {
+            return itemOptional;
+        }
+
+        String path = id.getPath();
+        if (path.endsWith("_crop")) {
+            Identifier fallbackId = new Identifier(id.getNamespace(), path.substring(0, path.length() - "_crop".length()));
+            itemOptional = Registries.ITEM.getOrEmpty(fallbackId);
+            if (itemOptional.isPresent()) {
+                return itemOptional;
+            }
+        }
+
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure market offers that reference Croptopia crop identifiers (for example `croptopia:tomato_crop`) resolve to actual `Item` entries so those offers load and can be shown when `show_all_offers` is enabled.

### Description
- Add a `resolveItem(Identifier)` helper and update `createStack` to call it; the helper first tries the given id and, if missing and the path ends with `_crop`, falls back to the same namespace id with `_crop` stripped.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e41aaeff88321a100e6ef1bdc8fa8)