### PR TITLE
Fix BlockTags import in LumberJackTreeChopHandler

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackTreeChopHandler.java
+++ b/src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackTreeChopHandler.java
@@ -11,7 +11,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.item.AxeItem;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.tag.BlockTags;
+import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 


### PR DESCRIPTION
### Motivation
- Fix a compile-time error caused by the removed `net.minecraft.tag.BlockTags` package when targeting Fabric/Minecraft 1.20.1 mappings.

### Description
- Replace `import net.minecraft.tag.BlockTags;` with `import net.minecraft.registry.tag.BlockTags;` in `LumberJackTreeChopHandler.java`; place any texture `.png` assets under `src/main/resources/assets/gardenkingmod/textures/` (for example `textures/item/` or `textures/block/`).

### Testing
- Ran `./gradlew compileJava` which did not complete in this environment due to a Java/Gradle runtime mismatch (`Unsupported class file major version 69`), but the source-level import issue is corrected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac343ea93083219c3f0419c4c494ca)