### PR TITLE
Make Croptopia onUse mixin optional

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java
+++ b/src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java
@@ -23,7 +23,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class CroptopiaCropBlockMixin {
 
         @Inject(method = "onUse(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;",
-                        at = @At("HEAD"), cancellable = true, remap = false)
+                        at = @At("HEAD"), cancellable = true, remap = false, require = 0)
         private void gardenkingmod$harvestCrops(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand,
                         BlockHitResult hit, CallbackInfoReturnable<ActionResult> cir) {
                 CropBlock crop = (CropBlock) (Object) this;


### PR DESCRIPTION
### Motivation
- Prevent the mod from crashing at startup when Croptopia's `onUse` method is missing, which previously caused the mixin injection to fail.

### Description
- Added `require = 0` to the `@Inject` on the Croptopia mixin in `src/main/java/net/jeremy/gardenkingmod/mixin/CroptopiaCropBlockMixin.java` so the injection is optional and the mixin will be skipped if the target method is absent.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f82fee3708321a190469b9c229f38)