### PR TITLE
Send full Garden Market offers to client to fix blank offers on dedicated servers

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
@@ -19,6 +19,8 @@ import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.item.WalletItem;
 import net.jeremy.gardenkingmod.screen.MarketScreenHandler;
 import net.jeremy.gardenkingmod.shop.GardenMarketOfferState;
+import net.jeremy.gardenkingmod.shop.GearShopOffer;
+import net.jeremy.gardenkingmod.shop.GearShopStackHelper;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
@@ -86,11 +88,15 @@ public class MarketBlockEntity extends BlockEntity implements ExtendedScreenHand
                 ServerWorld serverWorld = player.getServerWorld();
                 if (serverWorld != null) {
                         GardenMarketOfferState state = GardenMarketOfferState.get(serverWorld);
-                        var offerIndices = state.getActiveOfferIndices(serverWorld);
-                        buf.writeVarInt(offerIndices.size());
-                        for (Integer index : offerIndices) {
-                                if (index != null) {
-                                        buf.writeVarInt(index);
+                        var activeOffers = state.getActiveOffers(serverWorld);
+                        buf.writeVarInt(activeOffers.size());
+                        for (GearShopOffer offer : activeOffers) {
+                                buf.writeItemStack(offer.copyResultStack());
+                                var costs = offer.copyCostStacks();
+                                buf.writeVarInt(costs.size());
+                                for (ItemStack cost : costs) {
+                                        buf.writeItemStack(cost);
+                                        buf.writeVarInt(GearShopStackHelper.getRequestedCount(cost));
                                 }
                         }
                         buf.writeLong(state.getNextRefreshTime(serverWorld));


### PR DESCRIPTION
### Motivation
- The client GUI could open on a dedicated server before the client has the local offer index data, which left the buy offers blank because the server only sent indices. 

### Description
- Changed `MarketBlockEntity.writeScreenOpeningData` to serialize full active offers (result `ItemStack`, cost `ItemStack`s and requested counts) instead of only sending indices.  
- Updated `MarketScreenHandler` to decode the full offer payload via a new `readOffers` routine and to construct `GearShopOffer` instances from the packet when the client-side block entity/state is unavailable.  
- Preserved server-side behavior when the block entity and server state are present, and used `GearShopStackHelper.applyRequestedCount` to restore large requested-count metadata for cost stacks.  
- Modified files: `src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java` and `src/main/java/net/jeremy/gardenkingmod/screen/MarketScreenHandler.java`.

### Testing
- Attempted a Java compile with `./gradlew compileJava`, which failed in this environment due to a toolchain/Gradle mismatch (`Unsupported class file major version 69`) and not because of the market packet changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991cf033fbc83219399eefcf46491b8)