### PR TITLE
Hide seed sell-value tooltip and render sell total as three centered lines

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java
@@ -297,6 +297,7 @@ public class GardenKingModClient implements ClientModInitializer {
                                                 Math.round(sellValue * enchantedDefinition.get().effectiveValueMultiplier()));
                         }
                         boolean showSellValue = sellValue > 0
+                                        && !MarketBlockEntity.isSeedItem(stack.getItem())
                                         && !Registries.ITEM.getEntry(stack.getItem()).isIn(MarketBlockEntity.MARKET_UNSELLABLE);
                         if (showSellValue) {
                                 lines.add(Text.translatable("tooltip." + GardenKingMod.MOD_ID + ".crop_value_each",

--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -67,8 +67,10 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
         private static final int BUY_TAB_TEXT_X = 54;
         private static final int SCOREBOARD_BAND_TOP = 107;
         private static final int SCOREBOARD_BAND_BOTTOM = 138;
-        private static final int SELL_TOTAL_LABEL_X = 106;
-        private static final int SELL_TOTAL_LABEL_Y = 116;
+        private static final int SELL_TOTAL_CENTER_X = 135;
+        private static final int SELL_TOTAL_LABEL_Y = 108;
+        private static final int SELL_TOTAL_VALUE_Y = 118;
+        private static final int SELL_TOTAL_SUFFIX_Y = 128;
         private static final int SELL_TOTAL_PREFIX_COLOR = 0x404040;
         private static final int SELL_TOTAL_VALUE_COLOR = 0xE34646;
         private static final int SELL_TOTAL_SUFFIX_COLOR = 0x404040;
@@ -374,16 +376,17 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
 
         private void drawPendingSellTotal(DrawContext context) {
                 int totalDollars = Math.max(0, handler.getPendingSaleTotal());
-                String prefix = "Total: ";
+                String prefix = "TOTAL :";
                 String value = Integer.toString(totalDollars);
-                String suffix = " Dollars";
-                int valueX = SELL_TOTAL_LABEL_X + textRenderer.getWidth(prefix);
-                int suffixX = valueX + textRenderer.getWidth(value);
+                String suffix = "DOLLARS";
 
-                context.drawText(textRenderer, prefix, SELL_TOTAL_LABEL_X, SELL_TOTAL_LABEL_Y, SELL_TOTAL_PREFIX_COLOR,
-                                false);
-                context.drawText(textRenderer, value, valueX, SELL_TOTAL_LABEL_Y, SELL_TOTAL_VALUE_COLOR, false);
-                context.drawText(textRenderer, suffix, suffixX, SELL_TOTAL_LABEL_Y, SELL_TOTAL_SUFFIX_COLOR, false);
+                int prefixX = SELL_TOTAL_CENTER_X - textRenderer.getWidth(prefix) / 2;
+                int valueX = SELL_TOTAL_CENTER_X - textRenderer.getWidth(value) / 2;
+                int suffixX = SELL_TOTAL_CENTER_X - textRenderer.getWidth(suffix) / 2;
+
+                context.drawText(textRenderer, prefix, prefixX, SELL_TOTAL_LABEL_Y, SELL_TOTAL_PREFIX_COLOR, false);
+                context.drawText(textRenderer, value, valueX, SELL_TOTAL_VALUE_Y, SELL_TOTAL_VALUE_COLOR, false);
+                context.drawText(textRenderer, suffix, suffixX, SELL_TOTAL_SUFFIX_Y, SELL_TOTAL_SUFFIX_COLOR, false);
         }
 
         private void showSaleResultToast() {


### PR DESCRIPTION
### Motivation
- Seed items should not display a per-item sell-value in the tooltip, and the market's pending-sale total should match the requested visual layout of three stacked centered lines.

### Description
- Suppress the crop value tooltip for seed items by adding a seed check to the client tooltip visibility logic in `GardenKingModClient` so seed items no longer show the "Value: $%s each" line.
- Replace the single-line inline "Total: X Dollars" rendering in `MarketScreen` with three separate centered lines (`TOTAL :`, numeric value, `DOLLARS`) and add layout constants for center X and per-line Y offsets.
- Files changed: `src/main/java/net/jeremy/gardenkingmod/GardenKingModClient.java` and `src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java`.

### Testing
- Ran a build compile attempt using `./gradlew compileJava` which failed in this environment due to local Java/Gradle compatibility (`Unsupported class file major version 69`).
- No automated compilation or runtime verification could be completed here because of the environment Java/Gradle mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab7a9d2fc88321b24109fce57f7442)