### PR TITLE
Fix Endless Night boss bar persisting before event start

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/event/EndlessNightEventManager.java
+++ b/src/main/java/net/jeremy/gardenkingmod/event/EndlessNightEventManager.java
@@ -35,6 +35,11 @@ public final class EndlessNightEventManager {
             BossBar.Color.PURPLE,
             BossBar.Style.PROGRESS);
 
+    static {
+        BOSS_BAR.setPercent(0.0F);
+        BOSS_BAR.setVisible(false);
+    }
+
     private static MinecraftServer server;
     private static boolean active;
     private static TaskDefinition activeTask;
@@ -47,7 +52,10 @@ public final class EndlessNightEventManager {
     }
 
     public static void register() {
-        ServerLifecycleEvents.SERVER_STARTED.register(startedServer -> server = startedServer);
+        ServerLifecycleEvents.SERVER_STARTED.register(startedServer -> {
+            server = startedServer;
+            resetState();
+        });
         ServerLifecycleEvents.SERVER_STOPPED.register(stoppedServer -> {
             server = null;
             resetState();
@@ -75,9 +83,16 @@ public final class EndlessNightEventManager {
     }
 
     public static boolean forceEnd() {
-        if (!active) {
+        if (!active && !BOSS_BAR.isVisible()) {
             return false;
         }
+
+        if (!active) {
+            resetState();
+            syncToAllPlayers();
+            return true;
+        }
+
         completeEvent();
         return true;
     }


### PR DESCRIPTION
### Motivation
- Players reported the Endless Night boss bar populating the screen on first connect (single-player and servers) and not clearing when using the `gkendlessnight stop` command, only disappearing after an actual event completes.
- The change aims to ensure the boss bar cannot appear from stale static state and that `stop` reliably clears any visible boss bar even if the event manager isn't marked `active`.

### Description
- Initialize the `ServerBossBar` to 0% and hidden at class load so it cannot appear before any runtime state is set (changed in `EndlessNightEventManager`).
- Reset the Endless Night runtime state on `SERVER_STARTED` by invoking `resetState()` so a fresh server session can't inherit stale static values (in `EndlessNightEventManager.register`).
- Harden `forceEnd()` (invoked by the `gkendlessnight stop` command) to treat a visible boss bar as a condition for clearing and to call `resetState()` and `syncToAllPlayers()` when the manager is not `active` but the boss bar is visible (in `EndlessNightEventManager`).
- Changed file: `src/main/java/net/jeremy/gardenkingmod/event/EndlessNightEventManager.java`.

### Testing
- Ran `./gradlew compileJava` to validate the change, but the build failed in this environment with a Gradle/JDK incompatibility: `Unsupported class file major version 69` (no successful compilation result available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab67fd951c8321aa0620ad8a41e95a)