### PR TITLE
Prevent seeds from being sellable in the market

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -32,6 +32,7 @@ import net.jeremy.gardenkingmod.client.render.GearShopBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.MarketBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.ScarecrowBlockEntityRenderer;
 import net.jeremy.gardenkingmod.client.render.SprinklerBlockEntityRenderer;
+import net.jeremy.gardenkingmod.block.entity.MarketBlockEntity;
 import net.jeremy.gardenkingmod.client.skill.SkillState;
 import net.jeremy.gardenkingmod.client.render.item.BankItemRenderer;
 import net.jeremy.gardenkingmod.client.render.item.GearShopItemRenderer;
@@ -294,7 +295,7 @@ public class GardenKingModClient implements ClientModInitializer {
                                 sellValue = Math.max(1,
                                                 Math.round(sellValue * enchantedDefinition.get().effectiveValueMultiplier()));
                         }
-                        if (sellValue > 0) {
+                        if (sellValue > 0 && !MarketBlockEntity.isSeedItem(stack.getItem())) {
                                 lines.add(Text.translatable("tooltip." + GardenKingMod.MOD_ID + ".crop_value_each",
                                                 sellValue)
                                                 .formatted(pricingColor));

--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
@@ -66,6 +66,10 @@ public class MarketBlockEntity extends BlockEntity implements ExtendedScreenHand
                         return false;
                 }
 
+                if (isSeedItem(stack.getItem())) {
+                        return false;
+                }
+
                 if (Registries.ITEM.getEntry(stack.getItem()).isIn(MARKET_UNSELLABLE)) {
                         return false;
                 }
@@ -81,6 +85,20 @@ public class MarketBlockEntity extends BlockEntity implements ExtendedScreenHand
 
                 String namespace = identifier.getNamespace();
                 return "croptopia".equals(namespace) || "minecraft".equals(namespace);
+        }
+
+        public static boolean isSeedItem(Item item) {
+                if (item == null) {
+                        return false;
+                }
+
+                Identifier identifier = Registries.ITEM.getId(item);
+                if (identifier == null) {
+                        return false;
+                }
+
+                String path = identifier.getPath();
+                return path.endsWith("_seed") || path.endsWith("_seeds");
         }
 
         @Override

--- a/src/testmod/java/net/jeremy/gardenkingmod/GardenKingModGameTest.java
+++ b/src/testmod/java/net/jeremy/gardenkingmod/GardenKingModGameTest.java
@@ -74,4 +74,54 @@ public final class GardenKingModGameTest implements FabricGameTest {
                         helper.succeed();
                 });
         }
+
+
+        @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+        public void sellingSeedIsRejected(GameTestHelper helper) {
+                helper.setBlock(BlockPos.ORIGIN, ModBlocks.MARKET_BLOCK.getDefaultState());
+
+                helper.runAtTickTime(1, () -> {
+                        MarketBlockEntity blockEntity = helper.getBlockEntity(BlockPos.ORIGIN);
+                        if (blockEntity == null) {
+                                helper.fail("Market block entity was not created");
+                                return;
+                        }
+
+                        Optional<Item> seedOptional = Registries.ITEM.getOrEmpty(new Identifier("croptopia", "tomato_seed"));
+                        if (seedOptional.isEmpty()) {
+                                helper.fail("Croptopia tomato seed item is missing from the registry");
+                                return;
+                        }
+
+                        Item seedItem = seedOptional.get();
+                        blockEntity.setStack(0, new ItemStack(seedItem, 16));
+
+                        ServerPlayerEntity player = helper.spawnPlayer(BlockPos.ORIGIN.up());
+                        boolean sold = blockEntity.sell(player);
+                        if (sold) {
+                                helper.fail("Market should not sell seed items");
+                                return;
+                        }
+
+                        if (!blockEntity.getStack(0).isOf(seedItem) || blockEntity.getStack(0).getCount() != 16) {
+                                helper.fail("Seed stack should remain in the market input when sale is rejected");
+                                return;
+                        }
+
+                        int dollarCount = 0;
+                        for (ItemStack inventoryStack : player.getInventory().main) {
+                                if (inventoryStack.isOf(ModItems.DOLLAR)) {
+                                        dollarCount += inventoryStack.getCount();
+                                }
+                        }
+
+                        if (dollarCount > 0) {
+                                helper.fail("Player should not receive dollars when trying to sell seeds");
+                                return;
+                        }
+
+                        helper.succeed();
+                });
+        }
+
 }


### PR DESCRIPTION
### Motivation
- Seeds were inheriting crop tier sell values because the crop tier lookup uses the crop block/item id suffixes, which caused seed items to be sold by the market despite them needing to remain purchasable for planting.
- The goal is to keep the tier information visible on tooltips while preventing seeds from having any sell value or being sold.

### Description
- Added `isSeedItem(Item)` to `MarketBlockEntity` and made `isSellable(ItemStack)` return false for items where `isSeedItem` is true, rejecting seed items before pricing/sale logic runs (file: `src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java`).
- Modified client tooltip code to keep the tier line but suppress the per-item `Value: $X each` line for seed items by checking `MarketBlockEntity.isSeedItem(stack.getItem())` (file: `src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java`).
- Added a game test `sellingSeedIsRejected` to `GardenKingModGameTest` that asserts the market will not sell a `croptopia:tomato_seed`, that the seed stack remains in the input slot, and that no dollars are awarded (file: `src/testmod/java/net/jeremy/gardenkingmod/GardenKingModGameTest.java`).

### Testing
- Attempted to run automated tests with `./gradlew test --no-daemon`, but the build failed in this environment with the JVM/Groovy error `Unsupported class file major version 69`, so the test suite could not be executed here.
- The new game test is present in the test sources (`sellingSeedIsRejected`) and will run in a compatible CI or local environment with matching JVM tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab6d379790832198e870758d25a388)