### PR TITLE
Fix LumberJack enchantment target constant

### DIFF
--- a/src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackEnchantment.java
+++ b/src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackEnchantment.java
@@ -6,7 +6,7 @@ import net.minecraft.entity.EquipmentSlot;
 
 public class LumberJackEnchantment extends Enchantment {
         public LumberJackEnchantment() {
-                super(Rarity.RARE, EnchantmentTarget.AXE, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
+                super(Rarity.RARE, EnchantmentTarget.DIGGER, new EquipmentSlot[] { EquipmentSlot.MAINHAND });
         }
 
         @Override

--- a/src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackEnchantment.java
+++ b/src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackEnchantment.java
@@ -3,6 +3,8 @@ package net.jeremy.gardenkingmod.enchantment;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentTarget;
 import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.item.AxeItem;
+import net.minecraft.item.ItemStack;
 
 public class LumberJackEnchantment extends Enchantment {
         public LumberJackEnchantment() {
@@ -32,5 +34,10 @@ public class LumberJackEnchantment extends Enchantment {
         @Override
         public boolean isAvailableForEnchantedBookOffer() {
                 return false;
+        }
+
+        @Override
+        public boolean isAcceptableItem(ItemStack stack) {
+                return stack.getItem() instanceof AxeItem;
         }
 }


### PR DESCRIPTION
### Motivation
- Fix the compile error where `EnchantmentTarget.AXE` is not present for this mapping/version and caused a "cannot find symbol" in `LumberJackEnchantment`.

### Description
- Replaced `EnchantmentTarget.AXE` with `EnchantmentTarget.DIGGER` in `src/main/java/net/jeremy/gardenkingmod/enchantment/LumberJackEnchantment.java` to correctly target tool-based items, and place any enchantment icon PNG under `src/main/resources/assets/gardenkingmod/textures/item/`.

### Testing
- Ran `./gradlew compileJava --no-daemon` which could not complete here due to a toolchain/JDK mismatch (`Unsupported class file major version 69`), so compilation was not validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac34f6262083218017ff1e179ef704)