### PR TITLE
Fix seed sellability regression for roasted Croptopia seed foods

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
+++ b/src/main/java/net/jeremy/gardenkingmod/block/entity/MarketBlockEntity.java
@@ -3,6 +3,7 @@ package net.jeremy.gardenkingmod.block.entity;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
@@ -54,6 +55,9 @@ public class MarketBlockEntity extends BlockEntity implements ExtendedScreenHand
         public static final TagKey<Item> MARKET_UNSELLABLE =
                         TagKey.of(RegistryKeys.ITEM,
                                         new Identifier(GardenKingMod.MOD_ID, "market_unsellable"));
+        private static final Set<Identifier> NON_PLANTABLE_SEED_EXCEPTIONS = Set.of(
+                        new Identifier("croptopia", "roasted_pumpkin_seeds"),
+                        new Identifier("croptopia", "roasted_sunflower_seeds"));
 
         private DefaultedList<ItemStack> items = DefaultedList.ofSize(INVENTORY_SIZE, ItemStack.EMPTY);
 
@@ -94,6 +98,10 @@ public class MarketBlockEntity extends BlockEntity implements ExtendedScreenHand
 
                 Identifier identifier = Registries.ITEM.getId(item);
                 if (identifier == null) {
+                        return false;
+                }
+
+                if (NON_PLANTABLE_SEED_EXCEPTIONS.contains(identifier)) {
                         return false;
                 }
 

--- a/src/testmod/java/net/jeremy/gardenkingmod/GardenKingModGameTest.java
+++ b/src/testmod/java/net/jeremy/gardenkingmod/GardenKingModGameTest.java
@@ -124,4 +124,52 @@ public final class GardenKingModGameTest implements FabricGameTest {
                 });
         }
 
+        @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+        public void sellingRoastedSeedFoodsIsAllowed(GameTestHelper helper) {
+                helper.setBlock(BlockPos.ORIGIN, ModBlocks.MARKET_BLOCK.getDefaultState());
+
+                helper.runAtTickTime(1, () -> {
+                        MarketBlockEntity blockEntity = helper.getBlockEntity(BlockPos.ORIGIN);
+                        if (blockEntity == null) {
+                                helper.fail("Market block entity was not created");
+                                return;
+                        }
+
+                        Optional<Item> roastedPumpkinSeedsOptional =
+                                        Registries.ITEM.getOrEmpty(new Identifier("croptopia", "roasted_pumpkin_seeds"));
+                        Optional<Item> roastedSunflowerSeedsOptional =
+                                        Registries.ITEM.getOrEmpty(new Identifier("croptopia", "roasted_sunflower_seeds"));
+                        if (roastedPumpkinSeedsOptional.isEmpty() || roastedSunflowerSeedsOptional.isEmpty()) {
+                                helper.fail("Expected roasted seed food items are missing from the registry");
+                                return;
+                        }
+
+                        Item roastedPumpkinSeeds = roastedPumpkinSeedsOptional.get();
+                        Item roastedSunflowerSeeds = roastedSunflowerSeedsOptional.get();
+                        blockEntity.setStack(0, new ItemStack(roastedPumpkinSeeds, 8));
+                        blockEntity.setStack(1, new ItemStack(roastedSunflowerSeeds, 8));
+
+                        ServerPlayerEntity player = helper.spawnPlayer(BlockPos.ORIGIN.up());
+                        boolean sold = blockEntity.sell(player);
+                        if (!sold) {
+                                helper.fail("Market should sell roasted seed food outputs");
+                                return;
+                        }
+
+                        int dollarCount = 0;
+                        for (ItemStack inventoryStack : player.getInventory().main) {
+                                if (inventoryStack.isOf(ModItems.DOLLAR)) {
+                                        dollarCount += inventoryStack.getCount();
+                                }
+                        }
+
+                        if (dollarCount <= 0) {
+                                helper.fail("Player should receive dollars when selling roasted seed food outputs");
+                                return;
+                        }
+
+                        helper.succeed();
+                });
+        }
+
 }


### PR DESCRIPTION
### Motivation
- The `_seed`/`_seeds` suffix check in `isSeedItem` caused cooked/processed outputs that end with that suffix to be treated as seeds and thus unsellable, which broke existing market behavior for tiered crop outputs listed in the data tags. 
- Two items in `tier_4.json` (`croptopia:roasted_pumpkin_seeds` and `croptopia:roasted_sunflower_seeds`) are processed foods, not plantable seeds, and must remain sellable with their tier value preserved.

### Description
- Added a `NON_PLANTABLE_SEED_EXCEPTIONS` `Set<Identifier>` containing `croptopia:roasted_pumpkin_seeds` and `croptopia:roasted_sunflower_seeds` to `MarketBlockEntity` and imported `Set`.
- Updated `isSeedItem` to return `false` for identifiers in `NON_PLANTABLE_SEED_EXCEPTIONS` before applying the existing suffix-based `_seed`/`_seeds` check so legitimate cooked seed foods are not misclassified.
- Added a GameTest `sellingRoastedSeedFoodsIsAllowed` to `GardenKingModGameTest` that ensures both roasted seed food items can be sold and award dollars when sold.

### Testing
- Ran `./gradlew test --no-daemon` which could not complete in this environment due to a Java/Gradle runtime mismatch (`Unsupported class file major version 69`).
- The new GameTest was added to cover the regression but could not be executed here for the same runtime issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab77ea46a083218005001cd4ffc97a)