### PR TITLE
Add Lumber Jack axe enchantment with capped tree-felling

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
+++ b/src/main/java/net/jeremy/gardenkingmod/GardenKingMod.java
@@ -13,6 +13,7 @@ import net.jeremy.gardenkingmod.crop.BonusHarvestDropManager;
 import net.jeremy.gardenkingmod.crop.CropDropModifier;
 import net.jeremy.gardenkingmod.crop.CropTierRegistry;
 import net.jeremy.gardenkingmod.entity.MobDropConfig;
+import net.jeremy.gardenkingmod.enchantment.ModEnchantments;
 import net.jeremy.gardenkingmod.entity.MobDropModifier;
 import net.jeremy.gardenkingmod.event.EndlessNightConfig;
 import net.jeremy.gardenkingmod.event.EndlessNightEventManager;
@@ -52,6 +53,7 @@ public class GardenKingMod implements ModInitializer {
                 ModSoundEvents.register();
                 ModScreenHandlers.registerScreenHandlers();
                 ModScoreboards.registerScoreboards();
+                ModEnchantments.register();
                 ModArmorSetEffects.register();
                 ModServerNetworking.register();
                 EndlessNightEventManager.register();

--- a/src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackEnchantment.java
+++ b/src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackEnchantment.java
@@ -1,0 +1,36 @@
+package net.jeremy.gardenkingmod.enchantment;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentTarget;
+import net.minecraft.entity.EquipmentSlot;
+
+public class LumberJackEnchantment extends Enchantment {
+        public LumberJackEnchantment() {
+                super(Rarity.RARE, EnchantmentTarget.AXE, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
+        }
+
+        @Override
+        public int getMinPower(int level) {
+                return 15;
+        }
+
+        @Override
+        public int getMaxPower(int level) {
+                return 50;
+        }
+
+        @Override
+        public int getMaxLevel() {
+                return 1;
+        }
+
+        @Override
+        public boolean isAvailableForRandomSelection() {
+                return false;
+        }
+
+        @Override
+        public boolean isAvailableForEnchantedBookOffer() {
+                return false;
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackTreeChopHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackTreeChopHandler.java
@@ -59,6 +59,10 @@ public final class LumberJackTreeChopHandler {
                         BREAKING_TREE.set(Boolean.TRUE);
                         try {
                                 for (BlockPos logPos : connectedLogs) {
+                                        if (!isHoldingEnchantedAxe(serverPlayer)) {
+                                                break;
+                                        }
+
                                         if (world.getBlockState(logPos).isIn(BlockTags.LOGS)) {
                                                 serverPlayer.interactionManager.tryBreakBlock(logPos);
                                         }
@@ -67,6 +71,14 @@ public final class LumberJackTreeChopHandler {
                                 BREAKING_TREE.set(Boolean.FALSE);
                         }
                 });
+        }
+
+        private static boolean isHoldingEnchantedAxe(ServerPlayerEntity player) {
+                if (!(player.getMainHandStack().getItem() instanceof AxeItem)) {
+                        return false;
+                }
+
+                return EnchantmentHelper.getLevel(ModEnchantments.LUMBER_JACK, player.getMainHandStack()) > 0;
         }
 
         private static List<BlockPos> findConnectedLogs(World world, BlockPos origin, int maxAdditionalLogs) {

--- a/src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackTreeChopHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackTreeChopHandler.java
@@ -1,0 +1,109 @@
+package net.jeremy.gardenkingmod.enchantment;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
+import net.minecraft.block.BlockState;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.item.AxeItem;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.tag.BlockTags;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public final class LumberJackTreeChopHandler {
+        // Adjust this value to control max connected log blocks the enchantment can fell.
+        // This count includes the first log mined by the player.
+        public static final int MAX_CONNECTED_LOG_BLOCKS = 32;
+
+        private static final ThreadLocal<Boolean> BREAKING_TREE = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+        private LumberJackTreeChopHandler() {
+        }
+
+        public static void register() {
+                PlayerBlockBreakEvents.AFTER.register((world, player, pos, state, blockEntity) -> {
+                        if (!(player instanceof ServerPlayerEntity serverPlayer)) {
+                                return;
+                        }
+
+                        if (world.isClient() || BREAKING_TREE.get()) {
+                                return;
+                        }
+
+                        if (!state.isIn(BlockTags.LOGS)) {
+                                return;
+                        }
+
+                        if (!(serverPlayer.getMainHandStack().getItem() instanceof AxeItem)) {
+                                return;
+                        }
+
+                        if (EnchantmentHelper.getLevel(ModEnchantments.LUMBER_JACK, serverPlayer.getMainHandStack()) <= 0) {
+                                return;
+                        }
+
+                        if (world.getBlockState(pos.down()).isIn(BlockTags.LOGS)) {
+                                return;
+                        }
+
+                        List<BlockPos> connectedLogs = findConnectedLogs(world, pos, MAX_CONNECTED_LOG_BLOCKS - 1);
+                        if (connectedLogs.isEmpty()) {
+                                return;
+                        }
+
+                        BREAKING_TREE.set(Boolean.TRUE);
+                        try {
+                                for (BlockPos logPos : connectedLogs) {
+                                        if (world.getBlockState(logPos).isIn(BlockTags.LOGS)) {
+                                                serverPlayer.interactionManager.tryBreakBlock(logPos);
+                                        }
+                                }
+                        } finally {
+                                BREAKING_TREE.set(Boolean.FALSE);
+                        }
+                });
+        }
+
+        private static List<BlockPos> findConnectedLogs(World world, BlockPos origin, int maxAdditionalLogs) {
+                List<BlockPos> collected = new ArrayList<>();
+                if (maxAdditionalLogs <= 0) {
+                        return collected;
+                }
+
+                Set<BlockPos> visited = new HashSet<>();
+                ArrayDeque<BlockPos> queue = new ArrayDeque<>();
+                visited.add(origin);
+                queue.add(origin);
+
+                while (!queue.isEmpty() && collected.size() < maxAdditionalLogs) {
+                        BlockPos current = queue.poll();
+                        for (BlockPos neighbor : BlockPos.iterate(current.add(-1, -1, -1), current.add(1, 1, 1))) {
+                                BlockPos immutableNeighbor = neighbor.toImmutable();
+                                if (immutableNeighbor.equals(current) || visited.contains(immutableNeighbor)) {
+                                        continue;
+                                }
+
+                                visited.add(immutableNeighbor);
+
+                                BlockState neighborState = world.getBlockState(immutableNeighbor);
+                                if (!neighborState.isIn(BlockTags.LOGS)) {
+                                        continue;
+                                }
+
+                                collected.add(immutableNeighbor);
+                                queue.add(immutableNeighbor);
+
+                                if (collected.size() >= maxAdditionalLogs) {
+                                        break;
+                                }
+                        }
+                }
+
+                return collected;
+        }
+}

--- a/src/main/java/net/jeremy/gardenkingmod/enchantment/ModEnchantments.java
+++ b/src/main/java/net/jeremy/gardenkingmod/enchantment/ModEnchantments.java
@@ -1,0 +1,22 @@
+package net.jeremy.gardenkingmod.enchantment;
+
+import net.jeremy.gardenkingmod.GardenKingMod;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+
+public final class ModEnchantments {
+        public static final Enchantment LUMBER_JACK = register("enchantment_lumberjack", new LumberJackEnchantment());
+
+        private ModEnchantments() {
+        }
+
+        public static void register() {
+                LumberJackTreeChopHandler.register();
+        }
+
+        private static Enchantment register(String name, Enchantment enchantment) {
+                return Registry.register(Registries.ENCHANTMENT, new Identifier(GardenKingMod.MOD_ID, name), enchantment);
+        }
+}

--- a/src/main/resources/assets/gardenkingmod/lang/en_us.json
+++ b/src/main/resources/assets/gardenkingmod/lang/en_us.json
@@ -356,5 +356,6 @@
   "event.gardenkingmod.endless_night.task.kill_skeletons": "Slay %s Skeletons",
   "event.gardenkingmod.endless_night.task.kill_spiders": "Slay %s Spiders",
   "subtitles.gardenkingmod.music.endless_night": "Distant haunting melody",
-  "event.gardenkingmod.endless_night.task.kill_generic": "Slay %1$s %2$s"
+  "event.gardenkingmod.endless_night.task.kill_generic": "Slay %1$s %2$s",
+  "enchantment.gardenkingmod.enchantment_lumberjack": "Lumber Jack"
 }


### PR DESCRIPTION
### Motivation
- Provide a shop-only custom axe enchantment that fells a whole tree when the bottom log is broken. 
- Prevent accidental large-scale destruction by adding a tunable connected-log cap.

### Description
- Added `LumberJackEnchantment` (axe-only, max level 1, not available via random/enchantment book offers) registered as `gardenkingmod:enchantment_lumberjack` in `ModEnchantments`.
- Implemented server-side tree-felling in `LumberJackTreeChopHandler` which flood-fills connected log blocks and breaks them via `ServerPlayerEntity.interactionManager.tryBreakBlock(...)` so normal drops and tool damage still apply.
- Hooked enchantment/handler registration into mod initialization by calling `ModEnchantments.register()` from `GardenKingMod`.
- Added English localization entry and documented where to tune the safety cap: the `MAX_CONNECTED_LOG_BLOCKS` constant in `src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackTreeChopHandler.java` (currently set to `32`).

### Testing
- Ran `./gradlew compileJava`, which failed in this environment with `Unsupported class file major version 69` before project compilation completed (build failed).
- No other automated tests were executed in this environment due to the compilation failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac26f2f28c832193345cddc630f3b2)