### PR TITLE
Use vanilla Minecraft font for Market sell total

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
+++ b/src/main/java/net/jeremy/gardenkingmod/screen/MarketScreen.java
@@ -376,9 +376,9 @@ public class MarketScreen extends HandledScreen<MarketScreenHandler> {
 
         private void drawPendingSellTotal(DrawContext context) {
                 int totalDollars = Math.max(0, handler.getPendingSaleTotal());
-                String prefix = "TOTAL :";
-                String value = Integer.toString(totalDollars);
-                String suffix = "DOLLARS";
+                Text prefix = Text.translatable("screen.gardenkingmod.market.sell_total.prefix");
+                Text value = Text.literal(Integer.toString(totalDollars));
+                Text suffix = Text.translatable("screen.gardenkingmod.market.sell_total.suffix");
 
                 int prefixX = SELL_TOTAL_CENTER_X - textRenderer.getWidth(prefix) / 2;
                 int valueX = SELL_TOTAL_CENTER_X - textRenderer.getWidth(value) / 2;

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -103,6 +103,8 @@
   "screen.gardenkingmod.market.tab.buy": "Buy",
   "screen.gardenkingmod.market.offers": "OFFERS",
   "screen.gardenkingmod.market.refresh_time": "Refresh Time",
+  "screen.gardenkingmod.market.sell_total.prefix": "Total :",
+  "screen.gardenkingmod.market.sell_total.suffix": "Dollars",
   "screen.gardenkingmod.bank.title": "%s's Bank",
   "screen.gardenkingmod.bank.total": "Total Balance: %s dollars",
   "screen.gardenkingmod.bank.slot.dollar": "Dollars",


### PR DESCRIPTION
### Motivation
- Ensure the sell total text in the Market screen uses the same vanilla text rendering path and font as other UI labels (for example `Inventory` and `Garden Market`) so the UI is visually consistent.

### Description
- Replaced hardcoded `String` labels in `MarketScreen.drawPendingSellTotal` with localized `Text` values (`Text.translatable("screen.gardenkingmod.market.sell_total.prefix")`, `Text.literal(...)`, and `Text.translatable("screen.gardenkingmod.market.sell_total.suffix")`) while preserving the existing centering logic, and added the corresponding English localization keys in `src/main/resources/assets/gardenkingmod/lang/en_us.json`.

### Testing
- Ran `./gradlew -q compileJava` in this environment which failed due to a local Java/Gradle runtime mismatch (`Unsupported class file major version 69`) rather than code-level errors, so no further automated test failures attributable to the change were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab7dfcd0bc8321be15e48cea18c9c4)